### PR TITLE
Add Event Groups in Core SDK

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,7 @@
 [env]
 # This temporarily overrides the version of the CLI used for integration tests, locally and in CI
-# CLI_VERSION_OVERRIDE = "v1.6.3-serverless"
+# TEMP: Event Groups requires server >v1.32.0-158.0, for which there's no published CLI release yet.
+CLI_VERSION_OVERRIDE = "v1.7.4-standalone-nexus-operations"
 
 [alias]
 # Not sure why --all-features doesn't work

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -157,6 +157,10 @@ jobs:
 
   integ-tests:
     name: Integ tests
+    # TEMP(event-groups): the default cached-download dev server does not yet support Event Groups,
+    # so pin the CLI to a build that does. Remove once Event Groups support lands in a default release.
+    env:
+      CLI_VERSION_OVERRIDE: v1.7.4-standalone-nexus-operations
     timeout-minutes: ${{ github.ref == 'refs/heads/main' && 30 || 25 }}
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ relevant information.
   `TEMPORAL_WORKFLOW_TASK_DURATION_WARN_SECONDS` to change the threshold.
 * `SignalWorkflowOptions::summary` attaches a single-line summary to a signal sent to another
   workflow, which the UI and CLI display alongside the resulting history event.
+* Core now supports attaching `EventGroupMarker`s to various workflow commands.
 
 ### Changed
 * Cancellation errors propagated after workflow cancellation now complete the workflow as cancelled

--- a/crates/common/src/payload_visitor.rs
+++ b/crates/common/src/payload_visitor.rs
@@ -427,7 +427,7 @@ mod tests {
                             },
                             ..Default::default()
                         })),
-                        user_metadata: None,
+                        ..Default::default()
                     }],
                     ..Default::default()
                 },
@@ -566,7 +566,7 @@ mod tests {
                                     }),
                                 },
                             )),
-                            user_metadata: None,
+                            ..Default::default()
                         },
                         // ContinueAsNewWorkflowExecution command
                         WorkflowCommand {
@@ -586,7 +586,7 @@ mod tests {
                                     ..Default::default()
                                 },
                             )),
-                            user_metadata: None,
+                            ..Default::default()
                         },
                         // StartChildWorkflowExecution command
                         WorkflowCommand {
@@ -608,7 +608,7 @@ mod tests {
                                     ..Default::default()
                                 },
                             )),
-                            user_metadata: None,
+                            ..Default::default()
                         },
                     ],
                     ..Default::default()

--- a/crates/common/src/payload_visitor.rs
+++ b/crates/common/src/payload_visitor.rs
@@ -373,7 +373,7 @@ mod tests {
                             },
                             ..Default::default()
                         })),
-                        user_metadata: None,
+                        ..Default::default()
                     }],
                     ..Default::default()
                 },
@@ -508,7 +508,7 @@ mod tests {
                                     }),
                                 },
                             )),
-                            user_metadata: None,
+                            ..Default::default()
                         },
                         // ContinueAsNewWorkflowExecution command
                         WorkflowCommand {
@@ -528,7 +528,7 @@ mod tests {
                                     ..Default::default()
                                 },
                             )),
-                            user_metadata: None,
+                            ..Default::default()
                         },
                         // StartChildWorkflowExecution command
                         WorkflowCommand {
@@ -550,7 +550,7 @@ mod tests {
                                     ..Default::default()
                                 },
                             )),
-                            user_metadata: None,
+                            ..Default::default()
                         },
                     ],
                     ..Default::default()

--- a/crates/protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/crates/protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -211,6 +211,12 @@ message InitializeWorkflow {
     temporal.api.common.v1.WorkflowExecution root_workflow = 24;
     // Priority of this workflow execution
     temporal.api.common.v1.Priority priority = 25;
+    // Event ID of the `WORKFLOW_EXECUTION_STARTED` history event that triggered this job.
+    int64 originating_event_id = 26;
+    // The run id recorded on the `WORKFLOW_EXECUTION_STARTED` event. Unlike the execution's current
+    // run id, this value is preserved across workflow resets. Mirrors the `original_execution_run_id`
+    // field from `WorkflowExecutionStartedEventAttributes`.
+    string original_execution_run_id = 27;
 }
 
 // Notify a workflow that a timer has fired
@@ -300,6 +306,8 @@ message SignalWorkflow {
     string identity = 3;
     // Headers attached to the signal
     map<string, temporal.api.common.v1.Payload> headers = 5;
+    // Event ID of the `WORKFLOW_EXECUTION_SIGNALED` history event that produced this job.
+    int64 originating_event_id = 6;
 }
 
 // Inform lang what the result of a call to `patched` or similar API should be -- this is always

--- a/crates/protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/crates/protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -215,6 +215,11 @@ message InitializeWorkflow {
     // Always `1` in practice. Used by SDKs that auto-create an implicit event group marker
     // wrapping the workflow's main function. See `temporal.api.sdk.v1.EventGroupMarker`.
     int64 originating_event_id = 26;
+    // The run id recorded on the `WORKFLOW_EXECUTION_STARTED` event. Unlike the execution's current
+    // run id, this value is preserved across workflow resets, which makes it suitable as a stable salt
+    // for deriving Event Group label identifiers. Mirrors `original_execution_run_id` on
+    // `WorkflowExecutionStartedEventAttributes`.
+    string original_execution_run_id = 27;
 }
 
 // Notify a workflow that a timer has fired

--- a/crates/protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/crates/protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -211,6 +211,10 @@ message InitializeWorkflow {
     temporal.api.common.v1.WorkflowExecution root_workflow = 24;
     // Priority of this workflow execution
     temporal.api.common.v1.Priority priority = 25;
+    // Event ID of the `WORKFLOW_EXECUTION_STARTED` history event that triggered this job.
+    // Always `1` in practice. Used by SDKs that auto-create an implicit event group marker
+    // wrapping the workflow's main function. See `temporal.api.sdk.v1.EventGroupMarker`.
+    int64 originating_event_id = 26;
 }
 
 // Notify a workflow that a timer has fired
@@ -300,6 +304,10 @@ message SignalWorkflow {
     string identity = 3;
     // Headers attached to the signal
     map<string, temporal.api.common.v1.Payload> headers = 5;
+    // Event ID of the `WORKFLOW_EXECUTION_SIGNALED` history event that produced this job.
+    // Used by SDKs that auto-create an implicit event group marker wrapping the signal handler.
+    // See `temporal.api.sdk.v1.EventGroupMarker`.
+    int64 originating_event_id = 6;
 }
 
 // Inform lang what the result of a call to `patched` or similar API should be -- this is always

--- a/crates/protos/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
+++ b/crates/protos/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
@@ -15,6 +15,7 @@ import "temporal/api/common/v1/message.proto";
 import "temporal/api/enums/v1/workflow.proto";
 import "temporal/api/failure/v1/message.proto";
 import "temporal/api/sdk/v1/user_metadata.proto";
+import "temporal/api/sdk/v1/event_group_marker.proto";
 import "temporal/sdk/core/child_workflow/child_workflow.proto";
 import "temporal/sdk/core/nexus/nexus.proto";
 import "temporal/sdk/core/common/common.proto";
@@ -24,6 +25,11 @@ message WorkflowCommand {
     // Lang layers are expected to expose the setting of the internals of this metadata on a
     // per-command basis where applicable.
     temporal.api.sdk.v1.UserMetadata user_metadata = 100;
+
+    // Event group markers attached to the command. These are forwarded onto
+    // the corresponding server-side Command, and consequently surfaced on the
+    // resulting HistoryEvent. See `temporal/api/sdk/v1/event_group_marker.proto`.
+    repeated temporal.api.sdk.v1.EventGroupMarker event_group_markers = 101;
 
     oneof variant {
         StartTimer start_timer = 1;

--- a/crates/protos/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
+++ b/crates/protos/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
@@ -15,6 +15,7 @@ import "temporal/api/common/v1/message.proto";
 import "temporal/api/enums/v1/workflow.proto";
 import "temporal/api/failure/v1/message.proto";
 import "temporal/api/sdk/v1/user_metadata.proto";
+import "temporal/api/sdk/v1/event_group_marker.proto";
 import "temporal/sdk/core/child_workflow/child_workflow.proto";
 import "temporal/sdk/core/nexus/nexus.proto";
 import "temporal/sdk/core/common/common.proto";
@@ -24,6 +25,11 @@ message WorkflowCommand {
     // Lang layers are expected to expose the setting of the internals of this metadata on a
     // per-command basis where applicable.
     temporal.api.sdk.v1.UserMetadata user_metadata = 100;
+
+    // Event group markers attached to the command. These are forwarded onto
+    // the corresponding server-side Command, and consequently surface on the
+    // resulting HistoryEvent. See `temporal/api/sdk/v1/event_group_marker.proto`.
+    repeated temporal.api.sdk.v1.EventGroupMarker event_group_markers = 101;
 
     oneof variant {
         StartTimer start_timer = 1;

--- a/crates/protos/src/protos/mod.rs
+++ b/crates/protos/src/protos/mod.rs
@@ -89,7 +89,7 @@ pub mod coresdk {
             fn from(v: workflow_command::Variant) -> Self {
                 Self {
                     variant: Some(v),
-                    user_metadata: None,
+                    ..Default::default()
                 }
             }
         }
@@ -1307,13 +1307,16 @@ pub mod coresdk {
                 }
             }
 
-            impl From<WorkflowExecutionSignaledEventAttributes> for SignalWorkflow {
-                fn from(a: WorkflowExecutionSignaledEventAttributes) -> Self {
+            impl From<(WorkflowExecutionSignaledEventAttributes, i64)> for SignalWorkflow {
+                fn from(
+                    (a, originating_event_id): (WorkflowExecutionSignaledEventAttributes, i64),
+                ) -> Self {
                     Self {
                         signal_name: a.signal_name,
                         input: Vec::from_payloads(a.input),
                         identity: a.identity,
                         headers: a.header.map(Into::into).unwrap_or_default(),
+                        originating_event_id,
                     }
                 }
             }
@@ -1330,6 +1333,7 @@ pub mod coresdk {
                 workflow_id: String,
                 randomness_seed: u64,
                 start_time: Timestamp,
+                originating_event_id: i64,
             ) -> InitializeWorkflow {
                 InitializeWorkflow {
                     workflow_type: attrs.workflow_type.map(|wt| wt.name).unwrap_or_default(),
@@ -1363,6 +1367,8 @@ pub mod coresdk {
                     start_time: Some(start_time),
                     root_workflow: attrs.root_workflow_execution,
                     priority: attrs.priority,
+                    originating_event_id,
+                    original_execution_run_id: attrs.original_execution_run_id,
                 }
             }
         }

--- a/crates/protos/src/protos/mod.rs
+++ b/crates/protos/src/protos/mod.rs
@@ -89,7 +89,7 @@ pub mod coresdk {
             fn from(v: workflow_command::Variant) -> Self {
                 Self {
                     variant: Some(v),
-                    user_metadata: None,
+                    ..Default::default()
                 }
             }
         }
@@ -1309,6 +1309,7 @@ pub mod coresdk {
                         input: Vec::from_payloads(a.input),
                         identity: a.identity,
                         headers: a.header.map(Into::into).unwrap_or_default(),
+                        originating_event_id: 0,
                     }
                 }
             }
@@ -1325,6 +1326,7 @@ pub mod coresdk {
                 workflow_id: String,
                 randomness_seed: u64,
                 start_time: Timestamp,
+                originating_event_id: i64,
             ) -> InitializeWorkflow {
                 InitializeWorkflow {
                     workflow_type: attrs.workflow_type.map(|wt| wt.name).unwrap_or_default(),
@@ -1358,6 +1360,7 @@ pub mod coresdk {
                     start_time: Some(start_time),
                     root_workflow: attrs.root_workflow_execution,
                     priority: attrs.priority,
+                    originating_event_id,
                 }
             }
         }

--- a/crates/protos/src/protos/mod.rs
+++ b/crates/protos/src/protos/mod.rs
@@ -1361,6 +1361,7 @@ pub mod coresdk {
                     root_workflow: attrs.root_workflow_execution,
                     priority: attrs.priority,
                     originating_event_id,
+                    original_execution_run_id: attrs.original_execution_run_id,
                 }
             }
         }

--- a/crates/sdk-core/src/core_tests/updates.rs
+++ b/crates/sdk-core/src/core_tests/updates.rs
@@ -322,3 +322,73 @@ async fn replay_with_signal_and_update_same_task() {
     .await
     .unwrap();
 }
+
+#[tokio::test]
+async fn originating_ids_on_inbound_activation_jobs() {
+    // Each inbound-job kind that auto-creates an event group marker on the lang side
+    // is supposed to carry the identifier it needs to construct that marker:
+    //   - `InitializeWorkflow.originating_event_id` = `WorkflowExecutionStarted` event id (1)
+    //   - `SignalWorkflow.originating_event_id`    = `WorkflowExecutionSignaled` event id
+    //   - `DoUpdate.id`                            = the workflow-unique update id (always set)
+    let mut t = TestHistoryBuilder::default();
+    t.add_by_type(EventType::WorkflowExecutionStarted); // 1
+    t.add_full_wf_task(); //                              2,3,4
+    t.add_we_signaled("go", vec![]); //                   5
+    let signal_event_id = t.current_event_id();
+    t.add_full_wf_task(); //                              6,7,8
+    let accept_id = t.add_update_accepted("upd1", "update"); // 9
+    t.add_update_completed(accept_id); //                 10
+    t.add_workflow_execution_completed(); //              11
+
+    let mock = MockPollCfg::from_resps(t, [ResponseType::AllHistory]);
+    let mut mock = build_mock_pollers(mock);
+    mock.worker_cfg(|wc| wc.max_cached_workflows = 1);
+    let core = mock_worker(mock);
+
+    let task = core.poll_workflow_activation().await.unwrap();
+    assert_matches!(
+        task.jobs.as_slice(),
+        [WorkflowActivationJob {
+            variant: Some(workflow_activation_job::Variant::InitializeWorkflow(init)),
+        }] => {
+            assert_eq!(init.originating_event_id, 1);
+        }
+    );
+    core.complete_workflow_activation(WorkflowActivationCompletion::empty(task.run_id))
+        .await
+        .unwrap();
+
+    let task = core.poll_workflow_activation().await.unwrap();
+    assert_matches!(
+        task.jobs.as_slice(),
+        [
+            WorkflowActivationJob {
+                variant: Some(workflow_activation_job::Variant::SignalWorkflow(sig)),
+            },
+            WorkflowActivationJob {
+                variant: Some(workflow_activation_job::Variant::DoUpdate(upd)),
+            }
+        ] => {
+            assert_eq!(sig.originating_event_id, signal_event_id);
+            assert_eq!(upd.id, "upd1");
+        }
+    );
+    core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
+        task.run_id,
+        vec![
+            UpdateResponse {
+                protocol_instance_id: "upd1".to_string(),
+                response: Some(Response::Accepted(())),
+            }
+            .into(),
+            UpdateResponse {
+                protocol_instance_id: "upd1".to_string(),
+                response: Some(Response::Completed(Payload::default())),
+            }
+            .into(),
+            CompleteWorkflowExecution { result: None }.into(),
+        ],
+    ))
+    .await
+    .unwrap();
+}

--- a/crates/sdk-core/src/protosext/mod.rs
+++ b/crates/sdk-core/src/protosext/mod.rs
@@ -38,7 +38,7 @@ use temporalio_common::protos::{
         failure::v1::Failure,
         history::v1::{History, HistoryEvent, MarkerRecordedEventAttributes, history_event},
         query::v1::WorkflowQuery,
-        sdk::v1::UserMetadata,
+        sdk::v1::{EventGroupMarker, UserMetadata},
         workflowservice::v1::PollWorkflowTaskQueueResponse,
     },
     utilities::TryIntoOrNone,
@@ -323,6 +323,7 @@ pub(crate) struct ValidScheduleLA {
     pub(crate) local_retry_threshold: Duration,
     pub(crate) cancellation_type: ActivityCancellationType,
     pub(crate) user_metadata: Option<UserMetadata>,
+    pub(crate) event_group_markers: Vec<EventGroupMarker>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -355,6 +356,7 @@ impl ValidScheduleLA {
     pub(crate) fn from_schedule_la(
         v: ScheduleLocalActivity,
         user_metadata: Option<UserMetadata>,
+        event_group_markers: Vec<EventGroupMarker>,
     ) -> Result<Self, anyhow::Error> {
         let original_schedule_time = v
             .original_schedule_time
@@ -431,6 +433,7 @@ impl ValidScheduleLA {
             local_retry_threshold,
             cancellation_type,
             user_metadata,
+            event_group_markers,
         })
     }
 }

--- a/crates/sdk-core/src/worker/workflow/driven_workflow.rs
+++ b/crates/sdk-core/src/worker/workflow/driven_workflow.rs
@@ -45,6 +45,7 @@ impl DrivenWorkflow {
         workflow_id: String,
         randomness_seed: u64,
         start_time: Timestamp,
+        originating_event_id: i64,
         attribs: WorkflowExecutionStartedEventAttributes,
     ) {
         debug!(run_id = %attribs.original_execution_run_id, "Driven WF start");
@@ -55,7 +56,14 @@ impl DrivenWorkflow {
             retry_policy: attribs.retry_policy.clone(),
         };
         self.send_job(
-            start_workflow_from_attribs(attribs, workflow_id, randomness_seed, start_time).into(),
+            start_workflow_from_attribs(
+                attribs,
+                workflow_id,
+                randomness_seed,
+                start_time,
+                originating_event_id,
+            )
+            .into(),
         );
         self.started_attrs = Some(started_info);
     }
@@ -89,12 +97,8 @@ impl DrivenWorkflow {
     /// from a buffer that the language side sinks into when it calls [crate::Core::complete_task]
     pub(super) fn fetch_workflow_iteration_output(&mut self) -> Vec<WFCommand> {
         let in_cmds = self.incoming_commands.try_recv();
-        let in_cmds = in_cmds.unwrap_or_else(|_| {
-            vec![WFCommand {
-                variant: WFCommandVariant::NoCommandsFromLang,
-                metadata: None,
-            }]
-        });
+        let in_cmds =
+            in_cmds.unwrap_or_else(|_| vec![WFCommand::new(WFCommandVariant::NoCommandsFromLang)]);
         debug!(in_cmds = %in_cmds.display(), "wf bridge iteration fetch");
         in_cmds
     }

--- a/crates/sdk-core/src/worker/workflow/driven_workflow.rs
+++ b/crates/sdk-core/src/worker/workflow/driven_workflow.rs
@@ -45,6 +45,7 @@ impl DrivenWorkflow {
         workflow_id: String,
         randomness_seed: u64,
         start_time: Timestamp,
+        originating_event_id: i64,
         attribs: WorkflowExecutionStartedEventAttributes,
     ) {
         debug!(run_id = %attribs.original_execution_run_id, "Driven WF start");
@@ -55,7 +56,14 @@ impl DrivenWorkflow {
             retry_policy: attribs.retry_policy.clone(),
         };
         self.send_job(
-            start_workflow_from_attribs(attribs, workflow_id, randomness_seed, start_time).into(),
+            start_workflow_from_attribs(
+                attribs,
+                workflow_id,
+                randomness_seed,
+                start_time,
+                originating_event_id,
+            )
+            .into(),
         );
         self.started_attrs = Some(started_info);
     }
@@ -93,6 +101,7 @@ impl DrivenWorkflow {
             vec![WFCommand {
                 variant: WFCommandVariant::NoCommandsFromLang,
                 metadata: None,
+                event_group_markers: vec![],
             }]
         });
         debug!(in_cmds = %in_cmds.display(), "wf bridge iteration fetch");

--- a/crates/sdk-core/src/worker/workflow/driven_workflow.rs
+++ b/crates/sdk-core/src/worker/workflow/driven_workflow.rs
@@ -100,8 +100,7 @@ impl DrivenWorkflow {
         let in_cmds = in_cmds.unwrap_or_else(|_| {
             vec![WFCommand {
                 variant: WFCommandVariant::NoCommandsFromLang,
-                metadata: None,
-                event_group_markers: vec![],
+                ..Default::default()
             }]
         });
         debug!(in_cmds = %in_cmds.display(), "wf bridge iteration fetch");

--- a/crates/sdk-core/src/worker/workflow/machines/local_activity_state_machine.rs
+++ b/crates/sdk-core/src/worker/workflow/machines/local_activity_state_machine.rs
@@ -731,6 +731,7 @@ impl WFMachinesAdapter for LocalActivityMachine {
                     };
                     let command = ProtoCommand {
                         user_metadata: self.shared_state.attrs.user_metadata.clone(),
+                        event_group_markers: self.shared_state.attrs.event_group_markers.clone(),
                         ..command::Attributes::RecordMarkerCommandAttributes(marker_data).into()
                     };
                     responses.push(MachineResponse::IssueNewCommand(command));

--- a/crates/sdk-core/src/worker/workflow/machines/workflow_machines.rs
+++ b/crates/sdk-core/src/worker/workflow/machines/workflow_machines.rs
@@ -71,7 +71,7 @@ use temporalio_common::{
             enums::v1::EventType,
             history::v1::{HistoryEvent, history_event},
             protocol::v1::{Message as ProtocolMessage, message::SequencingId},
-            sdk::v1::{UserMetadata, WorkflowTaskCompletedMetadata},
+            sdk::v1::{EventGroupMarker, UserMetadata, WorkflowTaskCompletedMetadata},
         },
     },
     worker::WorkerDeploymentVersion,
@@ -1008,6 +1008,7 @@ impl WorkflowMachines {
                         self.workflow_id.clone(),
                         str_to_randomness_seed(&attrs.original_execution_run_id),
                         event_dat.event.event_time.unwrap_or_default(),
+                        event_id,
                         attrs,
                     );
                 } else {
@@ -1027,8 +1028,9 @@ impl WorkflowMachines {
                     attrs,
                 )) = event_dat.event.attributes
                 {
-                    self.drive_me
-                        .send_job(workflow_activation::SignalWorkflow::from(attrs).into());
+                    self.drive_me.send_job(
+                        workflow_activation::SignalWorkflow::from((attrs, event_id)).into(),
+                    );
                 } else {
                     // err
                 }
@@ -1196,7 +1198,10 @@ impl WorkflowMachines {
                         };
                         self.add_cmd_to_wf_task(
                             new_external_cancel(0, we, attrs.child_workflow_only, attrs.reason),
+                            // FIXME: Wire metadata and group markers from lang's cancellation command,
+                            // through the state machine, into the command we issue here.
                             None,
+                            vec![],
                             CommandIdKind::CoreInternal,
                         );
                     }
@@ -1206,7 +1211,10 @@ impl WorkflowMachines {
                         // workflows by users (but rather, just for them to search with).
                         self.add_cmd_to_wf_task(
                             upsert_search_attrs_internal(attrs),
+                            // FIXME: Wire metadata and group markers from lang's patch command,
+                            // through the state machine, into the command we issue here.
                             None,
+                            vec![],
                             CommandIdKind::NeverResolves,
                         );
                     }
@@ -1313,6 +1321,7 @@ impl WorkflowMachines {
                     self.add_cmd_to_wf_task(
                         new_timer(attrs),
                         cmd.metadata,
+                        cmd.event_group_markers,
                         CommandID::Timer(seq).into(),
                     );
                 }
@@ -1326,6 +1335,7 @@ impl WorkflowMachines {
                             self.replaying,
                         ),
                         cmd.metadata,
+                        cmd.event_group_markers,
                         CommandIdKind::NeverResolves,
                     );
                 }
@@ -1345,15 +1355,20 @@ impl WorkflowMachines {
                             use_compat,
                         ),
                         cmd.metadata,
+                        cmd.event_group_markers,
                         CommandID::Activity(seq).into(),
                     );
                 }
                 WFCommandVariant::AddLocalActivity(attrs) => {
                     let seq = attrs.seq;
-                    let attrs: ValidScheduleLA =
-                        ValidScheduleLA::from_schedule_la(attrs, cmd.metadata).map_err(|e| {
-                            fatal!("Invalid schedule local activity request (seq {seq}): {e}")
-                        })?;
+                    let attrs: ValidScheduleLA = ValidScheduleLA::from_schedule_la(
+                        attrs,
+                        cmd.metadata,
+                        cmd.event_group_markers,
+                    )
+                    .map_err(|e| {
+                        fatal!("Invalid schedule local activity request (seq {seq}): {e}")
+                    })?;
                     let (la, mach_resp) = new_local_activity(
                         attrs,
                         self.replaying,
@@ -1382,10 +1397,18 @@ impl WorkflowMachines {
                     );
                 }
                 WFCommandVariant::CompleteWorkflow(attrs) => {
-                    self.add_terminal_command(complete_workflow(attrs), cmd.metadata);
+                    self.add_terminal_command(
+                        complete_workflow(attrs),
+                        cmd.metadata,
+                        cmd.event_group_markers,
+                    );
                 }
                 WFCommandVariant::FailWorkflow(attrs) => {
-                    self.add_terminal_command(fail_workflow(attrs), cmd.metadata);
+                    self.add_terminal_command(
+                        fail_workflow(attrs),
+                        cmd.metadata,
+                        cmd.event_group_markers,
+                    );
                 }
                 WFCommandVariant::ContinueAsNew(attrs) => {
                     let attrs = self.augment_continue_as_new_with_current_values(attrs);
@@ -1393,10 +1416,18 @@ impl WorkflowMachines {
                         attrs.versioning_intent(),
                         &attrs.task_queue,
                     );
-                    self.add_terminal_command(continue_as_new(attrs, use_compat), cmd.metadata);
+                    self.add_terminal_command(
+                        continue_as_new(attrs, use_compat),
+                        cmd.metadata,
+                        cmd.event_group_markers,
+                    );
                 }
                 WFCommandVariant::CancelWorkflow(attrs) => {
-                    self.add_terminal_command(cancel_workflow(attrs), cmd.metadata);
+                    self.add_terminal_command(
+                        cancel_workflow(attrs),
+                        cmd.metadata,
+                        cmd.event_group_markers,
+                    );
                 }
                 WFCommandVariant::SetPatchMarker(attrs) => {
                     // Do not create commands for change IDs that we have already created commands
@@ -1418,6 +1449,7 @@ impl WorkflowMachines {
                         let mkey = self.add_cmd_to_wf_task(
                             patch_machine,
                             cmd.metadata,
+                            cmd.event_group_markers,
                             CommandIdKind::NeverResolves,
                         );
                         self.process_machine_responses(mkey, other_cmds)?;
@@ -1447,6 +1479,7 @@ impl WorkflowMachines {
                             use_compat,
                         ),
                         cmd.metadata,
+                        cmd.event_group_markers,
                         CommandID::ChildWorkflowStart(seq).into(),
                     );
                 }
@@ -1474,6 +1507,7 @@ impl WorkflowMachines {
                             ),
                         ),
                         cmd.metadata,
+                        cmd.event_group_markers,
                         CommandID::CancelExternal(attrs.seq).into(),
                     );
                 }
@@ -1482,6 +1516,7 @@ impl WorkflowMachines {
                     self.add_cmd_to_wf_task(
                         new_external_signal(attrs, &self.worker_config.namespace)?,
                         cmd.metadata,
+                        cmd.event_group_markers,
                         CommandID::SignalExternal(seq).into(),
                     );
                 }
@@ -1501,6 +1536,7 @@ impl WorkflowMachines {
                     self.add_cmd_to_wf_task(
                         modify_workflow_properties(attrs),
                         cmd.metadata,
+                        cmd.event_group_markers,
                         CommandIdKind::NeverResolves,
                     );
                 }
@@ -1523,6 +1559,7 @@ impl WorkflowMachines {
                     self.add_cmd_to_wf_task(
                         NexusOperationMachine::new_scheduled(attrs),
                         cmd.metadata,
+                        cmd.event_group_markers,
                         CommandID::NexusOperation(seq).into(),
                     );
                 }
@@ -1568,8 +1605,9 @@ impl WorkflowMachines {
         &mut self,
         machine: NewMachineWithCommand,
         metadata: Option<UserMetadata>,
+        markers: Vec<EventGroupMarker>,
     ) {
-        let cwfm = self.add_new_command_machine(machine, metadata);
+        let cwfm = self.add_new_command_machine(machine, metadata, markers);
         self.workflow_end_time = Some(SystemTime::now());
         self.current_wf_task_commands.push_back(cwfm);
         // Wipe out any pending / executing local activity data since we're about to terminate
@@ -1582,9 +1620,10 @@ impl WorkflowMachines {
         &mut self,
         machine: NewMachineWithCommand,
         metadata: Option<UserMetadata>,
+        markers: Vec<EventGroupMarker>,
         id: CommandIdKind,
     ) -> MachineKey {
-        let mach = self.add_new_command_machine(machine, metadata);
+        let mach = self.add_new_command_machine(machine, metadata, markers);
         let key = mach.machine;
         if let CommandIdKind::LangIssued(id) = id {
             self.id_to_machine.insert(id, key);
@@ -1600,13 +1639,14 @@ impl WorkflowMachines {
         &mut self,
         machine: NewMachineWithCommand,
         metadata: Option<UserMetadata>,
+        markers: Vec<EventGroupMarker>,
     ) -> CommandAndMachine {
         let k = self.all_machines.insert(machine.machine);
         let cmd = ProtoCommand {
             command_type: machine.command.as_type() as i32,
             attributes: Some(machine.command),
             user_metadata: metadata,
-            event_group_markers: vec![],
+            event_group_markers: markers,
         };
         CommandAndMachine {
             command: cmd,

--- a/crates/sdk-core/src/worker/workflow/machines/workflow_machines.rs
+++ b/crates/sdk-core/src/worker/workflow/machines/workflow_machines.rs
@@ -71,7 +71,7 @@ use temporalio_common::{
             enums::v1::EventType,
             history::v1::{HistoryEvent, history_event},
             protocol::v1::{Message as ProtocolMessage, message::SequencingId},
-            sdk::v1::{UserMetadata, WorkflowTaskCompletedMetadata},
+            sdk::v1::{EventGroupMarker, UserMetadata, WorkflowTaskCompletedMetadata},
         },
     },
     worker::WorkerDeploymentVersion,
@@ -1021,6 +1021,7 @@ impl WorkflowMachines {
                         self.workflow_id.clone(),
                         str_to_randomness_seed(&attrs.original_execution_run_id),
                         event_dat.event.event_time.unwrap_or_default(),
+                        event_id,
                         attrs,
                     );
                 } else {
@@ -1040,8 +1041,9 @@ impl WorkflowMachines {
                     attrs,
                 )) = event_dat.event.attributes
                 {
-                    self.drive_me
-                        .send_job(workflow_activation::SignalWorkflow::from(attrs).into());
+                    let mut sw: workflow_activation::SignalWorkflow = attrs.into();
+                    sw.originating_event_id = event_id;
+                    self.drive_me.send_job(sw.into());
                 } else {
                     // err
                 }
@@ -1215,6 +1217,7 @@ impl WorkflowMachines {
                         self.add_cmd_to_wf_task(
                             new_external_cancel(0, we, attrs.child_workflow_only, attrs.reason),
                             None,
+                            vec![],
                             CommandIdKind::CoreInternal,
                         );
                     }
@@ -1225,6 +1228,7 @@ impl WorkflowMachines {
                         self.add_cmd_to_wf_task(
                             upsert_search_attrs_internal(attrs),
                             None,
+                            vec![],
                             CommandIdKind::NeverResolves,
                         );
                     }
@@ -1337,6 +1341,7 @@ impl WorkflowMachines {
                     self.add_cmd_to_wf_task(
                         new_timer(attrs),
                         cmd.metadata,
+                        cmd.event_group_markers,
                         CommandID::Timer(seq).into(),
                     );
                 }
@@ -1350,6 +1355,7 @@ impl WorkflowMachines {
                             self.replaying,
                         ),
                         cmd.metadata,
+                        cmd.event_group_markers,
                         CommandIdKind::NeverResolves,
                     );
                 }
@@ -1369,6 +1375,7 @@ impl WorkflowMachines {
                             use_compat,
                         ),
                         cmd.metadata,
+                        cmd.event_group_markers,
                         CommandID::Activity(seq).into(),
                     );
                 }
@@ -1407,10 +1414,18 @@ impl WorkflowMachines {
                     );
                 }
                 WFCommandVariant::CompleteWorkflow(attrs) => {
-                    self.add_terminal_command(complete_workflow(attrs), cmd.metadata);
+                    self.add_terminal_command(
+                        complete_workflow(attrs),
+                        cmd.metadata,
+                        cmd.event_group_markers,
+                    );
                 }
                 WFCommandVariant::FailWorkflow(attrs) => {
-                    self.add_terminal_command(fail_workflow(attrs), cmd.metadata);
+                    self.add_terminal_command(
+                        fail_workflow(attrs),
+                        cmd.metadata,
+                        cmd.event_group_markers,
+                    );
                 }
                 WFCommandVariant::ContinueAsNew(attrs) => {
                     let attrs = self.augment_continue_as_new_with_current_values(attrs);
@@ -1418,10 +1433,18 @@ impl WorkflowMachines {
                         attrs.versioning_intent(),
                         &attrs.task_queue,
                     );
-                    self.add_terminal_command(continue_as_new(attrs, use_compat), cmd.metadata);
+                    self.add_terminal_command(
+                        continue_as_new(attrs, use_compat),
+                        cmd.metadata,
+                        cmd.event_group_markers,
+                    );
                 }
                 WFCommandVariant::CancelWorkflow(attrs) => {
-                    self.add_terminal_command(cancel_workflow(attrs), cmd.metadata);
+                    self.add_terminal_command(
+                        cancel_workflow(attrs),
+                        cmd.metadata,
+                        cmd.event_group_markers,
+                    );
                 }
                 WFCommandVariant::SetPatchMarker(attrs) => {
                     // Do not create commands for change IDs that we have already created commands
@@ -1443,6 +1466,7 @@ impl WorkflowMachines {
                         let mkey = self.add_cmd_to_wf_task(
                             patch_machine,
                             cmd.metadata,
+                            cmd.event_group_markers,
                             CommandIdKind::NeverResolves,
                         );
                         self.process_machine_responses(mkey, other_cmds)?;
@@ -1472,6 +1496,7 @@ impl WorkflowMachines {
                             use_compat,
                         ),
                         cmd.metadata,
+                        cmd.event_group_markers,
                         CommandID::ChildWorkflowStart(seq).into(),
                     );
                 }
@@ -1499,6 +1524,7 @@ impl WorkflowMachines {
                             ),
                         ),
                         cmd.metadata,
+                        cmd.event_group_markers,
                         CommandID::CancelExternal(attrs.seq).into(),
                     );
                 }
@@ -1507,6 +1533,7 @@ impl WorkflowMachines {
                     self.add_cmd_to_wf_task(
                         new_external_signal(attrs, &self.worker_config.namespace)?,
                         cmd.metadata,
+                        cmd.event_group_markers,
                         CommandID::SignalExternal(seq).into(),
                     );
                 }
@@ -1526,6 +1553,7 @@ impl WorkflowMachines {
                     self.add_cmd_to_wf_task(
                         modify_workflow_properties(attrs),
                         cmd.metadata,
+                        cmd.event_group_markers,
                         CommandIdKind::NeverResolves,
                     );
                 }
@@ -1548,6 +1576,7 @@ impl WorkflowMachines {
                     self.add_cmd_to_wf_task(
                         NexusOperationMachine::new_scheduled(attrs),
                         cmd.metadata,
+                        cmd.event_group_markers,
                         CommandID::NexusOperation(seq).into(),
                     );
                 }
@@ -1593,8 +1622,9 @@ impl WorkflowMachines {
         &mut self,
         machine: NewMachineWithCommand,
         metadata: Option<UserMetadata>,
+        markers: Vec<EventGroupMarker>,
     ) {
-        let cwfm = self.add_new_command_machine(machine, metadata);
+        let cwfm = self.add_new_command_machine(machine, metadata, markers);
         self.workflow_end_time = Some(SystemTime::now());
         self.current_wf_task_commands.push_back(cwfm);
         // Wipe out any pending / executing local activity data since we're about to terminate
@@ -1607,9 +1637,10 @@ impl WorkflowMachines {
         &mut self,
         machine: NewMachineWithCommand,
         metadata: Option<UserMetadata>,
+        markers: Vec<EventGroupMarker>,
         id: CommandIdKind,
     ) -> MachineKey {
-        let mach = self.add_new_command_machine(machine, metadata);
+        let mach = self.add_new_command_machine(machine, metadata, markers);
         let key = mach.machine;
         if let CommandIdKind::LangIssued(id) = id {
             self.id_to_machine.insert(id, key);
@@ -1625,13 +1656,14 @@ impl WorkflowMachines {
         &mut self,
         machine: NewMachineWithCommand,
         metadata: Option<UserMetadata>,
+        markers: Vec<EventGroupMarker>,
     ) -> CommandAndMachine {
         let k = self.all_machines.insert(machine.machine);
         let cmd = ProtoCommand {
             command_type: machine.command.as_type() as i32,
             attributes: Some(machine.command),
             user_metadata: metadata,
-            event_group_markers: vec![],
+            event_group_markers: markers,
         };
         CommandAndMachine {
             command: MachineAssociatedCommand::Real(Box::new(cmd)),

--- a/crates/sdk-core/src/worker/workflow/managed_run.rs
+++ b/crates/sdk-core/src/worker/workflow/managed_run.rs
@@ -661,12 +661,11 @@ impl ManagedRun {
                 warn!(failure=?failure, "Failing workflow due to nondeterminism error");
                 return self
                     .successful_completion(
-                        vec![WFCommand {
-                            variant: WFCommandVariant::FailWorkflow(FailWorkflowExecution {
+                        vec![WFCommand::new(WFCommandVariant::FailWorkflow(
+                            FailWorkflowExecution {
                                 failure: failure.failure,
-                            }),
-                            metadata: None,
-                        }],
+                            },
+                        ))],
                         vec![],
                         VersioningBehavior::Unspecified, // Doesn't matter since we're failing wf
                         resp_chan,
@@ -1905,39 +1904,27 @@ mod tests {
         use super::*;
 
         pub(crate) fn complete() -> WFCommand {
-            WFCommand {
-                variant: WFCommandVariant::CompleteWorkflow(CompleteWorkflowExecution {
-                    result: None,
-                }),
-                metadata: None,
-            }
+            WFCommand::new(WFCommandVariant::CompleteWorkflow(
+                CompleteWorkflowExecution { result: None },
+            ))
         }
 
         pub(crate) fn cancel() -> WFCommand {
-            WFCommand {
-                variant: WFCommandVariant::CancelWorkflow(CancelWorkflowExecution {}),
-                metadata: None,
-            }
+            WFCommand::new(WFCommandVariant::CancelWorkflow(CancelWorkflowExecution {}))
         }
 
         pub(crate) fn query_response() -> WFCommand {
-            WFCommand {
-                variant: WFCommandVariant::QueryResponse(QueryResult {
-                    query_id: "".into(),
-                    variant: None,
-                }),
-                metadata: None,
-            }
+            WFCommand::new(WFCommandVariant::QueryResponse(QueryResult {
+                query_id: "".into(),
+                variant: None,
+            }))
         }
 
         pub(crate) fn update_response() -> WFCommand {
-            WFCommand {
-                variant: WFCommandVariant::UpdateResponse(UpdateResponse {
-                    protocol_instance_id: "".into(),
-                    response: None,
-                }),
-                metadata: None,
-            }
+            WFCommand::new(WFCommandVariant::UpdateResponse(UpdateResponse {
+                protocol_instance_id: "".into(),
+                response: None,
+            }))
         }
 
         pub(crate) fn command_types(commands: &[WFCommand]) -> Vec<Discriminant<WFCommand>> {

--- a/crates/sdk-core/src/worker/workflow/managed_run.rs
+++ b/crates/sdk-core/src/worker/workflow/managed_run.rs
@@ -629,8 +629,7 @@ impl ManagedRun {
                             variant: WFCommandVariant::FailWorkflow(FailWorkflowExecution {
                                 failure: failure.failure,
                             }),
-                            metadata: None,
-                            event_group_markers: vec![],
+                            ..Default::default()
                         }],
                         vec![],
                         VersioningBehavior::Unspecified, // Doesn't matter since we're failing wf
@@ -1633,16 +1632,14 @@ mod tests {
                 variant: WFCommandVariant::CompleteWorkflow(CompleteWorkflowExecution {
                     result: None,
                 }),
-                metadata: None,
-                event_group_markers: vec![],
+                ..Default::default()
             }
         }
 
         pub(crate) fn cancel() -> WFCommand {
             WFCommand {
                 variant: WFCommandVariant::CancelWorkflow(CancelWorkflowExecution {}),
-                metadata: None,
-                event_group_markers: vec![],
+                ..Default::default()
             }
         }
 
@@ -1652,8 +1649,7 @@ mod tests {
                     query_id: "".into(),
                     variant: None,
                 }),
-                metadata: None,
-                event_group_markers: vec![],
+                ..Default::default()
             }
         }
 
@@ -1663,8 +1659,7 @@ mod tests {
                     protocol_instance_id: "".into(),
                     response: None,
                 }),
-                metadata: None,
-                event_group_markers: vec![],
+                ..Default::default()
             }
         }
 

--- a/crates/sdk-core/src/worker/workflow/managed_run.rs
+++ b/crates/sdk-core/src/worker/workflow/managed_run.rs
@@ -630,6 +630,7 @@ impl ManagedRun {
                                 failure: failure.failure,
                             }),
                             metadata: None,
+                            event_group_markers: vec![],
                         }],
                         vec![],
                         VersioningBehavior::Unspecified, // Doesn't matter since we're failing wf
@@ -1633,6 +1634,7 @@ mod tests {
                     result: None,
                 }),
                 metadata: None,
+                event_group_markers: vec![],
             }
         }
 
@@ -1640,6 +1642,7 @@ mod tests {
             WFCommand {
                 variant: WFCommandVariant::CancelWorkflow(CancelWorkflowExecution {}),
                 metadata: None,
+                event_group_markers: vec![],
             }
         }
 
@@ -1650,6 +1653,7 @@ mod tests {
                     variant: None,
                 }),
                 metadata: None,
+                event_group_markers: vec![],
             }
         }
 
@@ -1660,6 +1664,7 @@ mod tests {
                     response: None,
                 }),
                 metadata: None,
+                event_group_markers: vec![],
             }
         }
 

--- a/crates/sdk-core/src/worker/workflow/mod.rs
+++ b/crates/sdk-core/src/worker/workflow/mod.rs
@@ -83,7 +83,7 @@ use temporalio_common::{
             failure::v1::{ApplicationFailureInfo, failure::FailureInfo},
             protocol::v1::Message as ProtocolMessage,
             query::v1::WorkflowQuery,
-            sdk::v1::{UserMetadata, WorkflowTaskCompletedMetadata},
+            sdk::v1::{EventGroupMarker, UserMetadata, WorkflowTaskCompletedMetadata},
             taskqueue::v1::StickyExecutionAttributes,
             workflowservice::v1::{PollActivityTaskQueueResponse, get_system_info_response},
         },
@@ -1414,6 +1414,17 @@ struct EmptyWorkflowCommandErr;
 struct WFCommand {
     variant: WFCommandVariant,
     metadata: Option<UserMetadata>,
+    event_group_markers: Vec<EventGroupMarker>,
+}
+
+impl WFCommand {
+    fn new(variant: WFCommandVariant) -> Self {
+        Self {
+            variant,
+            metadata: None,
+            event_group_markers: vec![],
+        }
+    }
 }
 
 #[derive(Debug, derive_more::From, derive_more::Display)]
@@ -1508,6 +1519,7 @@ impl TryFrom<WorkflowCommand> for WFCommand {
         Ok(Self {
             variant,
             metadata: c.user_metadata,
+            event_group_markers: c.event_group_markers,
         })
     }
 }

--- a/crates/sdk-core/src/worker/workflow/mod.rs
+++ b/crates/sdk-core/src/worker/workflow/mod.rs
@@ -81,7 +81,7 @@ use temporalio_common::{
             failure::v1::{ApplicationFailureInfo, failure::FailureInfo},
             protocol::v1::Message as ProtocolMessage,
             query::v1::WorkflowQuery,
-            sdk::v1::{UserMetadata, WorkflowTaskCompletedMetadata},
+            sdk::v1::{EventGroupMarker, UserMetadata, WorkflowTaskCompletedMetadata},
             taskqueue::v1::StickyExecutionAttributes,
             workflowservice::v1::{PollActivityTaskQueueResponse, get_system_info_response},
         },
@@ -1345,6 +1345,7 @@ struct EmptyWorkflowCommandErr;
 struct WFCommand {
     variant: WFCommandVariant,
     metadata: Option<UserMetadata>,
+    event_group_markers: Vec<EventGroupMarker>,
 }
 
 #[derive(Debug, derive_more::From, derive_more::Display)]
@@ -1439,6 +1440,7 @@ impl TryFrom<WorkflowCommand> for WFCommand {
         Ok(Self {
             variant,
             metadata: c.user_metadata,
+            event_group_markers: c.event_group_markers,
         })
     }
 }

--- a/crates/sdk-core/src/worker/workflow/mod.rs
+++ b/crates/sdk-core/src/worker/workflow/mod.rs
@@ -1340,7 +1340,7 @@ struct EmptyWorkflowCommandErr;
 
 /// [DrivenWorkflow]s respond with these when called, to indicate what they want to do next.
 /// EX: Create a new timer, complete the workflow, etc.
-#[derive(Debug, derive_more::From, derive_more::Display)]
+#[derive(Debug, Default, derive_more::From, derive_more::Display)]
 #[display("{}", variant)]
 struct WFCommand {
     variant: WFCommandVariant,
@@ -1348,10 +1348,11 @@ struct WFCommand {
     event_group_markers: Vec<EventGroupMarker>,
 }
 
-#[derive(Debug, derive_more::From, derive_more::Display)]
+#[derive(Debug, Default, derive_more::From, derive_more::Display)]
 #[allow(clippy::large_enum_variant)]
 enum WFCommandVariant {
     /// Returned when we need to wait for the lang sdk to send us something
+    #[default]
     NoCommandsFromLang,
     AddActivity(ScheduleActivity),
     AddLocalActivity(ScheduleLocalActivity),

--- a/crates/sdk-core/tests/integ_tests/workflow_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests.rs
@@ -6,6 +6,7 @@ mod client_interactions;
 mod continue_as_new;
 mod determinism;
 mod eager;
+mod event_groups;
 mod interceptors;
 mod local_activities;
 mod modify_wf_properties;

--- a/crates/sdk-core/tests/integ_tests/workflow_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests.rs
@@ -6,6 +6,7 @@ mod client_interactions;
 mod continue_as_new;
 mod determinism;
 mod eager;
+mod event_groups;
 mod local_activities;
 mod modify_wf_properties;
 mod nexus;
@@ -1076,6 +1077,7 @@ async fn pass_timer_summary_to_metadata() {
             ctx.timer(TimerOptions {
                 duration: Duration::from_secs(1),
                 summary: Some("timer summary".to_string()),
+                ..Default::default()
             })
             .await;
             Ok(())

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/event_groups.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/event_groups.rs
@@ -1,0 +1,426 @@
+//! Verify that `EventGroupMarker`s attached to lang-side options propagate all the
+//! way down to the server-side `Command`s issued by Core. One mocked test per command
+//! kind we currently expose `event_group_markers` on: activity, child workflow, timer,
+//! local activity.
+//!
+//! Plus one end-to-end test against a real server, verifying that the markers also
+//! land on the resulting `HistoryEvent` (i.e. the server persists what we send).
+//!
+//! Event Groups are not implemented in the Rust SDK, so these tests build markers as raw
+//! protos and set them through the `#[doc(hidden)]` `event_group_markers` option fields,
+//! which exist for that purpose only.
+
+use std::time::Duration;
+
+use crate::common::{
+    CoreWfStarter, activity_functions::StdActivities, build_fake_sdk_with_options,
+    mock_sdk_cfg_with_options,
+};
+use temporalio_client::{UntypedWorkflow, WorkflowStartOptions};
+use temporalio_common::{
+    data_converters::RawValue,
+    protos::{
+        coresdk::AsJsonPayloadExt,
+        temporal::api::{
+            enums::v1::{CommandType, EventType},
+            sdk::v1::{
+                EventGroupMarker,
+                event_group_marker::{Label, Variant},
+            },
+        },
+    },
+};
+use temporalio_macros::{workflow, workflow_methods};
+use temporalio_sdk::{
+    ActivityOptions, ChildWorkflowOptions, LocalActivityOptions, TimerOptions, WorkflowContext,
+    WorkflowResult,
+};
+use temporalio_sdk_core::{
+    replay::{DEFAULT_WORKFLOW_TYPE, canned_histories},
+    test_help::MockPollCfg,
+};
+
+#[tokio::test]
+async fn pass_event_group_markers_on_schedule_activity() {
+    let t = canned_histories::single_activity("1");
+    let mut mock_cfg = MockPollCfg::from_hist_builder(t);
+    let wf_id = mock_cfg.hists[0].wf_id.clone();
+    let wf_type = DEFAULT_WORKFLOW_TYPE;
+    let expected_markers = vec![label_marker("activity-group", "activity-group-label")];
+
+    let expected_for_assert = expected_markers.clone();
+    mock_cfg.completion_asserts_from_expectations(|mut asserts| {
+        asserts
+            .then(move |wft| {
+                assert_eq!(wft.commands.len(), 1);
+                assert_eq!(
+                    wft.commands[0].command_type(),
+                    CommandType::ScheduleActivityTask
+                );
+                assert_eq!(wft.commands[0].event_group_markers, expected_for_assert);
+            })
+            .then(|wft| {
+                assert_eq!(wft.commands.len(), 1);
+                assert_eq!(
+                    wft.commands[0].command_type(),
+                    CommandType::CompleteWorkflowExecution
+                );
+                assert!(wft.commands[0].event_group_markers.is_empty());
+            });
+    });
+
+    #[workflow]
+    struct ActivityWithGroupWorkflow {
+        event_group_markers: Vec<EventGroupMarker>,
+    }
+
+    #[workflow_methods(factory_only)]
+    impl ActivityWithGroupWorkflow {
+        #[run(name = DEFAULT_WORKFLOW_TYPE)]
+        async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+            let event_group_markers = ctx.state(|wf| wf.event_group_markers.clone());
+            ctx.execute_activity(
+                StdActivities::default,
+                (),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                    .event_group_markers(event_group_markers)
+                    .build(),
+            )
+            .await?;
+            Ok(())
+        }
+    }
+
+    let mut worker = mock_sdk_cfg_with_options(
+        mock_cfg,
+        |_| {},
+        |options| {
+            options
+                .register_workflow_with_factory(move || ActivityWithGroupWorkflow {
+                    event_group_markers: expected_markers.clone(),
+                })
+                .unwrap();
+        },
+    );
+    let task_queue = worker.inner_mut().task_queue().to_owned();
+    worker
+        .submit_wf(
+            wf_type.to_owned(),
+            vec![],
+            WorkflowStartOptions::new(task_queue, wf_id.to_owned()).build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+}
+
+#[tokio::test]
+async fn pass_event_group_markers_on_start_child_workflow() {
+    let wf_id = "1";
+    let wf_type = DEFAULT_WORKFLOW_TYPE;
+    let t = canned_histories::single_child_workflow(wf_id);
+    let mut mock_cfg = MockPollCfg::from_hist_builder(t);
+    let expected_markers = vec![label_marker("child-group", "child-group-label")];
+
+    let expected_for_assert = expected_markers.clone();
+    mock_cfg.completion_asserts_from_expectations(|mut asserts| {
+        asserts
+            .then(move |wft| {
+                assert_eq!(wft.commands.len(), 1);
+                assert_eq!(
+                    wft.commands[0].command_type(),
+                    CommandType::StartChildWorkflowExecution
+                );
+                assert_eq!(wft.commands[0].event_group_markers, expected_for_assert);
+            })
+            .then(|wft| {
+                assert_eq!(wft.commands.len(), 1);
+                assert_eq!(
+                    wft.commands[0].command_type(),
+                    CommandType::CompleteWorkflowExecution
+                );
+                assert!(wft.commands[0].event_group_markers.is_empty());
+            });
+    });
+
+    #[workflow]
+    struct ChildWithGroupWorkflow {
+        child_wf_id: String,
+        event_group_markers: Vec<EventGroupMarker>,
+    }
+
+    #[workflow_methods(factory_only)]
+    impl ChildWithGroupWorkflow {
+        #[run(name = DEFAULT_WORKFLOW_TYPE)]
+        async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+            let (child_wf_id, event_group_markers) =
+                ctx.state(|wf| (wf.child_wf_id.clone(), wf.event_group_markers.clone()));
+            ctx.start_child_workflow(
+                UntypedWorkflow::new("child"),
+                RawValue::new(vec![]),
+                ChildWorkflowOptions::builder()
+                    .workflow_id(child_wf_id)
+                    .event_group_markers(event_group_markers)
+                    .build(),
+            )
+            .await?;
+            Ok(())
+        }
+    }
+
+    let child_wf_id = wf_id.to_string();
+    let event_group_markers_for_wf = expected_markers.clone();
+    let mut worker = mock_sdk_cfg_with_options(
+        mock_cfg,
+        |_| {},
+        |options| {
+            options
+                .register_workflow_with_factory(move || ChildWithGroupWorkflow {
+                    child_wf_id: child_wf_id.clone(),
+                    event_group_markers: event_group_markers_for_wf.clone(),
+                })
+                .unwrap();
+        },
+    );
+    let task_queue = worker.inner_mut().task_queue().to_owned();
+    worker
+        .submit_wf(
+            wf_type.to_owned(),
+            vec![],
+            WorkflowStartOptions::new(task_queue, wf_id.to_owned()).build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+}
+
+#[tokio::test]
+async fn pass_event_group_markers_on_start_timer() {
+    let t = canned_histories::single_timer("1");
+    let mut mock_cfg = MockPollCfg::from_hist_builder(t);
+    let wf_id = mock_cfg.hists[0].wf_id.clone();
+    let wf_type = DEFAULT_WORKFLOW_TYPE;
+    let expected_markers = vec![label_marker("timer-group", "timer-group-label")];
+
+    let expected_for_assert = expected_markers.clone();
+    mock_cfg.completion_asserts_from_expectations(|mut asserts| {
+        asserts
+            .then(move |wft| {
+                assert_eq!(wft.commands.len(), 1);
+                assert_eq!(wft.commands[0].command_type(), CommandType::StartTimer);
+                assert_eq!(wft.commands[0].event_group_markers, expected_for_assert);
+            })
+            .then(|wft| {
+                assert_eq!(wft.commands.len(), 1);
+                assert_eq!(
+                    wft.commands[0].command_type(),
+                    CommandType::CompleteWorkflowExecution
+                );
+                assert!(wft.commands[0].event_group_markers.is_empty());
+            });
+    });
+
+    #[workflow]
+    struct TimerWithGroupWorkflow {
+        event_group_markers: Vec<EventGroupMarker>,
+    }
+
+    #[workflow_methods(factory_only)]
+    impl TimerWithGroupWorkflow {
+        #[run(name = DEFAULT_WORKFLOW_TYPE)]
+        async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+            let event_group_markers = ctx.state(|wf| wf.event_group_markers.clone());
+            ctx.timer(
+                TimerOptions::builder(Duration::from_secs(1))
+                    .event_group_markers(event_group_markers)
+                    .build(),
+            )
+            .await;
+            Ok(())
+        }
+    }
+
+    let event_group_markers_for_wf = expected_markers.clone();
+    let mut worker = mock_sdk_cfg_with_options(
+        mock_cfg,
+        |_| {},
+        |options| {
+            options
+                .register_workflow_with_factory(move || TimerWithGroupWorkflow {
+                    event_group_markers: event_group_markers_for_wf.clone(),
+                })
+                .unwrap();
+        },
+    );
+    let task_queue = worker.inner_mut().task_queue().to_owned();
+    worker
+        .submit_wf(
+            wf_type.to_owned(),
+            vec![],
+            WorkflowStartOptions::new(task_queue, wf_id.to_owned()).build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+}
+
+/// Local activities pose some particular challenges: the corresponding `RecordMarker` command
+/// only gets created at a later point, after the local activity completes execution.
+/// server, so instead of a command of their own they produce a `RecordMarker` command that
+/// Core synthesizes when the activity resolves. Markers attached to the `ScheduleLocalActivity`
+/// command have to survive that indirection and end up on the marker command.
+#[tokio::test]
+async fn pass_event_group_markers_on_schedule_local_activity() {
+    let t = canned_histories::single_local_activity("1");
+    let mut mock_cfg = MockPollCfg::from_hist_builder(t);
+    let expected_markers = vec![label_marker("local-activity-group", "local-activity-label")];
+
+    let expected_for_assert = expected_markers.clone();
+    mock_cfg.completion_asserts_from_expectations(|mut asserts| {
+        // The activity resolves within the same workflow task that scheduled it, so the marker
+        // command is flushed together with the workflow completion rather than on its own.
+        asserts.then(move |wft| {
+            assert_eq!(wft.commands.len(), 2);
+            assert_eq!(wft.commands[0].command_type(), CommandType::RecordMarker);
+            assert_eq!(wft.commands[0].event_group_markers, expected_for_assert);
+            assert_eq!(
+                wft.commands[1].command_type(),
+                CommandType::CompleteWorkflowExecution
+            );
+            assert!(wft.commands[1].event_group_markers.is_empty());
+        });
+    });
+
+    #[workflow]
+    struct LocalActivityWithGroupWorkflow {
+        event_group_markers: Vec<EventGroupMarker>,
+    }
+
+    #[workflow_methods(factory_only)]
+    impl LocalActivityWithGroupWorkflow {
+        #[run(name = DEFAULT_WORKFLOW_TYPE)]
+        async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+            let event_group_markers = ctx.state(|wf| wf.event_group_markers.clone());
+            ctx.execute_local_activity(
+                StdActivities::default,
+                (),
+                LocalActivityOptions::builder()
+                    .event_group_markers(event_group_markers)
+                    .build(),
+            )
+            .await?;
+            Ok(())
+        }
+    }
+
+    // Unlike the tests above, this one drives a plain SDK worker off the canned history rather
+    // than submitting a workflow: the local activity must actually run for a marker to be
+    // recorded, so the worker needs the activity implementation registered too.
+    let mut worker = build_fake_sdk_with_options(mock_cfg, |options| {
+        options
+            .register_workflow_with_factory(move || LocalActivityWithGroupWorkflow {
+                event_group_markers: expected_markers.clone(),
+            })
+            .unwrap()
+            .register_activities(StdActivities);
+    });
+    worker.run().await.unwrap();
+}
+
+// Constants used by the real-server test below; defining them at module scope so the
+// workflow body and the assertion can construct the same marker independently.
+const PERSIST_TEST_MARKER_ID: &str = "persist-test";
+const PERSIST_TEST_MARKER_LABEL: &str = "persist-test-label";
+const PERSIST_TEST_LA_MARKER_ID: &str = "persist-test-la";
+const PERSIST_TEST_LA_MARKER_LABEL: &str = "persist-test-la-label";
+
+#[workflow]
+#[derive(Default)]
+pub(crate) struct ActivityEventGroupPersistsWf;
+
+#[workflow_methods]
+impl ActivityEventGroupPersistsWf {
+    #[run(name = "event_group_markers_persist_to_history_events")]
+    pub(crate) async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+        ctx.execute_activity(
+            StdActivities::default,
+            (),
+            ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                .event_group_markers(vec![label_marker(
+                    PERSIST_TEST_MARKER_ID,
+                    PERSIST_TEST_MARKER_LABEL,
+                )])
+                .build(),
+        )
+        .await?;
+        ctx.execute_local_activity(
+            StdActivities::default,
+            (),
+            LocalActivityOptions::builder()
+                .start_to_close_timeout(Duration::from_secs(5))
+                .event_group_markers(vec![label_marker(
+                    PERSIST_TEST_LA_MARKER_ID,
+                    PERSIST_TEST_LA_MARKER_LABEL,
+                )])
+                .build(),
+        )
+        .await?;
+        Ok(())
+    }
+}
+
+/// End-to-end: a marker attached to a command must also land on the resulting history event
+/// after the server persists it. Covers both an ordinary activity (`ActivityTaskScheduled`) and
+/// a local activity, which surfaces as the `MarkerRecorded` event Core writes on resolution.
+#[tokio::test]
+async fn event_group_markers_persist_to_history_events() {
+    let wf_name = "event_group_markers_persist_to_history_events";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter
+        .sdk_config
+        .register_activities(StdActivities)
+        .register_workflow::<ActivityEventGroupPersistsWf>()
+        .unwrap();
+    let mut worker = starter.worker().await;
+
+    starter.start_with_worker(wf_name, &mut worker).await;
+    worker.run_until_done().await.unwrap();
+
+    let history = starter.get_history().await;
+    let scheduled_events: Vec<_> = history
+        .events
+        .iter()
+        .filter(|e| e.event_type() == EventType::ActivityTaskScheduled)
+        .collect();
+    assert_eq!(scheduled_events.len(), 1);
+    assert_eq!(
+        scheduled_events[0].event_group_markers,
+        vec![label_marker(
+            PERSIST_TEST_MARKER_ID,
+            PERSIST_TEST_MARKER_LABEL
+        )]
+    );
+
+    let marker_events: Vec<_> = history
+        .events
+        .iter()
+        .filter(|e| e.event_type() == EventType::MarkerRecorded)
+        .collect();
+    assert_eq!(marker_events.len(), 1);
+    assert_eq!(
+        marker_events[0].event_group_markers,
+        vec![label_marker(
+            PERSIST_TEST_LA_MARKER_ID,
+            PERSIST_TEST_LA_MARKER_LABEL
+        )]
+    );
+}
+
+fn label_marker(id: &str, label: &str) -> EventGroupMarker {
+    EventGroupMarker {
+        variant: Some(Variant::Label(Label {
+            id: id.to_string(),
+            label: Some(label.as_json_payload().unwrap()),
+        })),
+    } as EventGroupMarker
+}

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/event_groups.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/event_groups.rs
@@ -1,0 +1,312 @@
+//! Verify that `EventGroupMarker`s attached to lang-side options propagate all the
+//! way down to the server-side `Command`s issued by Core. One mocked test per command
+//! kind we currently expose `groups` on: activity, child workflow, timer.
+//!
+//! Plus one end-to-end test against a real server, verifying that the markers also
+//! land on the resulting `HistoryEvent` (i.e. the server persists what we send).
+
+use crate::common::{CoreWfStarter, activity_functions::StdActivities, mock_sdk_cfg};
+use temporalio_client::{UntypedWorkflow, WorkflowStartOptions};
+use temporalio_common::{
+    data_converters::RawValue,
+    protos::{
+        coresdk::AsJsonPayloadExt,
+        temporal::api::{
+            enums::v1::{CommandType, EventType},
+            sdk::v1::{
+                EventGroupMarker,
+                event_group_marker::{Label, Variant},
+            },
+        },
+    },
+};
+use temporalio_macros::{workflow, workflow_methods};
+use temporalio_sdk::{
+    ActivityOptions, ChildWorkflowOptions, TimerOptions, WorkflowContext, WorkflowResult,
+};
+use temporalio_sdk_core::{
+    replay::{DEFAULT_WORKFLOW_TYPE, canned_histories},
+    test_help::MockPollCfg,
+};
+
+use std::time::Duration;
+
+fn label_marker(id: &str, label: &str) -> EventGroupMarker {
+    EventGroupMarker {
+        variant: Some(Variant::Label(Label {
+            id: id.to_string(),
+            label: Some(label.as_json_payload().unwrap()),
+        })),
+    } as EventGroupMarker
+}
+
+#[tokio::test]
+async fn pass_event_group_markers_on_schedule_activity() {
+    let t = canned_histories::single_activity("1");
+    let mut mock_cfg = MockPollCfg::from_hist_builder(t);
+    let wf_id = mock_cfg.hists[0].wf_id.clone();
+    let wf_type = DEFAULT_WORKFLOW_TYPE;
+    let expected_markers = vec![label_marker("activity-group", "activity-group-label")];
+
+    let expected_for_assert = expected_markers.clone();
+    mock_cfg.completion_asserts_from_expectations(|mut asserts| {
+        asserts
+            .then(move |wft| {
+                assert_eq!(wft.commands.len(), 1);
+                assert_eq!(
+                    wft.commands[0].command_type(),
+                    CommandType::ScheduleActivityTask
+                );
+                assert_eq!(wft.commands[0].event_group_markers, expected_for_assert);
+            })
+            .then(|wft| {
+                assert_eq!(wft.commands.len(), 1);
+                assert_eq!(
+                    wft.commands[0].command_type(),
+                    CommandType::CompleteWorkflowExecution
+                );
+                assert!(wft.commands[0].event_group_markers.is_empty());
+            });
+    });
+
+    let mut worker = mock_sdk_cfg(mock_cfg, |_| {});
+
+    #[workflow]
+    struct ActivityWithGroupWorkflow {
+        groups: Vec<EventGroupMarker>,
+    }
+
+    #[workflow_methods(factory_only)]
+    impl ActivityWithGroupWorkflow {
+        #[run(name = DEFAULT_WORKFLOW_TYPE)]
+        async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+            let groups = ctx.state(|wf| wf.groups.clone());
+            ctx.start_activity(
+                StdActivities::default,
+                (),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                    .groups(groups)
+                    .build(),
+            )
+            .await?;
+            Ok(())
+        }
+    }
+
+    worker
+        .register_workflow_with_factory(move || ActivityWithGroupWorkflow {
+            groups: expected_markers.clone(),
+        })
+        .unwrap();
+    let task_queue = worker.inner_mut().task_queue().to_owned();
+    worker
+        .submit_wf(
+            wf_type.to_owned(),
+            vec![],
+            WorkflowStartOptions::new(task_queue, wf_id.to_owned()).build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+}
+
+#[tokio::test]
+async fn pass_event_group_markers_on_start_child_workflow() {
+    let wf_id = "1";
+    let wf_type = DEFAULT_WORKFLOW_TYPE;
+    let t = canned_histories::single_child_workflow(wf_id);
+    let mut mock_cfg = MockPollCfg::from_hist_builder(t);
+    let expected_markers = vec![label_marker("child-group", "child-group-label")];
+
+    let expected_for_assert = expected_markers.clone();
+    mock_cfg.completion_asserts_from_expectations(|mut asserts| {
+        asserts
+            .then(move |wft| {
+                assert_eq!(wft.commands.len(), 1);
+                assert_eq!(
+                    wft.commands[0].command_type(),
+                    CommandType::StartChildWorkflowExecution
+                );
+                assert_eq!(wft.commands[0].event_group_markers, expected_for_assert);
+            })
+            .then(|wft| {
+                assert_eq!(wft.commands.len(), 1);
+                assert_eq!(
+                    wft.commands[0].command_type(),
+                    CommandType::CompleteWorkflowExecution
+                );
+                assert!(wft.commands[0].event_group_markers.is_empty());
+            });
+    });
+
+    let mut worker = mock_sdk_cfg(mock_cfg, |_| {});
+
+    #[workflow]
+    struct ChildWithGroupWorkflow {
+        child_wf_id: String,
+        groups: Vec<EventGroupMarker>,
+    }
+
+    #[workflow_methods(factory_only)]
+    impl ChildWithGroupWorkflow {
+        #[run(name = DEFAULT_WORKFLOW_TYPE)]
+        async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+            let (child_wf_id, groups) = ctx.state(|wf| (wf.child_wf_id.clone(), wf.groups.clone()));
+            ctx.start_child_workflow(
+                UntypedWorkflow::new("child"),
+                RawValue::new(vec![]),
+                ChildWorkflowOptions {
+                    workflow_id: child_wf_id,
+                    groups,
+                    ..Default::default()
+                },
+            )
+            .await?;
+            Ok(())
+        }
+    }
+
+    let child_wf_id = wf_id.to_string();
+    let groups_for_wf = expected_markers.clone();
+    worker
+        .register_workflow_with_factory(move || ChildWithGroupWorkflow {
+            child_wf_id: child_wf_id.clone(),
+            groups: groups_for_wf.clone(),
+        })
+        .unwrap();
+    let task_queue = worker.inner_mut().task_queue().to_owned();
+    worker
+        .submit_wf(
+            wf_type.to_owned(),
+            vec![],
+            WorkflowStartOptions::new(task_queue, wf_id.to_owned()).build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+}
+
+#[tokio::test]
+async fn pass_event_group_markers_on_start_timer() {
+    let t = canned_histories::single_timer("1");
+    let mut mock_cfg = MockPollCfg::from_hist_builder(t);
+    let wf_id = mock_cfg.hists[0].wf_id.clone();
+    let wf_type = DEFAULT_WORKFLOW_TYPE;
+    let expected_markers = vec![label_marker("timer-group", "timer-group-label")];
+
+    let expected_for_assert = expected_markers.clone();
+    mock_cfg.completion_asserts_from_expectations(|mut asserts| {
+        asserts
+            .then(move |wft| {
+                assert_eq!(wft.commands.len(), 1);
+                assert_eq!(wft.commands[0].command_type(), CommandType::StartTimer);
+                assert_eq!(wft.commands[0].event_group_markers, expected_for_assert);
+            })
+            .then(|wft| {
+                assert_eq!(wft.commands.len(), 1);
+                assert_eq!(
+                    wft.commands[0].command_type(),
+                    CommandType::CompleteWorkflowExecution
+                );
+                assert!(wft.commands[0].event_group_markers.is_empty());
+            });
+    });
+
+    let mut worker = mock_sdk_cfg(mock_cfg, |_| {});
+
+    #[workflow]
+    struct TimerWithGroupWorkflow {
+        groups: Vec<EventGroupMarker>,
+    }
+
+    #[workflow_methods(factory_only)]
+    impl TimerWithGroupWorkflow {
+        #[run(name = DEFAULT_WORKFLOW_TYPE)]
+        async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+            let groups = ctx.state(|wf| wf.groups.clone());
+            ctx.timer(TimerOptions {
+                duration: Duration::from_secs(1),
+                groups,
+                ..Default::default()
+            })
+            .await;
+            Ok(())
+        }
+    }
+
+    let groups_for_wf = expected_markers.clone();
+    worker
+        .register_workflow_with_factory(move || TimerWithGroupWorkflow {
+            groups: groups_for_wf.clone(),
+        })
+        .unwrap();
+    let task_queue = worker.inner_mut().task_queue().to_owned();
+    worker
+        .submit_wf(
+            wf_type.to_owned(),
+            vec![],
+            WorkflowStartOptions::new(task_queue, wf_id.to_owned()).build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+}
+
+// Constants used by the real-server test below; defining them at module scope so the
+// workflow body and the assertion can construct the same marker independently.
+const PERSIST_TEST_MARKER_ID: &str = "persist-test";
+const PERSIST_TEST_MARKER_LABEL: &str = "persist-test-label";
+
+#[workflow]
+#[derive(Default)]
+pub(crate) struct ActivityEventGroupPersistsWf;
+
+#[workflow_methods]
+impl ActivityEventGroupPersistsWf {
+    #[run(name = "event_group_markers_persist_to_history_events")]
+    pub(crate) async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+        ctx.start_activity(
+            StdActivities::default,
+            (),
+            ActivityOptions::with_start_to_close_timeout(Duration::from_secs(5))
+                .groups(vec![label_marker(
+                    PERSIST_TEST_MARKER_ID,
+                    PERSIST_TEST_MARKER_LABEL,
+                )])
+                .build(),
+        )
+        .await?;
+        Ok(())
+    }
+}
+
+/// End-to-end: a marker attached to a `ScheduleActivity` command must also land on the
+/// resulting `ActivityTaskScheduled` history event after the server persists it.
+#[tokio::test]
+async fn event_group_markers_persist_to_history_events() {
+    let wf_name = "event_group_markers_persist_to_history_events";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.sdk_config.register_activities(StdActivities);
+    let mut worker = starter.worker().await;
+    worker
+        .register_workflow::<ActivityEventGroupPersistsWf>()
+        .unwrap();
+
+    starter.start_with_worker(wf_name, &mut worker).await;
+    worker.run_until_done().await.unwrap();
+
+    let history = starter.get_history().await;
+    let scheduled_events: Vec<_> = history
+        .events
+        .into_iter()
+        .filter(|e| e.event_type() == EventType::ActivityTaskScheduled)
+        .collect();
+    assert_eq!(scheduled_events.len(), 1);
+    assert_eq!(
+        scheduled_events[0].event_group_markers,
+        vec![label_marker(
+            PERSIST_TEST_MARKER_ID,
+            PERSIST_TEST_MARKER_LABEL
+        )]
+    );
+}

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -2525,6 +2525,7 @@ impl Future for LATimerBackoffFut {
                     .expect("duration converts ok"),
                 cancellation_token: Some(self.cancellation_token.clone()),
                 summary: None,
+                event_group_markers: vec![],
             });
             self.timer_fut = Some(Box::pin(timer_f));
             self.next_attempt = b.attempt;
@@ -3449,6 +3450,7 @@ mod tests {
             duration: Duration::from_secs(1),
             cancellation_token: Some(token.clone()),
             summary: None,
+            event_group_markers: vec![],
         });
 
         let mut activity_options = ActivityOptions::start_to_close_timeout(Duration::from_secs(1));

--- a/crates/workflow/src/workflow_context/options.rs
+++ b/crates/workflow/src/workflow_context/options.rs
@@ -29,7 +29,7 @@ use temporalio_common_wasm::{
                 ContinueAsNewVersioningBehavior as ProtoContinueAsNewVersioningBehavior,
                 WorkflowIdReusePolicy as ProtoWorkflowIdReusePolicy,
             },
-            sdk::v1::UserMetadata,
+            sdk::v1::{EventGroupMarker, UserMetadata},
         },
     },
     search_attributes::SearchAttributes,
@@ -323,6 +323,13 @@ pub struct ActivityOptions {
     /// If true, disable eager execution for this activity
     #[builder(default)]
     pub do_not_eagerly_execute: bool,
+    /// Event group markers to attach to the resulting `ScheduleActivityTask` command.
+    ///
+    /// **Unstable:** Event Groups are not yet implemented in the Rust SDK; this field exists
+    /// only for internal test purposes. This API *will* change.
+    #[doc(hidden)]
+    #[builder(default)]
+    pub event_group_markers: Vec<EventGroupMarker>,
 }
 
 impl ActivityOptions {
@@ -390,6 +397,7 @@ impl ActivityOptions {
             }),
             self.summary,
             None,
+            self.event_group_markers,
         )
     }
 }
@@ -437,6 +445,13 @@ pub struct LocalActivityOptions {
     pub start_to_close_timeout: Option<Duration>,
     /// Single-line summary for this activity that will appear in UI/CLI.
     pub summary: Option<String>,
+    /// Event group markers to attach to the resulting `RecordMarker` command.
+    ///
+    /// **Unstable:** Event Groups are not yet implemented in the Rust SDK; this field exists
+    /// only for internal test purposes. This API *will* change.
+    #[doc(hidden)]
+    #[builder(default)]
+    pub event_group_markers: Vec<EventGroupMarker>,
 }
 
 impl Default for LocalActivityOptions {
@@ -483,6 +498,7 @@ impl LocalActivityOptions {
             }),
             self.summary,
             None,
+            self.event_group_markers,
         )
     }
 }
@@ -524,6 +540,13 @@ pub struct ChildWorkflowOptions {
     pub search_attributes: Option<SearchAttributes>,
     /// Priority for the workflow
     pub priority: Option<Priority>,
+    /// Event group markers to attach to the resulting `StartChildWorkflowExecution` command.
+    ///
+    /// **Unstable:** Event Groups are not yet implemented in the Rust SDK; this field exists
+    /// only for internal test purposes. This API *will* change.
+    #[doc(hidden)]
+    #[builder(default)]
+    pub event_group_markers: Vec<EventGroupMarker>,
 }
 
 impl ChildWorkflowOptions {
@@ -576,6 +599,7 @@ impl ChildWorkflowOptions {
             }),
             self.static_summary,
             self.static_details,
+            self.event_group_markers,
         )
     }
 }
@@ -591,6 +615,13 @@ pub struct TimerOptions {
     pub cancellation_token: Option<WorkflowCancellationToken>,
     /// Summary of the timer
     pub summary: Option<String>,
+    /// Event group markers to attach to the resulting `StartTimer` command.
+    ///
+    /// **Unstable:** Event Groups are not yet implemented in the Rust SDK; this field exists
+    /// only for internal test purposes. This API *will* change.
+    #[doc(hidden)]
+    #[builder(default)]
+    pub event_group_markers: Vec<EventGroupMarker>,
 }
 
 impl Default for TimerOptions {
@@ -621,6 +652,7 @@ impl TimerOptions {
             }),
             self.summary,
             None,
+            self.event_group_markers,
         )
     }
 }
@@ -641,6 +673,13 @@ pub struct SignalWorkflowOptions {
     pub cancellation_token: Option<WorkflowCancellationToken>,
     /// Single-line summary for this signal that will appear in UI/CLI.
     pub summary: Option<String>,
+    /// Event group markers to attach to the resulting `SignalExternalWorkflowExecution` command.
+    ///
+    /// **Unstable:** Event Groups are not yet implemented in the Rust SDK; this field exists
+    /// only for internal test purposes. This API *will* change.
+    #[doc(hidden)]
+    #[builder(default)]
+    pub event_group_markers: Vec<EventGroupMarker>,
 }
 
 impl SignalWorkflowOptions {
@@ -664,6 +703,7 @@ impl SignalWorkflowOptions {
             ),
             self.summary,
             None,
+            self.event_group_markers,
         )
     }
 }
@@ -870,10 +910,12 @@ fn command_with_metadata(
     variant: workflow_command::Variant,
     summary: Option<String>,
     details: Option<String>,
+    markers: Vec<EventGroupMarker>,
 ) -> WorkflowCommand {
     WorkflowCommand {
         variant: Some(variant),
         user_metadata: string_user_metadata(summary, details),
+        event_group_markers: markers,
     }
 }
 

--- a/crates/workflow/src/workflow_context/options.rs
+++ b/crates/workflow/src/workflow_context/options.rs
@@ -24,7 +24,7 @@ use temporalio_common_wasm::{
                 ContinueAsNewVersioningBehavior as ProtoContinueAsNewVersioningBehavior,
                 WorkflowIdReusePolicy,
             },
-            sdk::v1::UserMetadata,
+            sdk::v1::{EventGroupMarker, UserMetadata},
         },
     },
     search_attributes::SearchAttributes,
@@ -71,6 +71,10 @@ pub struct ActivityOptions {
     /// If true, disable eager execution for this activity
     #[builder(default)]
     pub do_not_eagerly_execute: bool,
+    /// Event group markers attached to the resulting `ScheduleActivityTask` command.
+    /// See [`EventGroupMarker`].
+    #[builder(default)]
+    pub groups: Vec<EventGroupMarker>,
 }
 
 impl ActivityOptions {
@@ -170,6 +174,7 @@ impl ActivityOptions {
             }),
             self.summary,
             None,
+            self.groups,
         )
     }
 }
@@ -251,6 +256,7 @@ impl LocalActivityOptions {
             }),
             self.summary,
             None,
+            vec![],
         )
     }
 }
@@ -286,6 +292,9 @@ pub struct ChildWorkflowOptions {
     pub search_attributes: Option<SearchAttributes>,
     /// Priority for the workflow
     pub priority: Option<Priority>,
+    /// Event group markers attached to the resulting `StartChildWorkflowExecution` command.
+    /// See [`EventGroupMarker`].
+    pub groups: Vec<EventGroupMarker>,
 }
 
 impl ChildWorkflowOptions {
@@ -325,6 +334,7 @@ impl ChildWorkflowOptions {
             }),
             self.static_summary,
             self.static_details,
+            self.groups,
         )
     }
 }
@@ -356,6 +366,7 @@ impl Signal {
             input: self.data.input,
             identity: String::new(),
             headers: self.data.headers,
+            originating_event_id: 0,
         }
     }
 }
@@ -396,6 +407,9 @@ pub struct TimerOptions {
     pub duration: Duration,
     /// Summary of the timer
     pub summary: Option<String>,
+    /// Event group markers attached to the resulting `StartTimer` command.
+    /// See [`EventGroupMarker`].
+    pub groups: Vec<EventGroupMarker>,
 }
 
 impl From<Duration> for TimerOptions {
@@ -420,6 +434,7 @@ impl TimerOptions {
             }),
             self.summary,
             None,
+            self.groups,
         )
     }
 }
@@ -613,10 +628,12 @@ fn command_with_metadata(
     variant: workflow_command::Variant,
     summary: Option<String>,
     details: Option<String>,
+    markers: Vec<EventGroupMarker>,
 ) -> WorkflowCommand {
     WorkflowCommand {
         variant: Some(variant),
         user_metadata: string_user_metadata(summary, details),
+        event_group_markers: markers,
     }
 }
 


### PR DESCRIPTION
## What was changed

Introduces support for Event Groups in Core SDK.

Surfacing that API properly in Rust SDK will be done in a distinct PR.

More specifically, this PR introduces the following two critical changes:
- Copy of the `event_group_markers` field from lang's `Command` → server's `Command`.
- Copy of the `event_id` or `update_id` field from server's `HistoryEvent` → lang's `Job`.

## Why?

Event Groups is a new form of metadata that allows regrouping of logically related Workflow Events, according to user-defined or system-inferred criteria, providing users with improved visibility, analysis, and debugging capabilities.

## Before merging

`.cargo/config.toml` pins the integ tests on `v1.7.4-standalone-nexus-operations`, since no CLI
release yet bundles a server that understands the Event Groups fields. Drop the pin once one does.

That pin exposes four failures that have nothing to do with Event Groups. Each is fixed by its own
PR, and CI here stays red until all four land:

- #1495 — `docker_metrics_with_prometheus` asserting on the wrong Prometheus series
- #1496 — the in-Docker environment check losing its offline guarantees
- #1497 — nexus `request-timeout` headers outside the Nexus duration grammar
- #1498 — activity cancellation against Server v1.32.0-158.0

## Related PRs in other repositories

- Protobuf API: https://github.com/temporalio/api/pull/793 (merged)
- Server: https://github.com/temporalio/temporal/pull/10472 (merged)