### PR TITLE
fix: encode ActivityOptions.summary as json/plain payload

### DIFF
--- a/crates/sdk/src/workflow_context/options.rs
+++ b/crates/sdk/src/workflow_context/options.rs
@@ -108,10 +108,13 @@ impl ActivityOptions {
                 }
                 .into(),
             ),
-            user_metadata: self.summary.map(|s| UserMetadata {
-                summary: Some(s.into()),
-                details: None,
-            }),
+            user_metadata: self
+                .summary
+                .and_then(|s| s.as_json_payload().ok())
+                .map(|summary| UserMetadata {
+                    summary: Some(summary),
+                    details: None,
+                }),
         }
     }
 }


### PR DESCRIPTION
## What was changed

`ActivityOptions::into_command` now encodes the `summary` field using `as_json_payload()` (`json/plain` encoding) instead of `.into()` (`binary/plain` encoding).

## Why?

`LocalActivityOptions::into_command` (same file, line ~203) already encodes its summary via `as_json_payload()`. The `ActivityOptions` path used `.into()` which produces a `binary/plain` payload — the Temporal UI cannot decode this and shows "Decoding failed" instead of the summary text.

## Checklist

1. Closes — no existing issue

2. How was this tested: built and ran locally, see screenshots:
### Before:
<img width="322" height="51" alt="image" src="https://github.com/user-attachments/assets/6486d4c1-78bc-4c77-b78d-10e447efebfb" />

### After:
<img width="346" height="53" alt="image" src="https://github.com/user-attachments/assets/8b3c4b0a-ae96-47e0-8418-72f1a7b9c307" />


3. Any docs updates needed? No