### PR TITLE
feat(sdk): gate experimental APIs behind feature

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,6 +15,8 @@ integ-test = [
     "--features",
     "ephemeral-server",
     "--features",
+    "temporalio-sdk/experimental",
+    "--features",
     "temporalio-sdk-core/otel",
     "--package",
     "temporalio-sdk-core",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,6 +13,8 @@ integ-test = [
     "--features",
     "ephemeral-server",
     "--features",
+    "temporalio-sdk/experimental",
+    "--features",
     "temporalio-sdk-core/otel",
     "--package",
     "temporalio-sdk-core",

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -31,6 +31,7 @@ jobs:
       - run: cargo lint
       - run: cargo test-lint
       - run: cargo check
+      - run: cargo check --features experimental
       - run: git diff --exit-code
 
   test:
@@ -67,12 +68,12 @@ jobs:
         with:
           script: |
             core.exportVariable('RUSTFLAGS', '-Csymbol-mangling-version=v0');
-      - run: cargo test -- --include-ignored --nocapture
+      - run: cargo test --features experimental -- --include-ignored --nocapture
       - name: Find test executable for cgroup tests
         id: find-cgroup-test
         if: runner.os == 'Linux' && runner.arch == 'X64'
         run: |
-          test_executable=$(cargo build --tests --message-format json | jq -r 'select(.profile?.test == true and .target?.name == "temporalio_sdk_core" and .executable) | .executable')
+          test_executable=$(cargo build --tests --features experimental --message-format json | jq -r 'select(.profile?.test == true and .target?.name == "temporalio_sdk_core" and .executable) | .executable')
           cp $test_executable ./core-tests
       - name: Upload cgroup test executable
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -186,7 +187,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           mise-install-args: protoc
-      - run: cargo test --features=test-utilities --test cloud_tests
+      - run: cargo test --features=test-utilities,temporalio-sdk/experimental --test cloud_tests
       - name: Generate Cloud test certificates
         run: |
           umask 077

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -43,6 +43,7 @@ jobs:
       - run: cargo lint
       - run: cargo test-lint
       - run: cargo check
+      - run: cargo check --features experimental
       - run: git diff --exit-code
 
   test:
@@ -88,12 +89,12 @@ jobs:
         with:
           cache-bin: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: cargo test -- --include-ignored --nocapture
+      - run: cargo test --features experimental -- --include-ignored --nocapture
       - name: Find test executable for cgroup tests
         id: find-cgroup-test
         if: runner.os == 'Linux' && runner.arch == 'X64'
         run: |
-          test_executable=$(cargo build --tests --message-format json | jq -r 'select(.profile?.test == true and .target?.name == "temporalio_sdk_core" and .executable) | .executable')
+          test_executable=$(cargo build --tests --features experimental --message-format json | jq -r 'select(.profile?.test == true and .target?.name == "temporalio_sdk_core" and .executable) | .executable')
           cp $test_executable ./core-tests
       - name: Upload cgroup test executable
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
@@ -248,7 +249,7 @@ jobs:
         with:
           cache-bin: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: cargo test --features=test-utilities --test cloud_tests
+      - run: cargo test --features=test-utilities,temporalio-sdk/experimental --test cloud_tests
 
   docker-integ-tests:
     name: Docker integ tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,6 @@ relevant information.
   * Nexus operation caller and workflow interceptor APIs, including `NexusOperationOptions`,
     `NexusOperationCancellationType`, `StartedNexusOperation`, the workflow-context start methods,
     and the `WorkflowInterceptor::start_nexus_operation` hook and input/result types.
-  * Eager Workflow Start via `WorkflowStartOptions::enable_eager_workflow_start`.
   * Worker deployment versioning APIs: `ContinueAsNewVersioningBehavior`,
     `ContinueAsNewOptions::initial_versioning_behavior`,
     `WorkflowContext::target_worker_deployment_version_changed`, and
@@ -85,7 +84,7 @@ relevant information.
   * Client, worker, and workflow replayer plugin APIs.
   * Client payload warning thresholds (`PayloadLimitsOptions` and
     `ConnectionOptions::payload_limits`) and `WorkerOptions::disable_payload_error_limit`.
-  * Patch activation callback types and the corresponding worker and workflow replayer options.
+  * Patch activation callback types and the corresponding worker option.
   * Worker lifecycle interception APIs (`WorkerInterceptor`, its input types and registration
     methods, and `ReturnWorkflowExitValueInterceptor`).
   * Event Group marker fields on activity, local activity, child workflow, timer, and external

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,24 @@ relevant information.
 * `WorkflowHistory::to_json` is now async, `WorkflowHistoryError` reports fetch and JSON conversion failures; and the eager `events`,
   `Clone`, and `From<WorkflowHistory> for History` APIs have been removed. Replay results expose
   their eagerly fetched events through `ReplayHistory`.
+* Rust SDK APIs previously marked experimental now require the `experimental` Cargo feature. This
+  includes:
+  * Nexus operation caller and workflow interceptor APIs, including `NexusOperationOptions`,
+    `NexusOperationCancellationType`, `StartedNexusOperation`, the workflow-context start methods,
+    and the `WorkflowInterceptor::start_nexus_operation` hook and input/result types.
+  * Eager Workflow Start via `WorkflowStartOptions::enable_eager_workflow_start`.
+  * Worker deployment versioning APIs: `ContinueAsNewVersioningBehavior`,
+    `ContinueAsNewOptions::initial_versioning_behavior`,
+    `WorkflowContext::target_worker_deployment_version_changed`, and
+    `SyncWorkflowContext::target_worker_deployment_version_changed`.
+  * Client, worker, and workflow replayer plugin APIs.
+  * Client payload warning thresholds (`PayloadLimitsOptions` and
+    `ConnectionOptions::payload_limits`) and `WorkerOptions::disable_payload_error_limit`.
+  * Patch activation callback types and the corresponding worker and workflow replayer options.
+  * Worker lifecycle interception APIs (`WorkerInterceptor`, its input types and registration
+    methods, and `ReturnWorkflowExitValueInterceptor`).
+  * Event Group marker fields on activity, local activity, child workflow, timer, and external
+    signal options.
 * The following types are now non-exhaustive: `Priority`, `WorkerDeploymentVersion`,
   `WorkerCallbacks`, `WorkflowExecutionInfo`, `ActivityCloseTimeouts`,
   `ActivityExecutionDecodeHint`, child-workflow and signal decode hints,

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Core SDK that can be used as a base for other Temporal SDKs. It is currently use
 
 # Documentation
 
-Rust & Core SDK documentation can be generated with `cargo doc`, output will be placed in the
-`target/doc` directory.
+Rust & Core SDK documentation can be generated with `cargo doc --workspace --all-features`, output
+will be placed in the `target/doc` directory.
 
 [Architecture](ARCHITECTURE.md) doc provides some high-level information about how Core SDK works
 and how language layers interact with it.
@@ -59,7 +59,7 @@ All the following commands are enforced for each pull request:
 
 You can build and test the project using cargo:
 `cargo build`
-`cargo test`
+`cargo test --features experimental`
 
 Run integ tests with `cargo integ-test`. By default it will start an ephemeral server. You can also
 use an already-running server by passing `-s external`.
@@ -79,7 +79,7 @@ cargo integ-test -s envconfig -- \
 `TEMPORAL_CONFIG_FILE` and `TEMPORAL_PROFILE` can select a TOML profile instead. The harness does
 not start, configure, or clean up the target server or namespace in this mode.
 
-Run load tests with `cargo test --test heavy_tests`.
+Run load tests with `cargo test --features experimental --test heavy_tests`.
 
 NOTE: Integration tests should pass locally, if running on MacOS and you see integration tests consistently failing
 with an error that mentions `Too many open files`, this is likely due to `ulimit -n` being too low. You can raise

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Core SDK that can be used as a base for other Temporal SDKs. It is currently use
 
 # Documentation
 
-Rust & Core SDK documentation can be generated with `cargo doc`, output will be placed in the
-`target/doc` directory.
+Rust & Core SDK documentation can be generated with `cargo doc --workspace --all-features`, output
+will be placed in the `target/doc` directory.
 
 [Architecture](ARCHITECTURE.md) doc provides some high-level information about how Core SDK works
 and how language layers interact with it.
@@ -59,12 +59,12 @@ All the following commands are enforced for each pull request:
 
 You can build and test the project using cargo:
 `cargo build`
-`cargo test`
+`cargo test --features experimental`
 
 Run integ tests with `cargo integ-test`. By default it will start an ephemeral server. You can also
 use an already-running server by passing `-s external`.
 
-Run load tests with `cargo test --test heavy_tests`.
+Run load tests with `cargo test --features experimental --test heavy_tests`.
 
 NOTE: Integration tests should pass locally, if running on MacOS and you see integration tests consistently failing
 with an error that mentions `Too many open files`, this is likely due to `ulimit -n` being too low. You can raise

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -11,8 +11,12 @@ keywords = ["temporal", "workflow"]
 categories = ["development-tools"]
 readme = "README.md"
 
+[package.metadata.docs.rs]
+features = ["experimental"]
+
 [features]
 default = ["envconfig", "tls-ring"]
+experimental = []
 tls-ring = ["tonic/tls-ring"]
 tls-aws-lc = ["tonic/tls-aws-lc"]
 telemetry = ["dep:opentelemetry"]

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -165,11 +165,7 @@ while let Some(result) = stream.next().await {
 ## Experimental APIs
 
 APIs that are still under development require the `experimental` Cargo feature and may change or
-be removed before stabilization:
-
-```toml
-temporalio-client = { version = "0.7", features = ["experimental"] }
-```
+be removed before stabilization.
 
 ## Raw gRPC Access
 

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -162,6 +162,15 @@ while let Some(result) = stream.next().await {
 }
 ```
 
+## Experimental APIs
+
+APIs that are still under development require the `experimental` Cargo feature and may change or
+be removed before stabilization:
+
+```toml
+temporalio-client = { version = "0.7", features = ["experimental"] }
+```
+
 ## Raw gRPC Access
 
 For operations not covered by the high-level API, access the underlying gRPC service clients

--- a/crates/client/src/errors.rs
+++ b/crates/client/src/errors.rs
@@ -28,7 +28,6 @@ use tonic::Code;
 pub enum ClientConnectError {
     /// A plugin failed while configuring connection options.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[error(transparent)]
     Plugin(#[from] PluginApplyError),
     /// Invalid URI. Configuration error, fatal.
@@ -431,7 +430,6 @@ impl AsyncActivityError {
 pub enum ClientNewError {
     /// A plugin failed while configuring client options.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[error(transparent)]
     Plugin(#[from] PluginApplyError),
 }

--- a/crates/client/src/errors.rs
+++ b/crates/client/src/errors.rs
@@ -1,6 +1,8 @@
 //! Contains errors that can be returned by clients.
 
-use crate::{PluginApplyError, WorkflowExecutionStatus, workflow_handle::WorkflowResultDetails};
+#[cfg(feature = "experimental")]
+use crate::PluginApplyError;
+use crate::{WorkflowExecutionStatus, workflow_handle::WorkflowResultDetails};
 use http::uri::InvalidUri;
 use temporalio_common::{
     data_converters::{DecodablePayloads, PayloadConversionError},
@@ -25,6 +27,8 @@ use tonic::Code;
 #[non_exhaustive]
 pub enum ClientConnectError {
     /// A plugin failed while configuring connection options.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[error(transparent)]
     Plugin(#[from] PluginApplyError),
     /// Invalid URI. Configuration error, fatal.
@@ -57,6 +61,7 @@ pub enum ClientConnectError {
 impl From<ClientNewError> for ClientConnectError {
     fn from(value: ClientNewError) -> Self {
         match value {
+            #[cfg(feature = "experimental")]
             ClientNewError::Plugin(err) => Self::Plugin(err),
         }
     }
@@ -425,6 +430,8 @@ impl AsyncActivityError {
 #[non_exhaustive]
 pub enum ClientNewError {
     /// A plugin failed while configuring client options.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[error(transparent)]
     Plugin(#[from] PluginApplyError),
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1194,6 +1194,10 @@ where
             res.run_id
         } else {
             // Normal start workflow
+            #[cfg(feature = "experimental")]
+            let request_eager_execution = options.enable_eager_workflow_start;
+            #[cfg(not(feature = "experimental"))]
+            let request_eager_execution = false;
             let res = self
                 .clone()
                 .start_workflow_execution(
@@ -1219,7 +1223,7 @@ where
                         workflow_task_timeout: options.task_timeout.and_then(|d| d.try_into().ok()),
                         search_attributes: options.search_attributes.map(|t| t.into_proto()),
                         cron_schedule: options.cron_schedule.unwrap_or_default(),
-                        request_eager_execution: options.enable_eager_workflow_start,
+                        request_eager_execution,
                         retry_policy: options.retry_policy,
                         links: options.links,
                         completion_callbacks: options.completion_callbacks,

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -22,7 +22,6 @@ pub mod interceptors;
 mod metrics;
 mod options_structs;
 #[cfg(feature = "experimental")]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 /// Experimental APIs for configuring clients with reusable plugins.
 pub mod plugins;
 /// Visible only for tests
@@ -69,7 +68,6 @@ pub use interceptors::{
 pub use metrics::{LONG_REQUEST_LATENCY_HISTOGRAM_NAME, REQUEST_LATENCY_HISTOGRAM_NAME};
 pub use options_structs::*;
 #[cfg(feature = "experimental")]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub use plugins::{
     ClientPlugin, ErasedClientPlugin, PluginApplyError, PluginError, PluginTarget, WorkerPluginData,
 };

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -440,11 +440,11 @@ impl Connection {
         #[cfg(feature = "experimental")]
         let payloads_warn_size = options.payload_limits.payloads_warn_size;
         #[cfg(not(feature = "experimental"))]
-        let payloads_warn_size = 512 * 1024;
+        let payloads_warn_size = options_structs::DEFAULT_PAYLOADS_WARN_SIZE;
         #[cfg(feature = "experimental")]
         let memo_warn_size = options.payload_limits.memo_warn_size;
         #[cfg(not(feature = "experimental"))]
-        let memo_warn_size = 2 * 1024;
+        let memo_warn_size = options_structs::DEFAULT_MEMO_WARN_SIZE;
         Ok(Self {
             inner: Arc::new(ConnectionInner {
                 service: svc_client,
@@ -1824,10 +1824,7 @@ fn build_start_workflow_request(
     options: WorkflowStartOptions,
 ) -> StartWorkflowExecutionRequest {
     let user_metadata = options.user_metadata();
-    #[cfg(feature = "experimental")]
     let request_eager_execution = options.enable_eager_workflow_start;
-    #[cfg(not(feature = "experimental"))]
-    let request_eager_execution = false;
     StartWorkflowExecutionRequest {
         namespace: client.namespace(),
         input,

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)] // error if there are missing docs
 
 //! This crate contains client implementations that can be used to contact the Temporal service.
@@ -20,6 +21,8 @@ pub mod grpc;
 pub mod interceptors;
 mod metrics;
 mod options_structs;
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 /// Experimental APIs for configuring clients with reusable plugins.
 pub mod plugins;
 /// Visible only for tests
@@ -65,6 +68,8 @@ pub use interceptors::{
 };
 pub use metrics::{LONG_REQUEST_LATENCY_HISTOGRAM_NAME, REQUEST_LATENCY_HISTOGRAM_NAME};
 pub use options_structs::*;
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub use plugins::{
     ClientPlugin, ErasedClientPlugin, PluginApplyError, PluginError, PluginTarget, WorkerPluginData,
 };
@@ -432,6 +437,14 @@ impl Connection {
         } else {
             None
         };
+        #[cfg(feature = "experimental")]
+        let payloads_warn_size = options.payload_limits.payloads_warn_size;
+        #[cfg(not(feature = "experimental"))]
+        let payloads_warn_size = 512 * 1024;
+        #[cfg(feature = "experimental")]
+        let memo_warn_size = options.payload_limits.memo_warn_size;
+        #[cfg(not(feature = "experimental"))]
+        let memo_warn_size = 2 * 1024;
         Ok(Self {
             inner: Arc::new(ConnectionInner {
                 service: svc_client,
@@ -445,12 +458,9 @@ impl Connection {
                 _dns_task: dns_task,
                 payloads_warn_size: resolve_warn_threshold(
                     "payloads_warn_size",
-                    options.payload_limits.payloads_warn_size,
+                    payloads_warn_size,
                 ),
-                memo_warn_size: resolve_warn_threshold(
-                    "memo_warn_size",
-                    options.payload_limits.memo_warn_size,
-                ),
+                memo_warn_size: resolve_warn_threshold("memo_warn_size", memo_warn_size),
             }),
         })
     }
@@ -1097,9 +1107,12 @@ impl Client {
     /// Connect to a Temporal service and create a namespace-bound client, applying registered
     /// plugins to connection and client options in registration order.
     pub async fn connect(
-        mut connection_options: ConnectionOptions,
+        connection_options: ConnectionOptions,
         client_options: ClientOptions,
     ) -> Result<Self, ClientConnectError> {
+        #[cfg(feature = "experimental")]
+        let mut connection_options = connection_options;
+        #[cfg(feature = "experimental")]
         plugins::apply_connection_plugins(&client_options, &mut connection_options)?;
         let connection = Connection::connect(connection_options).await?;
         Ok(Self::new(connection, client_options)?)
@@ -1109,7 +1122,10 @@ impl Client {
     ///
     /// Registered client plugins are applied here. Connection plugin hooks only run when using
     /// [`Client::connect`].
-    pub fn new(connection: Connection, mut options: ClientOptions) -> Result<Self, ClientNewError> {
+    pub fn new(connection: Connection, options: ClientOptions) -> Result<Self, ClientNewError> {
+        #[cfg(feature = "experimental")]
+        let mut options = options;
+        #[cfg(feature = "experimental")]
         plugins::apply_client_plugins(&mut options)?;
         Ok(Client {
             connection,

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1808,6 +1808,10 @@ fn build_start_workflow_request(
     options: WorkflowStartOptions,
 ) -> StartWorkflowExecutionRequest {
     let user_metadata = options.user_metadata();
+    #[cfg(feature = "experimental")]
+    let request_eager_execution = options.enable_eager_workflow_start;
+    #[cfg(not(feature = "experimental"))]
+    let request_eager_execution = false;
     StartWorkflowExecutionRequest {
         namespace: client.namespace(),
         input,
@@ -1837,7 +1841,7 @@ fn build_start_workflow_request(
             .search_attributes
             .map(|attributes| attributes.into_proto()),
         cron_schedule: options.cron_schedule.unwrap_or_default(),
-        request_eager_execution: options.enable_eager_workflow_start,
+        request_eager_execution,
         retry_policy: options.retry_policy.map(Into::into),
         links: options.links,
         completion_callbacks: options.completion_callbacks,

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -292,6 +292,7 @@ pub struct WorkflowStartOptions {
 
     /// Optionally enable Eager Workflow Start, a latency optimization using local workers
     /// NOTE: Experimental
+    #[cfg(feature = "experimental")]
     #[builder(default)]
     pub enable_eager_workflow_start: bool,
 

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -111,7 +111,6 @@ pub struct ConnectionOptions {
     /// disable an individual warning by setting its threshold to `0`.
     /// NOTE: Experimental
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[cfg_attr(
         docsrs,
         builder(setters(
@@ -224,7 +223,6 @@ impl<S: client_options_builder::State> ClientOptionsBuilder<S> {
     /// Register a type-erased client plugin.
     ///
     /// **Experimental:** This API may change or be removed.
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn plugin<P: Into<ErasedClientPlugin>>(mut self, plugin: P) -> Self {
         self.plugins.push(plugin.into());
         self
@@ -233,7 +231,6 @@ impl<S: client_options_builder::State> ClientOptionsBuilder<S> {
     /// Register type-erased client plugins in iteration order.
     ///
     /// **Experimental:** This API may change or be removed.
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn plugins<I, P>(mut self, plugins: I) -> Self
     where
         I: IntoIterator<Item = P>,
@@ -246,7 +243,6 @@ impl<S: client_options_builder::State> ClientOptionsBuilder<S> {
     /// Register a client-only plugin.
     ///
     /// **Experimental:** This API may change or be removed.
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn client_plugin<P: ClientPlugin>(mut self, plugin: P) -> Self {
         self.plugins.push(ErasedClientPlugin::new(plugin));
         self
@@ -260,7 +256,6 @@ impl ClientOptions {
     ///
     /// **Experimental:** This API may change or be removed.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn plugins(&self) -> &[ErasedClientPlugin] {
         &self.plugins
     }
@@ -406,7 +401,6 @@ impl Default for DnsLoadBalancingOptions {
 /// Payload size limit options for a connection.
 /// NOTE: Experimental
 #[cfg(feature = "experimental")]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Clone, Debug, PartialEq, bon::Builder)]
 #[non_exhaustive]
 pub struct PayloadLimitsOptions {

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -419,6 +419,7 @@ pub struct WorkflowStartOptions {
 
     /// Optionally enable Eager Workflow Start, a latency optimization using local workers
     /// NOTE: Experimental
+    #[cfg(feature = "experimental")]
     #[builder(default)]
     pub enable_eager_workflow_start: bool,
 
@@ -619,6 +620,7 @@ impl WorkflowUpdateWithStartOptions {
                 task_timeout,
                 cron_schedule: None,
                 search_attributes,
+                #[cfg(feature = "experimental")]
                 enable_eager_workflow_start: false,
                 retry_policy,
                 links,

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -35,6 +35,9 @@ use tokio_rustls::rustls::client::ResolvesClientCert;
 use tokio_rustls::rustls::client::danger::ServerCertVerifier;
 use url::Url;
 
+pub(crate) const DEFAULT_PAYLOADS_WARN_SIZE: u64 = 512 * 1024;
+pub(crate) const DEFAULT_MEMO_WARN_SIZE: u64 = 2 * 1024;
+
 /// Options for [crate::Connection::connect].
 #[derive(bon::Builder, Clone, Debug)]
 #[non_exhaustive]
@@ -112,8 +115,8 @@ pub struct ConnectionOptions {
     #[cfg_attr(
         docsrs,
         builder(setters(
-            some_fn(name = __payload_limits, vis = "pub(crate)"),
-            option_fn(name = __maybe_payload_limits, vis = "pub(crate)")
+            some_fn(name = payload_limits_impl, vis = "pub(crate)"),
+            option_fn(name = maybe_payload_limits_impl, vis = "pub(crate)")
         ))
     )]
     #[builder(default)]
@@ -138,6 +141,8 @@ pub struct ConnectionOptions {
     pub(crate) client_version: String,
 }
 
+// Bon does not propagate `doc(cfg)` to generated setters, so these docs-only methods forward to
+// renamed generated implementations.
 #[cfg(all(feature = "experimental", docsrs))]
 impl<S: connection_options_builder::State> ConnectionOptionsBuilder<S> {
     /// Set the payload size limit options for this connection.
@@ -149,7 +154,7 @@ impl<S: connection_options_builder::State> ConnectionOptionsBuilder<S> {
     where
         S::PayloadLimits: connection_options_builder::IsUnset,
     {
-        self.__payload_limits(value)
+        self.payload_limits_impl(value)
     }
 
     /// Set the payload size limit options for this connection from an optional value.
@@ -161,7 +166,7 @@ impl<S: connection_options_builder::State> ConnectionOptionsBuilder<S> {
     where
         S::PayloadLimits: connection_options_builder::IsUnset,
     {
-        self.__maybe_payload_limits(value)
+        self.maybe_payload_limits_impl(value)
     }
 }
 
@@ -407,11 +412,11 @@ impl Default for DnsLoadBalancingOptions {
 pub struct PayloadLimitsOptions {
     /// Warning threshold (bytes) for the size of an outbound payload-bearing field; over-threshold
     /// fields are logged but still sent to server. Defaults to 512 KiB. Set to `0` to disable.
-    #[builder(default = 512 * 1024)]
+    #[builder(default = DEFAULT_PAYLOADS_WARN_SIZE)]
     pub payloads_warn_size: u64,
     /// Warning threshold (bytes) for outbound memo sizes; over-threshold memos are logged but still
     /// sent to server. Defaults to 2 KiB. Set to `0` to disable.
-    #[builder(default = 2 * 1024)]
+    #[builder(default = DEFAULT_MEMO_WARN_SIZE)]
     pub memo_warn_size: u64,
 }
 
@@ -467,17 +472,7 @@ pub struct WorkflowStartOptions {
     /// Additional search attributes for the workflow.
     pub search_attributes: Option<SearchAttributes>,
 
-    /// Optionally enable Eager Workflow Start, a latency optimization using local workers
-    /// NOTE: Experimental
-    #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
-    #[cfg_attr(
-        docsrs,
-        builder(setters(
-            some_fn(name = __enable_eager_workflow_start, vis = "pub(crate)"),
-            option_fn(name = __maybe_enable_eager_workflow_start, vis = "pub(crate)")
-        ))
-    )]
+    /// Optionally enable Eager Workflow Start, a latency optimization using local workers.
     #[builder(default)]
     pub enable_eager_workflow_start: bool,
 
@@ -513,33 +508,6 @@ pub struct WorkflowStartOptions {
     /// Controls for the RPC used to start the workflow.
     #[builder(default)]
     pub rpc_options: RpcOptions,
-}
-
-#[cfg(all(feature = "experimental", docsrs))]
-impl<S: workflow_start_options_builder::State> WorkflowStartOptionsBuilder<S> {
-    /// Enable eager workflow start.
-    #[doc(cfg(feature = "experimental"))]
-    pub fn enable_eager_workflow_start(
-        self,
-        value: bool,
-    ) -> WorkflowStartOptionsBuilder<workflow_start_options_builder::SetEnableEagerWorkflowStart<S>>
-    where
-        S::EnableEagerWorkflowStart: workflow_start_options_builder::IsUnset,
-    {
-        self.__enable_eager_workflow_start(value)
-    }
-
-    /// Set eager workflow start from an optional value.
-    #[doc(cfg(feature = "experimental"))]
-    pub fn maybe_enable_eager_workflow_start(
-        self,
-        value: Option<bool>,
-    ) -> WorkflowStartOptionsBuilder<workflow_start_options_builder::SetEnableEagerWorkflowStart<S>>
-    where
-        S::EnableEagerWorkflowStart: workflow_start_options_builder::IsUnset,
-    {
-        self.__maybe_enable_eager_workflow_start(value)
-    }
 }
 
 impl WorkflowStartOptions {
@@ -705,7 +673,6 @@ impl WorkflowUpdateWithStartOptions {
                 task_timeout,
                 cron_schedule: None,
                 search_attributes,
-                #[cfg(feature = "experimental")]
                 enable_eager_workflow_start: false,
                 retry_policy,
                 links,

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -1,7 +1,8 @@
 use crate::{
-    ClientInterceptor, ClientPlugin, ErasedClientPlugin, HttpConnectProxyOptions, RetryOptions,
-    RpcOptions, VERSION, callback_based,
+    ClientInterceptor, HttpConnectProxyOptions, RetryOptions, RpcOptions, VERSION, callback_based,
 };
+#[cfg(feature = "experimental")]
+use crate::{ClientPlugin, ErasedClientPlugin};
 use http::Uri;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use temporalio_common::{
@@ -106,6 +107,15 @@ pub struct ConnectionOptions {
     /// Payload size limit options for this connection. Defaults to the standard warning thresholds;
     /// disable an individual warning by setting its threshold to `0`.
     /// NOTE: Experimental
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+    #[cfg_attr(
+        docsrs,
+        builder(setters(
+            some_fn(name = __payload_limits, vis = "pub(crate)"),
+            option_fn(name = __maybe_payload_limits, vis = "pub(crate)")
+        ))
+    )]
     #[builder(default)]
     pub payload_limits: PayloadLimitsOptions,
 
@@ -126,6 +136,33 @@ pub struct ConnectionOptions {
     #[builder(default = VERSION.to_owned())]
     #[cfg_attr(feature = "core-based-sdk", builder(setters(vis = "pub")))]
     pub(crate) client_version: String,
+}
+
+#[cfg(all(feature = "experimental", docsrs))]
+impl<S: connection_options_builder::State> ConnectionOptionsBuilder<S> {
+    /// Set the payload size limit options for this connection.
+    #[doc(cfg(feature = "experimental"))]
+    pub fn payload_limits(
+        self,
+        value: PayloadLimitsOptions,
+    ) -> ConnectionOptionsBuilder<connection_options_builder::SetPayloadLimits<S>>
+    where
+        S::PayloadLimits: connection_options_builder::IsUnset,
+    {
+        self.__payload_limits(value)
+    }
+
+    /// Set the payload size limit options for this connection from an optional value.
+    #[doc(cfg(feature = "experimental"))]
+    pub fn maybe_payload_limits(
+        self,
+        value: Option<PayloadLimitsOptions>,
+    ) -> ConnectionOptionsBuilder<connection_options_builder::SetPayloadLimits<S>>
+    where
+        S::PayloadLimits: connection_options_builder::IsUnset,
+    {
+        self.__maybe_payload_limits(value)
+    }
 }
 
 // Setters/getters for fields that should only be touched by SDK implementers.
@@ -160,10 +197,12 @@ pub struct ClientOptions {
 
     #[builder(field)]
     #[debug(skip)]
+    #[cfg(feature = "experimental")]
     plugins: Vec<ErasedClientPlugin>,
 
     #[builder(field)]
     #[debug(skip)]
+    #[cfg(feature = "experimental")]
     client_plugins_applied: bool,
 
     /// The data converter used for serializing/deserializing payloads.
@@ -175,10 +214,12 @@ pub struct ClientOptions {
     pub client_interceptors: Vec<Arc<dyn ClientInterceptor>>,
 }
 
+#[cfg(feature = "experimental")]
 impl<S: client_options_builder::State> ClientOptionsBuilder<S> {
     /// Register a type-erased client plugin.
     ///
     /// **Experimental:** This API may change or be removed.
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn plugin<P: Into<ErasedClientPlugin>>(mut self, plugin: P) -> Self {
         self.plugins.push(plugin.into());
         self
@@ -187,6 +228,7 @@ impl<S: client_options_builder::State> ClientOptionsBuilder<S> {
     /// Register type-erased client plugins in iteration order.
     ///
     /// **Experimental:** This API may change or be removed.
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn plugins<I, P>(mut self, plugins: I) -> Self
     where
         I: IntoIterator<Item = P>,
@@ -199,6 +241,7 @@ impl<S: client_options_builder::State> ClientOptionsBuilder<S> {
     /// Register a client-only plugin.
     ///
     /// **Experimental:** This API may change or be removed.
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn client_plugin<P: ClientPlugin>(mut self, plugin: P) -> Self {
         self.plugins.push(ErasedClientPlugin::new(plugin));
         self
@@ -211,14 +254,18 @@ impl ClientOptions {
     /// This is intended for SDK integrations that propagate worker plugin registrations.
     ///
     /// **Experimental:** This API may change or be removed.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn plugins(&self) -> &[ErasedClientPlugin] {
         &self.plugins
     }
 
+    #[cfg(feature = "experimental")]
     pub(crate) fn client_plugins_applied(&self) -> bool {
         self.client_plugins_applied
     }
 
+    #[cfg(feature = "experimental")]
     pub(crate) fn mark_client_plugins_applied(&mut self) {
         self.client_plugins_applied = true;
     }
@@ -353,6 +400,8 @@ impl Default for DnsLoadBalancingOptions {
 
 /// Payload size limit options for a connection.
 /// NOTE: Experimental
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Clone, Debug, PartialEq, bon::Builder)]
 #[non_exhaustive]
 pub struct PayloadLimitsOptions {
@@ -366,6 +415,7 @@ pub struct PayloadLimitsOptions {
     pub memo_warn_size: u64,
 }
 
+#[cfg(feature = "experimental")]
 impl Default for PayloadLimitsOptions {
     fn default() -> Self {
         Self::builder().build()
@@ -420,6 +470,14 @@ pub struct WorkflowStartOptions {
     /// Optionally enable Eager Workflow Start, a latency optimization using local workers
     /// NOTE: Experimental
     #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+    #[cfg_attr(
+        docsrs,
+        builder(setters(
+            some_fn(name = __enable_eager_workflow_start, vis = "pub(crate)"),
+            option_fn(name = __maybe_enable_eager_workflow_start, vis = "pub(crate)")
+        ))
+    )]
     #[builder(default)]
     pub enable_eager_workflow_start: bool,
 
@@ -455,6 +513,33 @@ pub struct WorkflowStartOptions {
     /// Controls for the RPC used to start the workflow.
     #[builder(default)]
     pub rpc_options: RpcOptions,
+}
+
+#[cfg(all(feature = "experimental", docsrs))]
+impl<S: workflow_start_options_builder::State> WorkflowStartOptionsBuilder<S> {
+    /// Enable eager workflow start.
+    #[doc(cfg(feature = "experimental"))]
+    pub fn enable_eager_workflow_start(
+        self,
+        value: bool,
+    ) -> WorkflowStartOptionsBuilder<workflow_start_options_builder::SetEnableEagerWorkflowStart<S>>
+    where
+        S::EnableEagerWorkflowStart: workflow_start_options_builder::IsUnset,
+    {
+        self.__enable_eager_workflow_start(value)
+    }
+
+    /// Set eager workflow start from an optional value.
+    #[doc(cfg(feature = "experimental"))]
+    pub fn maybe_enable_eager_workflow_start(
+        self,
+        value: Option<bool>,
+    ) -> WorkflowStartOptionsBuilder<workflow_start_options_builder::SetEnableEagerWorkflowStart<S>>
+    where
+        S::EnableEagerWorkflowStart: workflow_start_options_builder::IsUnset,
+    {
+        self.__maybe_enable_eager_workflow_start(value)
+    }
 }
 
 impl WorkflowStartOptions {

--- a/crates/client/src/plugins.rs
+++ b/crates/client/src/plugins.rs
@@ -4,7 +4,6 @@ use crate::{ClientOptions, ConnectionOptions};
 use std::{any::Any, error::Error, sync::Arc};
 
 /// An error returned by a plugin configuration hook.
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
 pub struct PluginError(Box<dyn Error + Send + Sync>);
@@ -17,7 +16,6 @@ impl PluginError {
 }
 
 /// The configuration target being modified when a plugin failed.
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, derive_more::Display)]
 #[non_exhaustive]
 pub enum PluginTarget {
@@ -36,7 +34,6 @@ pub enum PluginTarget {
 }
 
 /// An error applying a named plugin to a configuration target.
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Debug, thiserror::Error)]
 #[error("plugin '{plugin_name}' failed to configure {target}: {source}")]
 #[non_exhaustive]
@@ -67,7 +64,6 @@ impl PluginApplyError {
 /// Configures connection and namespace-bound client options.
 ///
 /// **Experimental:** This API may change or be removed.
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub trait ClientPlugin: Send + Sync + 'static {
     /// Return the stable, unique name used to identify this plugin in diagnostics and worker
     /// heartbeats.
@@ -91,7 +87,6 @@ pub trait ClientPlugin: Send + Sync + 'static {
 ///
 /// Implementing this trait will not make a type recognized as plugin. Only SDK known
 /// `WorkerPluginExtension` implementers will be used as plugins.
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub trait WorkerPluginData: Any + Send + Sync + 'static {}
 
 /// A type-erased client plugin and worker-plugin propagation data.
@@ -99,7 +94,6 @@ pub trait WorkerPluginData: Any + Send + Sync + 'static {}
 /// The worker data is intentionally opaque to avoid taking a dependency on `temporalio-sdk`.
 ///
 /// **Experimental:** This API may change or be removed.
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Clone)]
 pub struct ErasedClientPlugin {
     client: Arc<dyn ClientPlugin>,

--- a/crates/client/src/plugins.rs
+++ b/crates/client/src/plugins.rs
@@ -4,6 +4,7 @@ use crate::{ClientOptions, ConnectionOptions};
 use std::{any::Any, error::Error, sync::Arc};
 
 /// An error returned by a plugin configuration hook.
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
 pub struct PluginError(Box<dyn Error + Send + Sync>);
@@ -16,6 +17,7 @@ impl PluginError {
 }
 
 /// The configuration target being modified when a plugin failed.
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, derive_more::Display)]
 #[non_exhaustive]
 pub enum PluginTarget {
@@ -34,6 +36,7 @@ pub enum PluginTarget {
 }
 
 /// An error applying a named plugin to a configuration target.
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Debug, thiserror::Error)]
 #[error("plugin '{plugin_name}' failed to configure {target}: {source}")]
 #[non_exhaustive]
@@ -64,6 +67,7 @@ impl PluginApplyError {
 /// Configures connection and namespace-bound client options.
 ///
 /// **Experimental:** This API may change or be removed.
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub trait ClientPlugin: Send + Sync + 'static {
     /// Return the stable, unique name used to identify this plugin in diagnostics and worker
     /// heartbeats.
@@ -87,6 +91,7 @@ pub trait ClientPlugin: Send + Sync + 'static {
 ///
 /// Implementing this trait will not make a type recognized as plugin. Only SDK known
 /// `WorkerPluginExtension` implementers will be used as plugins.
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub trait WorkerPluginData: Any + Send + Sync + 'static {}
 
 /// A type-erased client plugin and worker-plugin propagation data.
@@ -94,6 +99,7 @@ pub trait WorkerPluginData: Any + Send + Sync + 'static {}
 /// The worker data is intentionally opaque to avoid taking a dependency on `temporalio-sdk`.
 ///
 /// **Experimental:** This API may change or be removed.
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Clone)]
 pub struct ErasedClientPlugin {
     client: Arc<dyn ClientPlugin>,
@@ -174,7 +180,7 @@ pub(crate) fn apply_client_plugins(options: &mut ClientOptions) -> Result<(), Pl
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "experimental"))]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/sdk-core-c-bridge/Cargo.toml
+++ b/crates/sdk-core-c-bridge/Cargo.toml
@@ -42,6 +42,7 @@ xz2 = { version = "0.1", optional = true }
 [dependencies.temporalio-client]
 path = "../client"
 version = "~0.7.0"
+features = ["experimental"]
 
 [dependencies.temporalio-sdk-core]
 path = "../sdk-core"

--- a/crates/sdk-core/Cargo.toml
+++ b/crates/sdk-core/Cargo.toml
@@ -164,9 +164,15 @@ hyper-util = { version = "0.1", features = [
 rstest = "0.26"
 semver = "1.0"
 # A registry version here creates a cycle when Cargo orders sdk-core before sdk for workspace publishing.
-temporalio-sdk = { path = "../sdk", features = ["testing", "wasm-workflows"] }
+temporalio-sdk = { path = "../sdk", features = [
+  "experimental",
+  "testing",
+  "wasm-workflows",
+] }
 temporalio-common = { path = "../common", version = "~0.7.0", default-features = false }
-temporalio-workflow = { path = "../workflow", version = "~0.7.0" }
+temporalio-workflow = { path = "../workflow", version = "~0.7.0", features = [
+  "experimental",
+] }
 tokio = { version = "1.47", default-features = false, features = [
   "rt",
   "rt-multi-thread",

--- a/crates/sdk-core/Cargo.toml
+++ b/crates/sdk-core/Cargo.toml
@@ -162,9 +162,9 @@ hyper-util = { version = "0.1", features = [
 ] }
 rstest = "0.26"
 semver = "1.0"
-temporalio-sdk = { path = "../sdk", features = ["wasm-workflows"] }
+temporalio-sdk = { path = "../sdk", features = ["experimental", "wasm-workflows"] }
 temporalio-common = { path = "../common", version = "0.5", default-features = false }
-temporalio-workflow = { path = "../workflow" }
+temporalio-workflow = { path = "../workflow", features = ["experimental"] }
 tokio = { version = "1.47", default-features = false, features = [
   "rt",
   "rt-multi-thread",

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -12,6 +12,9 @@ categories = ["development-tools"]
 readme = "README.md"
 autoexamples = false
 
+[package.metadata.docs.rs]
+features = ["experimental"]
+
 [dependencies]
 async-trait = "0.1"
 anyhow = "1.0"
@@ -71,6 +74,7 @@ rstest = "0.26"
 [features]
 default = ["envconfig", "prometheus"]
 envconfig = ["temporalio-sdk-core/envconfig"]
+experimental = ["temporalio-client/experimental", "temporalio-workflow/experimental"]
 prometheus = ["temporalio-sdk-core/prometheus"]
 otel = ["temporalio-sdk-core/otel"]
 examples = ["serde/derive", "dep:serde_json", "envconfig"]

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -12,6 +12,9 @@ categories = ["development-tools"]
 readme = "README.md"
 autoexamples = false
 
+[package.metadata.docs.rs]
+features = ["experimental"]
+
 [dependencies]
 async-trait = "0.1"
 anyhow = "1.0"
@@ -70,6 +73,7 @@ rstest = "0.26"
 [features]
 default = ["envconfig", "prometheus"]
 envconfig = ["temporalio-sdk-core/envconfig"]
+experimental = ["temporalio-client/experimental", "temporalio-workflow/experimental"]
 prometheus = ["temporalio-sdk-core/prometheus"]
 otel = ["temporalio-sdk-core/otel"]
 examples = ["serde/derive", "dep:serde_json", "envconfig"]

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -133,17 +133,16 @@ env.shutdown().await?;
 
 ## Crate Features
 
+The SDK enables a few convenience integrations by default. Users who want a smaller dependency
+graph can disable defaults and opt back into the integrations they use.
 
-| Feature | What it enables |
-| --- | --- |
-| `envconfig` | Support for loading connection settings from environment variables and `temporal.toml` files. |
-| `prometheus` | The Prometheus metrics exporter for `temporalio_common::telemetry`. |
-| `otel` | The OpenTelemetry metrics exporter for `temporalio_common::telemetry`. |
-| `experimental` | Rust SDK, client, and Workflow APIs that are still under development and may change or be removed. |
-| `testing` | The `testing` module, direct activity test support, and local Temporal CLI dev-server lifecycle management. |
-| `dynamic-tls` | Dynamic mTLS client-certificate resolution for transparent certificate rotation. |
-| `wasm-workflows` | Support WebAssembly workflow components through Wasmtime for workers and workflow replay. |
-
+- `envconfig`: Support for loading connection settings from environment variables and `temporal.toml` files. |
+- `prometheus`: The Prometheus metrics exporter for `temporalio_common::telemetry`. |
+- `otel`: The OpenTelemetry metrics exporter for `temporalio_common::telemetry`. |
+- `experimental`: Rust SDK, client, and Workflow APIs that are still under development and may change or be removed. |
+- `testing`: The `testing` module, direct activity test support, and local Temporal CLI dev-server lifecycle management. |
+- `dynamic-tls`: Dynamic mTLS client-certificate resolution for transparent certificate rotation. |
+- `wasm-workflows`: Support WebAssembly workflow components through Wasmtime for workers and workflow replay. |
 
 ## Workflows in detail
 

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -108,11 +108,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Testing
 
 Enable the `testing` feature to run activities directly or start an isolated Temporal CLI dev
-server for workflow tests:
-
-```toml
-temporalio-sdk = { version = "0.6", features = ["testing"] }
-```
+server for workflow tests.
 
 Activity test inputs and outputs are ordinary Rust values. Register an activity implementer when
 testing an instance activity:
@@ -137,21 +133,17 @@ env.shutdown().await?;
 
 ## Crate Features
 
-The SDK enables a few convenience integrations by default. Users who want a smaller dependency
-graph can disable defaults and opt back into the integrations they use:
 
-```toml
-temporalio-sdk = { version = "0.3", default-features = false, features = ["envconfig"] }
-```
+| Feature | What it enables |
+| --- | --- |
+| `envconfig` | Support for loading connection settings from environment variables and `temporal.toml` files. |
+| `prometheus` | The Prometheus metrics exporter for `temporalio_common::telemetry`. |
+| `otel` | The OpenTelemetry metrics exporter for `temporalio_common::telemetry`. |
+| `experimental` | Rust SDK, client, and Workflow APIs that are still under development and may change or be removed. |
+| `testing` | The `testing` module, direct activity test support, and local Temporal CLI dev-server lifecycle management. |
+| `dynamic-tls` | Dynamic mTLS client-certificate resolution for transparent certificate rotation. |
+| `wasm-workflows` | Support WebAssembly workflow components through Wasmtime for workers and workflow replay. |
 
-- `envconfig` - enabled by default. Adds `ClientOptions::load_from_config` and related helpers for
-  loading connection settings from environment variables and `temporal.toml` files.
-- `prometheus` - enabled by default. Adds the Prometheus metrics exporter in
-  `temporalio_common::telemetry` for serving SDK metrics from a HTTP endpoint.
-- `otel` - optional. Adds the OpenTelemetry metrics exporter in `temporalio_common::telemetry` for
-  sending SDK metrics to an OpenTelemetry collector.
-- `testing` - optional. Adds activity and workflow test environments, including local Temporal CLI
-  dev-server lifecycle management.
 
 ## Workflows in detail
 

--- a/crates/sdk/src/activities.rs
+++ b/crates/sdk/src/activities.rs
@@ -551,6 +551,7 @@ pub struct ActivityDefinitions {
 }
 
 impl ActivityDefinitions {
+    #[cfg(feature = "experimental")]
     pub(crate) fn extend(&mut self, other: &Self) {
         self.activities.extend(other.activities.clone());
     }

--- a/crates/sdk/src/error.rs
+++ b/crates/sdk/src/error.rs
@@ -1,6 +1,7 @@
 //! Shared SDK error re-exports.
 
 pub use crate::workflow_registry::WorkflowRegistrationError;
+#[cfg(feature = "experimental")]
 use temporalio_client::PluginApplyError;
 pub use temporalio_sdk_core::WorkerValidationError;
 
@@ -11,6 +12,8 @@ pub use temporalio_sdk_core::WorkerValidationError;
 #[non_exhaustive]
 pub enum WorkerCreateError {
     /// A plugin failed while configuring worker options.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[error(transparent)]
     Plugin(#[from] PluginApplyError),
     /// Worker initialization failed after plugin configuration completed.

--- a/crates/sdk/src/error.rs
+++ b/crates/sdk/src/error.rs
@@ -13,7 +13,6 @@ pub use temporalio_sdk_core::WorkerValidationError;
 pub enum WorkerCreateError {
     /// A plugin failed while configuring worker options.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[error(transparent)]
     Plugin(#[from] PluginApplyError),
     /// Worker initialization failed after plugin configuration completed.

--- a/crates/sdk/src/interceptors.rs
+++ b/crates/sdk/src/interceptors.rs
@@ -70,7 +70,6 @@ mod worker_lifecycle {
     ///
     /// Advanced usage only.
     /// **Experimental:** This API may change or be removed.
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[async_trait::async_trait(?Send)]
     pub trait WorkerInterceptor: Send + Sync {
         /// Intercept the running of a worker.
@@ -115,7 +114,6 @@ mod worker_lifecycle {
     }
 
     /// Input to [`WorkerInterceptor::run_worker`].
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[derive(Debug)]
     #[non_exhaustive]
     pub struct RunWorkerInput<'a> {
@@ -130,7 +128,6 @@ mod worker_lifecycle {
     }
 
     /// Input to [`WorkerInterceptor::with_workflow_replay_worker`].
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[derive(Debug)]
     #[non_exhaustive]
     pub struct WithWorkflowReplayWorkerInput<'a> {
@@ -182,7 +179,6 @@ pub(crate) use worker_lifecycle::{
     RunWorkerInput, WithWorkflowReplayWorkerInput, WorkerInterceptor,
 };
 #[cfg(feature = "experimental")]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub use worker_lifecycle::{RunWorkerInput, WithWorkflowReplayWorkerInput, WorkerInterceptor};
 pub(crate) use worker_lifecycle::{call_run_worker, call_with_workflow_replay_worker};
 
@@ -281,7 +277,6 @@ pub trait ActivityInboundInterceptor: Send + Sync + 'static {
 
 /// An interceptor that allows you to fetch the exit value of the workflow if and when it is set
 #[cfg(feature = "experimental")]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Default)]
 pub struct ReturnWorkflowExitValueInterceptor {
     result_value: Arc<OnceLock<Payload>>,

--- a/crates/sdk/src/interceptors.rs
+++ b/crates/sdk/src/interceptors.rs
@@ -5,11 +5,9 @@ use crate::{
     activities::{ActivityContext, ActivityError, ActivityInfo},
 };
 use futures_util::future::{BoxFuture, LocalBoxFuture};
-use std::{
-    any::Any,
-    collections::HashMap,
-    sync::{Arc, OnceLock},
-};
+#[cfg(feature = "experimental")]
+use std::sync::OnceLock;
+use std::{any::Any, collections::HashMap, sync::Arc};
 use temporalio_common::{
     data_converters::{
         GenericPayloadConverter, PayloadConversionError, SerializationContext, TemporalSerializable,
@@ -46,113 +44,11 @@ mod activity_execution_value {
     }
 }
 
-/// Implementors can intercept certain actions that happen within the Worker.
-///
-/// Advanced usage only.
-/// **Experimental:** This API may change or be removed.
-#[async_trait::async_trait(?Send)]
-pub trait WorkerInterceptor: Send + Sync {
-    /// Intercept the running of a worker.
-    fn run_worker<'a>(
-        &'a self,
-        input: RunWorkerInput<'a>,
-        next: Next<'a, RunWorkerInput<'a>, LocalBoxFuture<'a, Result<(), WorkerRunError>>>,
-    ) -> LocalBoxFuture<'a, Result<(), WorkerRunError>> {
-        next.run(input)
-    }
-
-    /// Intercept the running of a worker created for workflow replay.
-    fn with_workflow_replay_worker<'a>(
-        &'a self,
-        input: WithWorkflowReplayWorkerInput<'a>,
-        next: Next<
-            'a,
-            WithWorkflowReplayWorkerInput<'a>,
-            LocalBoxFuture<'a, Result<(), WorkerRunError>>,
-        >,
-    ) -> LocalBoxFuture<'a, Result<(), WorkerRunError>> {
-        next.run(input)
-    }
-
-    /// Called every time a workflow activation completes (just before sending the completion to
-    /// core).
-    async fn on_workflow_activation_completion(&self, _completion: &WorkflowActivationCompletion) {}
-    /// Called after the worker has initiated shutdown and the workflow/activity polling loops
-    /// have exited, but just before waiting for the inner core worker shutdown
-    fn on_shutdown(&self, _sdk_worker: &Worker) {}
-    /// Called every time a workflow is about to be activated
-    async fn on_workflow_activation(
-        &self,
-        _activation: &WorkflowActivation,
-    ) -> Result<(), anyhow::Error> {
-        Ok(())
-    }
-}
-
 /// Continuation for an interceptor operation.
 ///
 /// Interceptor implementations call [`Next::run`] to invoke the next step of the chain.
 pub struct Next<'a, I, O> {
     inner: Box<dyn FnOnce(I) -> O + Send + 'a>,
-}
-
-/// Input to [`WorkerInterceptor::run_worker`].
-#[derive(Debug)]
-#[non_exhaustive]
-pub struct RunWorkerInput<'a> {
-    /// The worker being run.
-    pub worker: &'a mut Worker,
-}
-
-impl<'a> RunWorkerInput<'a> {
-    pub(crate) fn new(worker: &'a mut Worker) -> Self {
-        Self { worker }
-    }
-}
-
-/// Input to [`WorkerInterceptor::with_workflow_replay_worker`].
-#[derive(Debug)]
-#[non_exhaustive]
-pub struct WithWorkflowReplayWorkerInput<'a> {
-    /// The worker created for this replay operation.
-    pub worker: &'a mut Worker,
-}
-
-impl<'a> WithWorkflowReplayWorkerInput<'a> {
-    pub(crate) fn new(worker: &'a mut Worker) -> Self {
-        Self { worker }
-    }
-}
-
-pub(crate) fn call_run_worker<'a>(
-    interceptors: &'a [Arc<dyn WorkerInterceptor>],
-    input: RunWorkerInput<'a>,
-    terminal: Next<'a, RunWorkerInput<'a>, LocalBoxFuture<'a, Result<(), WorkerRunError>>>,
-) -> LocalBoxFuture<'a, Result<(), WorkerRunError>> {
-    if let Some((interceptor, remaining)) = interceptors.split_first() {
-        let next = Next::new(move |input| call_run_worker(remaining, input, terminal));
-        interceptor.run_worker(input, next)
-    } else {
-        terminal.run(input)
-    }
-}
-
-pub(crate) fn call_with_workflow_replay_worker<'a>(
-    interceptors: &'a [Arc<dyn WorkerInterceptor>],
-    input: WithWorkflowReplayWorkerInput<'a>,
-    terminal: Next<
-        'a,
-        WithWorkflowReplayWorkerInput<'a>,
-        LocalBoxFuture<'a, Result<(), WorkerRunError>>,
-    >,
-) -> LocalBoxFuture<'a, Result<(), WorkerRunError>> {
-    if let Some((interceptor, remaining)) = interceptors.split_first() {
-        let next =
-            Next::new(move |input| call_with_workflow_replay_worker(remaining, input, terminal));
-        interceptor.with_workflow_replay_worker(input, next)
-    } else {
-        terminal.run(input)
-    }
 }
 
 impl<'a, I, O> Next<'a, I, O> {
@@ -165,6 +61,130 @@ impl<'a, I, O> Next<'a, I, O> {
         (self.inner)(input)
     }
 }
+
+#[cfg_attr(not(feature = "experimental"), allow(unreachable_pub))]
+mod worker_lifecycle {
+    use super::*;
+
+    /// Implementors can intercept certain actions that happen within the Worker.
+    ///
+    /// Advanced usage only.
+    /// **Experimental:** This API may change or be removed.
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+    #[async_trait::async_trait(?Send)]
+    pub trait WorkerInterceptor: Send + Sync {
+        /// Intercept the running of a worker.
+        fn run_worker<'a>(
+            &'a self,
+            input: RunWorkerInput<'a>,
+            next: Next<'a, RunWorkerInput<'a>, LocalBoxFuture<'a, Result<(), WorkerRunError>>>,
+        ) -> LocalBoxFuture<'a, Result<(), WorkerRunError>> {
+            next.run(input)
+        }
+
+        /// Intercept the running of a worker created for workflow replay.
+        fn with_workflow_replay_worker<'a>(
+            &'a self,
+            input: WithWorkflowReplayWorkerInput<'a>,
+            next: Next<
+                'a,
+                WithWorkflowReplayWorkerInput<'a>,
+                LocalBoxFuture<'a, Result<(), WorkerRunError>>,
+            >,
+        ) -> LocalBoxFuture<'a, Result<(), WorkerRunError>> {
+            next.run(input)
+        }
+
+        /// Called every time a workflow activation completes (just before sending the completion to
+        /// core).
+        async fn on_workflow_activation_completion(
+            &self,
+            _completion: &WorkflowActivationCompletion,
+        ) {
+        }
+        /// Called after the worker has initiated shutdown and the workflow/activity polling loops
+        /// have exited, but just before waiting for the inner core worker shutdown
+        fn on_shutdown(&self, _sdk_worker: &Worker) {}
+        /// Called every time a workflow is about to be activated
+        async fn on_workflow_activation(
+            &self,
+            _activation: &WorkflowActivation,
+        ) -> Result<(), anyhow::Error> {
+            Ok(())
+        }
+    }
+
+    /// Input to [`WorkerInterceptor::run_worker`].
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+    #[derive(Debug)]
+    #[non_exhaustive]
+    pub struct RunWorkerInput<'a> {
+        /// The worker being run.
+        pub worker: &'a mut Worker,
+    }
+
+    impl<'a> RunWorkerInput<'a> {
+        pub(crate) fn new(worker: &'a mut Worker) -> Self {
+            Self { worker }
+        }
+    }
+
+    /// Input to [`WorkerInterceptor::with_workflow_replay_worker`].
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+    #[derive(Debug)]
+    #[non_exhaustive]
+    pub struct WithWorkflowReplayWorkerInput<'a> {
+        /// The worker created for this replay operation.
+        pub worker: &'a mut Worker,
+    }
+
+    impl<'a> WithWorkflowReplayWorkerInput<'a> {
+        pub(crate) fn new(worker: &'a mut Worker) -> Self {
+            Self { worker }
+        }
+    }
+
+    pub(crate) fn call_run_worker<'a>(
+        interceptors: &'a [Arc<dyn WorkerInterceptor>],
+        input: RunWorkerInput<'a>,
+        terminal: Next<'a, RunWorkerInput<'a>, LocalBoxFuture<'a, Result<(), WorkerRunError>>>,
+    ) -> LocalBoxFuture<'a, Result<(), WorkerRunError>> {
+        if let Some((interceptor, remaining)) = interceptors.split_first() {
+            let next = Next::new(move |input| call_run_worker(remaining, input, terminal));
+            interceptor.run_worker(input, next)
+        } else {
+            terminal.run(input)
+        }
+    }
+
+    pub(crate) fn call_with_workflow_replay_worker<'a>(
+        interceptors: &'a [Arc<dyn WorkerInterceptor>],
+        input: WithWorkflowReplayWorkerInput<'a>,
+        terminal: Next<
+            'a,
+            WithWorkflowReplayWorkerInput<'a>,
+            LocalBoxFuture<'a, Result<(), WorkerRunError>>,
+        >,
+    ) -> LocalBoxFuture<'a, Result<(), WorkerRunError>> {
+        if let Some((interceptor, remaining)) = interceptors.split_first() {
+            let next = Next::new(move |input| {
+                call_with_workflow_replay_worker(remaining, input, terminal)
+            });
+            interceptor.with_workflow_replay_worker(input, next)
+        } else {
+            terminal.run(input)
+        }
+    }
+}
+
+#[cfg(not(feature = "experimental"))]
+pub(crate) use worker_lifecycle::{
+    RunWorkerInput, WithWorkflowReplayWorkerInput, WorkerInterceptor,
+};
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+pub use worker_lifecycle::{RunWorkerInput, WithWorkflowReplayWorkerInput, WorkerInterceptor};
+pub(crate) use worker_lifecycle::{call_run_worker, call_with_workflow_replay_worker};
 
 /// Activity execution data passed to [`ActivityInboundInterceptor::execute_activity`].
 #[non_exhaustive]
@@ -260,11 +280,14 @@ pub trait ActivityInboundInterceptor: Send + Sync + 'static {
 }
 
 /// An interceptor that allows you to fetch the exit value of the workflow if and when it is set
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Default)]
 pub struct ReturnWorkflowExitValueInterceptor {
     result_value: Arc<OnceLock<Payload>>,
 }
 
+#[cfg(feature = "experimental")]
 impl ReturnWorkflowExitValueInterceptor {
     /// Can be used to fetch the workflow result if/when it is determined
     pub fn result_handle(&self) -> Arc<OnceLock<Payload>> {
@@ -273,6 +296,7 @@ impl ReturnWorkflowExitValueInterceptor {
 }
 
 #[async_trait::async_trait(?Send)]
+#[cfg(feature = "experimental")]
 impl WorkerInterceptor for ReturnWorkflowExitValueInterceptor {
     async fn on_workflow_activation_completion(&self, c: &WorkflowActivationCompletion) {
         if let Some(v) = c.complete_workflow_execution_value() {

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -88,13 +88,15 @@ pub use crate::error::{
     WorkflowRegistrationError, WorkflowSignalError,
 };
 pub use temporalio_client::Namespace;
+#[cfg(feature = "experimental")]
+pub use temporalio_workflow::ContinueAsNewVersioningBehavior;
 pub use temporalio_workflow::{
     ActivityCloseTimeouts, ActivityOptions, BaseWorkflowContext, CancellableFuture,
-    ChildWorkflowOptions, ContinueAsNewOptions, ContinueAsNewVersioningBehavior,
-    ExternalWorkflowHandle, LocalActivityOptions, NexusOperationOptions, ParentWorkflowInfo,
-    RootWorkflowInfo, Signal, SignalData, StartChildWorkflowExecutionFailedCause,
-    StartedChildWorkflow, SyncWorkflowContext, TimerOptions, TimerResult, WorkflowContext,
-    WorkflowContextView, WorkflowResult, WorkflowTermination,
+    ChildWorkflowOptions, ContinueAsNewOptions, ExternalWorkflowHandle, LocalActivityOptions,
+    NexusOperationOptions, ParentWorkflowInfo, RootWorkflowInfo, Signal, SignalData,
+    StartChildWorkflowExecutionFailedCause, StartedChildWorkflow, SyncWorkflowContext,
+    TimerOptions, TimerResult, WorkflowContext, WorkflowContextView, WorkflowResult,
+    WorkflowTermination,
 };
 #[cfg(feature = "wasm-workflows")]
 pub use workflow_wasm::WasmWorkflowComponent;

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)] // error if there are missing docs
 
 //! This crate defines a Public Preview Temporal Rust SDK.
@@ -66,6 +67,8 @@ extern crate self as temporalio_sdk;
 pub mod activities;
 pub mod error;
 pub mod interceptors;
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 /// Experimental APIs for configuring clients and workers with reusable plugins.
 pub mod plugins;
 pub mod runtime;
@@ -81,6 +84,11 @@ pub mod workflow_replayer;
 mod workflow_wasm;
 pub mod workflows;
 
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+pub use crate::plugins::{
+    ClientAndWorkerPlugin, SimplePlugin, SimplePluginBuilder, SimplePluginOption, WorkerPlugin,
+};
 pub use crate::{
     error::{
         ActivityExecutionError, ApplicationFailure, ChildWorkflowExecutionError,
@@ -88,25 +96,25 @@ pub use crate::{
         RetryState, TimeoutType, WorkerCreateError, WorkerRunError, WorkerValidationError,
         WorkflowRegistrationError, WorkflowSignalError,
     },
-    plugins::{
-        ClientAndWorkerPlugin, SimplePlugin, SimplePluginBuilder, SimplePluginOption, WorkerPlugin,
-        WorkflowDefinitions,
-    },
+    workflow_registry::WorkflowDefinitions,
 };
 pub use runtime::Runtime;
 pub use temporalio_client::Namespace;
-#[cfg(feature = "experimental")]
-pub use temporalio_workflow::ContinueAsNewVersioningBehavior;
 pub use temporalio_workflow::{
     ActivityCancellationType, ActivityCloseTimeouts, ActivityOptions, BaseWorkflowContext,
     CancellableFuture, CancellableFutureWithReason, ChildWorkflowCancellationType,
     ChildWorkflowOptions, ContinueAsNewOptions, ExternalWorkflowHandle, LocalActivityOptions,
-    MemoValue, NexusOperationCancellationType, NexusOperationOptions, ParentClosePolicy,
-    PatchActivationCallback, SignalWorkflowOptions, StartChildWorkflowExecutionFailedCause,
-    StartChildWorkflowOutput, StartedChildWorkflow, StartedNexusOperation, SyncWorkflowContext,
-    TimerOptions, TimerResult, VersioningIntent, WaitConditionOptions, WorkflowCancellationError,
-    WorkflowCancellationToken, WorkflowContext, WorkflowContextView, WorkflowIdReusePolicy,
-    WorkflowRandomValue, WorkflowResult, WorkflowTermination,
+    MemoValue, ParentClosePolicy, SignalWorkflowOptions, StartChildWorkflowExecutionFailedCause,
+    StartChildWorkflowOutput, StartedChildWorkflow, SyncWorkflowContext, TimerOptions, TimerResult,
+    VersioningIntent, WaitConditionOptions, WorkflowCancellationError, WorkflowCancellationToken,
+    WorkflowContext, WorkflowContextView, WorkflowIdReusePolicy, WorkflowRandomValue,
+    WorkflowResult, WorkflowTermination,
+};
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+pub use temporalio_workflow::{
+    ContinueAsNewVersioningBehavior, NexusOperationCancellationType, NexusOperationOptions,
+    PatchActivationCallback, PatchActivationInput, StartedNexusOperation,
 };
 #[cfg(feature = "wasm-workflows")]
 pub use workflow_wasm::WasmWorkflowComponent;
@@ -133,6 +141,8 @@ use std::{
     time::Duration,
 };
 use temporalio_client::{Client, ClientOptions, NamespacedClient};
+#[cfg(feature = "experimental")]
+use temporalio_common::protos::temporal::api::worker::v1::PluginInfo;
 use temporalio_common::{
     ActivityDefinition, WorkflowDefinition,
     data_converters::{
@@ -151,13 +161,14 @@ use temporalio_common::{
         },
         temporal::api::{
             common::v1::Payload, enums::v1::WorkflowTaskFailedCause, failure::v1::Failure,
-            worker::v1::PluginInfo,
         },
     },
     worker::{WorkerDeploymentOptions, WorkerTaskTypes, build_id_from_current_exe},
 };
 use temporalio_sdk_core::{PollError, init_worker};
-use temporalio_workflow::runtime::entry::WorkflowImplementation;
+use temporalio_workflow::{
+    InternalPatchActivationCallback, runtime::entry::WorkflowImplementation,
+};
 use tokio::sync::{
     Notify,
     mpsc::{UnboundedSender, unbounded_channel},
@@ -201,9 +212,11 @@ pub struct WorkerOptions {
     workflow_interceptor_constructors: Vec<WorkflowInterceptorConstructor>,
 
     #[builder(field)]
+    #[cfg(feature = "experimental")]
     worker_plugins: Vec<Arc<dyn WorkerPlugin>>,
 
     #[builder(field)]
+    #[cfg(feature = "experimental")]
     client_plugin_names: HashSet<String>,
 
     #[cfg(feature = "wasm-workflows")]
@@ -304,6 +317,15 @@ pub struct WorkerOptions {
     /// exceed the namespace error limits; oversized payloads are sent to server, which enforces the
     /// limit. Defaults to false.
     /// NOTE: Experimental
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+    #[cfg_attr(
+        docsrs,
+        builder(setters(
+            some_fn(name = __disable_payload_error_limit, vis = "pub(crate)"),
+            option_fn(name = __maybe_disable_payload_error_limit, vis = "pub(crate)")
+        ))
+    )]
     #[builder(default = false)]
     pub disable_payload_error_limit: bool,
     /// Experimental callback that decides whether the first non-replay call to
@@ -313,7 +335,67 @@ pub struct WorkerOptions {
     /// `true` records the patch marker; returning `false` leaves the patch inactive for the
     /// workflow run. For registered WASM workflow components, the callback remains on the worker
     /// host and is invoked through the workflow component's synchronous host interface.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+    #[cfg_attr(
+        docsrs,
+        builder(setters(
+            some_fn(name = __patch_activation_callback, vis = "pub(crate)"),
+            option_fn(name = __maybe_patch_activation_callback, vis = "pub(crate)")
+        ))
+    )]
     pub patch_activation_callback: Option<PatchActivationCallback>,
+}
+
+#[cfg(all(feature = "experimental", docsrs))]
+impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
+    /// Set whether payloads over the namespace error limit are sent to the server.
+    #[doc(cfg(feature = "experimental"))]
+    pub fn disable_payload_error_limit(
+        self,
+        value: bool,
+    ) -> WorkerOptionsBuilder<worker_options_builder::SetDisablePayloadErrorLimit<S>>
+    where
+        S::DisablePayloadErrorLimit: worker_options_builder::IsUnset,
+    {
+        self.__disable_payload_error_limit(value)
+    }
+
+    /// Set the payload error limit override from an optional value.
+    #[doc(cfg(feature = "experimental"))]
+    pub fn maybe_disable_payload_error_limit(
+        self,
+        value: Option<bool>,
+    ) -> WorkerOptionsBuilder<worker_options_builder::SetDisablePayloadErrorLimit<S>>
+    where
+        S::DisablePayloadErrorLimit: worker_options_builder::IsUnset,
+    {
+        self.__maybe_disable_payload_error_limit(value)
+    }
+
+    /// Set the callback used to decide whether a patch should activate.
+    #[doc(cfg(feature = "experimental"))]
+    pub fn patch_activation_callback(
+        self,
+        value: PatchActivationCallback,
+    ) -> WorkerOptionsBuilder<worker_options_builder::SetPatchActivationCallback<S>>
+    where
+        S::PatchActivationCallback: worker_options_builder::IsUnset,
+    {
+        self.__patch_activation_callback(value)
+    }
+
+    /// Set the patch activation callback from an optional value.
+    #[doc(cfg(feature = "experimental"))]
+    pub fn maybe_patch_activation_callback(
+        self,
+        value: Option<PatchActivationCallback>,
+    ) -> WorkerOptionsBuilder<worker_options_builder::SetPatchActivationCallback<S>>
+    where
+        S::PatchActivationCallback: worker_options_builder::IsUnset,
+    {
+        self.__maybe_patch_activation_callback(value)
+    }
 }
 
 impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
@@ -338,6 +420,7 @@ impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
         self
     }
 
+    #[cfg(feature = "experimental")]
     pub(crate) fn with_worker_plugins(
         mut self,
         worker_plugins: Vec<Arc<dyn WorkerPlugin>>,
@@ -358,12 +441,16 @@ impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
     /// Register a worker plugin.
     ///
     /// **Experimental:** This API may change or be removed.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn worker_plugin<P: WorkerPlugin>(mut self, plugin: P) -> Self {
         self.worker_plugins.push(Arc::new(plugin));
         self
     }
 
     /// Append a worker interceptor. Interceptors run in registration order.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn worker_interceptor<I: WorkerInterceptor + 'static>(mut self, interceptor: I) -> Self {
         self.worker_interceptors.push(Arc::new(interceptor));
         self
@@ -476,6 +563,8 @@ fn def_build_id() -> WorkerDeploymentOptions {
 
 impl WorkerOptions {
     /// Append a worker interceptor. Interceptors run in registration order.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn worker_interceptor<I: WorkerInterceptor + 'static>(
         &mut self,
         interceptor: I,
@@ -589,6 +678,25 @@ impl WorkerOptions {
         if !workflows_registered && !activities_registered {
             return Err("At least one workflow or activity must be registered".to_owned());
         }
+        #[cfg(feature = "experimental")]
+        let disable_payload_error_limit = self.disable_payload_error_limit;
+        #[cfg(not(feature = "experimental"))]
+        let disable_payload_error_limit = false;
+        #[cfg(feature = "experimental")]
+        let plugin_info = self
+            .client_plugin_names
+            .iter()
+            .map(|name| PluginInfo {
+                name: name.clone(),
+                version: String::new(),
+            })
+            .chain(self.worker_plugins.iter().map(|registration| PluginInfo {
+                name: registration.name().to_owned(),
+                version: String::new(),
+            }))
+            .collect();
+        #[cfg(not(feature = "experimental"))]
+        let plugin_info = HashSet::new();
 
         WorkerConfig::builder()
             .namespace(namespace)
@@ -627,20 +735,8 @@ impl WorkerOptions {
             ))
             .workflow_failure_errors(self.workflow_failure_errors.clone())
             .workflow_types_to_failure_errors(self.workflow_types_to_failure_errors.clone())
-            .plugins(
-                self.client_plugin_names
-                    .iter()
-                    .map(|name| PluginInfo {
-                        name: name.clone(),
-                        version: String::new(),
-                    })
-                    .chain(self.worker_plugins.iter().map(|registration| PluginInfo {
-                        name: registration.name().to_owned(),
-                        version: String::new(),
-                    }))
-                    .collect(),
-            )
-            .disable_payload_error_limit(self.disable_payload_error_limit)
+            .plugins(plugin_info)
+            .disable_payload_error_limit(disable_payload_error_limit)
             .build()
     }
 }
@@ -678,7 +774,7 @@ struct WorkflowHalf {
     workflow_removed_from_map: Notify,
     detect_nondeterministic_futures: bool,
     #[debug(skip)]
-    patch_activation_callback: Option<PatchActivationCallback>,
+    patch_activation_callback: Option<InternalPatchActivationCallback>,
 }
 #[derive(Debug)]
 struct WorkflowData {
@@ -784,8 +880,11 @@ impl Worker {
     pub fn new(
         runtime: &Runtime,
         client: Client,
-        mut options: WorkerOptions,
+        options: WorkerOptions,
     ) -> Result<Self, WorkerCreateError> {
+        #[cfg(feature = "experimental")]
+        let mut options = options;
+        #[cfg(feature = "experimental")]
         plugins::apply_worker_plugins(client.options(), &mut options)?;
         let wc = options
             .to_core_options(client.namespace(), client.identity())
@@ -817,8 +916,11 @@ impl Worker {
     pub fn new_from_core_options(
         worker: Arc<CoreWorker>,
         client_options: ClientOptions,
-        mut options: WorkerOptions,
+        options: WorkerOptions,
     ) -> Result<Self, WorkerCreateError> {
+        #[cfg(feature = "experimental")]
+        let mut options = options;
+        #[cfg(feature = "experimental")]
         plugins::apply_worker_plugins(&client_options, &mut options)?;
         Self::new_from_core_options_prepared(worker, client_options, options)
     }
@@ -847,7 +949,10 @@ impl Worker {
             workflow_interceptor_constructors,
         );
         me.set_detect_nondeterministic_futures(options.detect_nondeterministic_futures);
-        me.workflow_half.patch_activation_callback = options.patch_activation_callback;
+        #[cfg(feature = "experimental")]
+        {
+            me.workflow_half.patch_activation_callback = options.patch_activation_callback;
+        }
         #[cfg(feature = "wasm-workflows")]
         me.workflow_half
             .workflow_definitions
@@ -1749,30 +1854,6 @@ mod tests {
             .unwrap();
     }
 
-    #[test]
-    fn simple_plugin_workflow_function_merges_definitions() {
-        let plugin = SimplePlugin::builder("simple")
-            .workflows(|existing: Option<WorkflowDefinitions>| {
-                assert!(existing.is_some());
-                let mut workflows = WorkflowDefinitions::new();
-                workflows.register_workflow::<OtherWorkflow>().unwrap();
-                workflows
-            })
-            .build();
-        let client_options = ClientOptions::new("namespace").build();
-        let mut worker_options = WorkerOptions::new("task_q")
-            .register_workflow::<MyWorkflow>()
-            .unwrap()
-            .worker_plugin(plugin)
-            .build();
-
-        crate::plugins::apply_worker_plugins(&client_options, &mut worker_options).unwrap();
-
-        let workflows = format!("{:?}", worker_options.workflows());
-        assert!(workflows.contains("MyWorkflow"));
-        assert!(workflows.contains("OtherWorkflow"));
-    }
-
     #[rstest::rstest]
     #[case::workflow_only(true, false, Ok(WorkerTaskTypes::workflow_only()))]
     #[case::activity_only(false, true, Ok(WorkerTaskTypes::activity_only()))]
@@ -1908,24 +1989,6 @@ mod tests {
         assert_eq!(config.client_identity_override, expected);
     }
 
-    #[rstest::rstest]
-    #[case::default_enforces_error_limit(None, false)]
-    #[case::opt_out_disables_error_limit(Some(true), true)]
-    #[case::explicit_enable_error_limit(Some(false), false)]
-    #[test]
-    fn disable_payload_error_limit_propagates(
-        #[case] override_value: Option<bool>,
-        #[case] expected: bool,
-    ) {
-        let config = WorkerOptions::new("task_q")
-            .register_activities(MyActivities {})
-            .maybe_disable_payload_error_limit(override_value)
-            .build()
-            .to_core_options("ns".into(), String::new())
-            .unwrap();
-        assert_eq!(config.disable_payload_error_limit, expected);
-    }
-
     #[test]
     fn max_eager_activity_reservations_per_workflow_task_propagates() {
         let config = WorkerOptions::new("task_q")
@@ -1935,5 +1998,52 @@ mod tests {
             .to_core_options("ns".into(), String::new())
             .unwrap();
         assert_eq!(config.max_eager_activity_reservations_per_workflow_task, 7);
+    }
+
+    #[cfg(feature = "experimental")]
+    mod experimental_tests {
+        use super::*;
+
+        #[test]
+        fn simple_plugin_workflow_function_merges_definitions() {
+            let plugin = SimplePlugin::builder("simple")
+                .workflows(|existing: Option<WorkflowDefinitions>| {
+                    assert!(existing.is_some());
+                    let mut workflows = WorkflowDefinitions::new();
+                    workflows.register_workflow::<OtherWorkflow>().unwrap();
+                    workflows
+                })
+                .build();
+            let client_options = ClientOptions::new("namespace").build();
+            let mut worker_options = WorkerOptions::new("task_q")
+                .register_workflow::<MyWorkflow>()
+                .unwrap()
+                .worker_plugin(plugin)
+                .build();
+
+            crate::plugins::apply_worker_plugins(&client_options, &mut worker_options).unwrap();
+
+            let workflows = format!("{:?}", worker_options.workflows());
+            assert!(workflows.contains("MyWorkflow"));
+            assert!(workflows.contains("OtherWorkflow"));
+        }
+
+        #[rstest::rstest]
+        #[case::default_enforces_error_limit(None, false)]
+        #[case::opt_out_disables_error_limit(Some(true), true)]
+        #[case::explicit_enable_error_limit(Some(false), false)]
+        #[test]
+        fn disable_payload_error_limit_propagates(
+            #[case] override_value: Option<bool>,
+            #[case] expected: bool,
+        ) {
+            let config = WorkerOptions::new("task_q")
+                .register_activities(MyActivities {})
+                .maybe_disable_payload_error_limit(override_value)
+                .build()
+                .to_core_options("ns".into(), String::new())
+                .unwrap();
+            assert_eq!(config.disable_payload_error_limit, expected);
+        }
     }
 }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -95,17 +95,18 @@ pub use crate::{
 };
 pub use runtime::Runtime;
 pub use temporalio_client::Namespace;
+#[cfg(feature = "experimental")]
+pub use temporalio_workflow::ContinueAsNewVersioningBehavior;
 pub use temporalio_workflow::{
     ActivityCancellationType, ActivityCloseTimeouts, ActivityOptions, BaseWorkflowContext,
     CancellableFuture, CancellableFutureWithReason, ChildWorkflowCancellationType,
-    ChildWorkflowOptions, ContinueAsNewOptions, ContinueAsNewVersioningBehavior,
-    ExternalWorkflowHandle, LocalActivityOptions, MemoValue, NexusOperationCancellationType,
-    NexusOperationOptions, ParentClosePolicy, PatchActivationCallback, SignalWorkflowOptions,
-    StartChildWorkflowExecutionFailedCause, StartChildWorkflowOutput, StartedChildWorkflow,
-    StartedNexusOperation, SyncWorkflowContext, TimerOptions, TimerResult, VersioningIntent,
-    WaitConditionOptions, WorkflowCancellationError, WorkflowCancellationToken, WorkflowContext,
-    WorkflowContextView, WorkflowIdReusePolicy, WorkflowRandomValue, WorkflowResult,
-    WorkflowTermination,
+    ChildWorkflowOptions, ContinueAsNewOptions, ExternalWorkflowHandle, LocalActivityOptions,
+    MemoValue, NexusOperationCancellationType, NexusOperationOptions, ParentClosePolicy,
+    PatchActivationCallback, SignalWorkflowOptions, StartChildWorkflowExecutionFailedCause,
+    StartChildWorkflowOutput, StartedChildWorkflow, StartedNexusOperation, SyncWorkflowContext,
+    TimerOptions, TimerResult, VersioningIntent, WaitConditionOptions, WorkflowCancellationError,
+    WorkflowCancellationToken, WorkflowContext, WorkflowContextView, WorkflowIdReusePolicy,
+    WorkflowRandomValue, WorkflowResult, WorkflowTermination,
 };
 #[cfg(feature = "wasm-workflows")]
 pub use workflow_wasm::WasmWorkflowComponent;

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -322,8 +322,8 @@ pub struct WorkerOptions {
     #[cfg_attr(
         docsrs,
         builder(setters(
-            some_fn(name = __disable_payload_error_limit, vis = "pub(crate)"),
-            option_fn(name = __maybe_disable_payload_error_limit, vis = "pub(crate)")
+            some_fn(name = disable_payload_error_limit_impl, vis = "pub(crate)"),
+            option_fn(name = maybe_disable_payload_error_limit_impl, vis = "pub(crate)")
         ))
     )]
     #[builder(default = false)]
@@ -340,13 +340,15 @@ pub struct WorkerOptions {
     #[cfg_attr(
         docsrs,
         builder(setters(
-            some_fn(name = __patch_activation_callback, vis = "pub(crate)"),
-            option_fn(name = __maybe_patch_activation_callback, vis = "pub(crate)")
+            some_fn(name = patch_activation_callback_impl, vis = "pub(crate)"),
+            option_fn(name = maybe_patch_activation_callback_impl, vis = "pub(crate)")
         ))
     )]
     pub patch_activation_callback: Option<PatchActivationCallback>,
 }
 
+// Bon does not propagate `doc(cfg)` to generated setters, so these docs-only methods forward to
+// renamed generated implementations.
 #[cfg(all(feature = "experimental", docsrs))]
 impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
     /// Set whether payloads over the namespace error limit are sent to the server.
@@ -358,7 +360,7 @@ impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
     where
         S::DisablePayloadErrorLimit: worker_options_builder::IsUnset,
     {
-        self.__disable_payload_error_limit(value)
+        self.disable_payload_error_limit_impl(value)
     }
 
     /// Set the payload error limit override from an optional value.
@@ -370,7 +372,7 @@ impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
     where
         S::DisablePayloadErrorLimit: worker_options_builder::IsUnset,
     {
-        self.__maybe_disable_payload_error_limit(value)
+        self.maybe_disable_payload_error_limit_impl(value)
     }
 
     /// Set the callback used to decide whether a patch should activate.
@@ -382,7 +384,7 @@ impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
     where
         S::PatchActivationCallback: worker_options_builder::IsUnset,
     {
-        self.__patch_activation_callback(value)
+        self.patch_activation_callback_impl(value)
     }
 
     /// Set the patch activation callback from an optional value.
@@ -394,7 +396,7 @@ impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
     where
         S::PatchActivationCallback: worker_options_builder::IsUnset,
     {
-        self.__maybe_patch_activation_callback(value)
+        self.maybe_patch_activation_callback_impl(value)
     }
 }
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -68,7 +68,6 @@ pub mod activities;
 pub mod error;
 pub mod interceptors;
 #[cfg(feature = "experimental")]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 /// Experimental APIs for configuring clients and workers with reusable plugins.
 pub mod plugins;
 pub mod runtime;
@@ -85,7 +84,6 @@ mod workflow_wasm;
 pub mod workflows;
 
 #[cfg(feature = "experimental")]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub use crate::plugins::{
     ClientAndWorkerPlugin, SimplePlugin, SimplePluginBuilder, SimplePluginOption, WorkerPlugin,
 };
@@ -111,7 +109,6 @@ pub use temporalio_workflow::{
     WorkflowResult, WorkflowTermination,
 };
 #[cfg(feature = "experimental")]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub use temporalio_workflow::{
     ContinueAsNewVersioningBehavior, NexusOperationCancellationType, NexusOperationOptions,
     PatchActivationCallback, PatchActivationInput, StartedNexusOperation,
@@ -318,7 +315,6 @@ pub struct WorkerOptions {
     /// limit. Defaults to false.
     /// NOTE: Experimental
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[cfg_attr(
         docsrs,
         builder(setters(
@@ -336,7 +332,6 @@ pub struct WorkerOptions {
     /// workflow run. For registered WASM workflow components, the callback remains on the worker
     /// host and is invoked through the workflow component's synchronous host interface.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[cfg_attr(
         docsrs,
         builder(setters(
@@ -444,7 +439,6 @@ impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
     ///
     /// **Experimental:** This API may change or be removed.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn worker_plugin<P: WorkerPlugin>(mut self, plugin: P) -> Self {
         self.worker_plugins.push(Arc::new(plugin));
         self
@@ -452,7 +446,6 @@ impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
 
     /// Append a worker interceptor. Interceptors run in registration order.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn worker_interceptor<I: WorkerInterceptor + 'static>(mut self, interceptor: I) -> Self {
         self.worker_interceptors.push(Arc::new(interceptor));
         self
@@ -566,7 +559,6 @@ fn def_build_id() -> WorkerDeploymentOptions {
 impl WorkerOptions {
     /// Append a worker interceptor. Interceptors run in registration order.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn worker_interceptor<I: WorkerInterceptor + 'static>(
         &mut self,
         interceptor: I,

--- a/crates/sdk/src/plugins.rs
+++ b/crates/sdk/src/plugins.rs
@@ -22,6 +22,7 @@ use temporalio_common::data_converters::DataConverter;
 /// Use [`ClientAndWorkerPlugin`] for plugins that target both clients and workers.
 ///
 /// **Experimental:** This API may change or be removed.
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub trait WorkerPlugin: Send + Sync + 'static {
     /// Stable, unique name used to identify this plugin.
     fn name(&self) -> &str;
@@ -77,6 +78,7 @@ impl WorkerPluginData for PropagatedWorkerPlugin {}
 /// ```
 ///
 /// **Experimental:** This API may change or be removed.
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Clone)]
 pub struct ClientAndWorkerPlugin {
     client: ErasedClientPlugin,
@@ -127,6 +129,7 @@ impl WorkerPlugin for ClientAndWorkerPlugin {
 /// functions into this type.
 ///
 /// **Experimental:** This API may change or be removed.
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Clone)]
 pub enum SimplePluginOption<T> {
     /// A value that replaces a scalar field or appends to a collection field.
@@ -210,6 +213,7 @@ fn apply_appending<T: Clone>(
 /// configured client when a worker is created.
 ///
 /// **Experimental:** This API may change or be removed.
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Clone, bon::Builder)]
 #[builder(state_mod(vis = "pub"))]
 pub struct SimplePlugin {
@@ -454,7 +458,7 @@ pub(crate) fn apply_workflow_replayer_plugins(
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "experimental"))]
 mod tests {
     use super::*;
     use std::{

--- a/crates/sdk/src/plugins.rs
+++ b/crates/sdk/src/plugins.rs
@@ -22,7 +22,6 @@ use temporalio_common::data_converters::DataConverter;
 /// Use [`ClientAndWorkerPlugin`] for plugins that target both clients and workers.
 ///
 /// **Experimental:** This API may change or be removed.
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub trait WorkerPlugin: Send + Sync + 'static {
     /// Stable, unique name used to identify this plugin.
     fn name(&self) -> &str;
@@ -78,7 +77,6 @@ impl WorkerPluginData for PropagatedWorkerPlugin {}
 /// ```
 ///
 /// **Experimental:** This API may change or be removed.
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Clone)]
 pub struct ClientAndWorkerPlugin {
     client: ErasedClientPlugin,
@@ -129,7 +127,6 @@ impl WorkerPlugin for ClientAndWorkerPlugin {
 /// functions into this type.
 ///
 /// **Experimental:** This API may change or be removed.
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Clone)]
 pub enum SimplePluginOption<T> {
     /// A value that replaces a scalar field or appends to a collection field.
@@ -213,7 +210,6 @@ fn apply_appending<T: Clone>(
 /// configured client when a worker is created.
 ///
 /// **Experimental:** This API may change or be removed.
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Clone, bon::Builder)]
 #[builder(state_mod(vis = "pub"))]
 pub struct SimplePlugin {

--- a/crates/sdk/src/workflow_future.rs
+++ b/crates/sdk/src/workflow_future.rs
@@ -34,7 +34,7 @@ use temporalio_common::{
     },
 };
 use temporalio_workflow::{
-    PatchActivationCallback,
+    InternalPatchActivationCallback as PatchActivationCallback,
     runtime::{
         guest::WorkflowInstance,
         host::WorkflowHost,

--- a/crates/sdk/src/workflow_registry.rs
+++ b/crates/sdk/src/workflow_registry.rs
@@ -12,7 +12,7 @@ use temporalio_common::{
     },
 };
 use temporalio_workflow::{
-    BaseWorkflowContext, PatchActivationCallback,
+    BaseWorkflowContext, InternalPatchActivationCallback as PatchActivationCallback,
     runtime::{
         entry::WorkflowImplementation,
         guest::WorkflowInstance,
@@ -75,6 +75,8 @@ pub struct WorkflowDefinitions {
 }
 
 impl WorkflowDefinitions {
+    // Only used by Plugins so feature flagged to avoid dead code.
+    #[cfg(feature = "experimental")]
     pub(crate) fn extend(&mut self, other: &Self) -> Result<(), WorkflowRegistrationError> {
         for workflow in other.workflows.values() {
             self.insert_workflow(workflow.definition.clone(), workflow.factory.clone())?;

--- a/crates/sdk/src/workflow_replayer.rs
+++ b/crates/sdk/src/workflow_replayer.rs
@@ -92,7 +92,6 @@ impl<S: workflow_replayer_options_builder::State> WorkflowReplayerOptionsBuilder
     ///
     /// **Experimental:** This API may change or be removed.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn worker_plugin<P: WorkerPlugin>(mut self, plugin: P) -> Self {
         self.worker_plugins.push(Arc::new(plugin));
         self
@@ -100,7 +99,6 @@ impl<S: workflow_replayer_options_builder::State> WorkflowReplayerOptionsBuilder
 
     /// Append a worker interceptor used during replay.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn worker_interceptor<I: WorkerInterceptor + 'static>(mut self, interceptor: I) -> Self {
         self.worker_interceptors.push(Arc::new(interceptor));
         self
@@ -166,7 +164,6 @@ impl<S: workflow_replayer_options_builder::State> WorkflowReplayerOptionsBuilder
 impl WorkflowReplayerOptions {
     /// Append a worker interceptor used during replay.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn worker_interceptor<I: WorkerInterceptor + 'static>(
         &mut self,
         interceptor: I,
@@ -323,7 +320,6 @@ pub enum WorkflowReplayError {
 pub enum WorkflowReplayWorkerError {
     /// A plugin failed while configuring replay options.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[error(transparent)]
     Plugin(#[from] PluginApplyError),
     /// No workflow definitions were registered after plugin configuration.

--- a/crates/sdk/src/workflow_replayer.rs
+++ b/crates/sdk/src/workflow_replayer.rs
@@ -31,8 +31,6 @@ use temporalio_sdk_core::{
     init_replay_worker,
     replay::{HistoryForReplay, ReplayWorkerInput},
 };
-#[cfg(feature = "experimental")]
-use temporalio_workflow::InternalPatchActivationCallback as PatchActivationCallback;
 use temporalio_workflow::runtime::entry::WorkflowImplementation;
 
 #[cfg(feature = "wasm-workflows")]
@@ -87,49 +85,6 @@ pub struct WorkflowReplayerOptions {
     /// Whether to detect nondeterministic future usage in workflow code.
     #[builder(default = true)]
     pub detect_nondeterministic_futures: bool,
-
-    /// Callback controlling first non-replay patch decisions.
-    #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
-    #[cfg_attr(
-        docsrs,
-        builder(setters(
-            some_fn(name = __patch_activation_callback, vis = "pub(crate)"),
-            option_fn(name = __maybe_patch_activation_callback, vis = "pub(crate)")
-        ))
-    )]
-    pub patch_activation_callback: Option<PatchActivationCallback>,
-}
-
-#[cfg(all(feature = "experimental", docsrs))]
-impl<S: workflow_replayer_options_builder::State> WorkflowReplayerOptionsBuilder<S> {
-    /// Set the callback used to decide whether a patch should activate during replay.
-    #[doc(cfg(feature = "experimental"))]
-    pub fn patch_activation_callback(
-        self,
-        value: PatchActivationCallback,
-    ) -> WorkflowReplayerOptionsBuilder<
-        workflow_replayer_options_builder::SetPatchActivationCallback<S>,
-    >
-    where
-        S::PatchActivationCallback: workflow_replayer_options_builder::IsUnset,
-    {
-        self.__patch_activation_callback(value)
-    }
-
-    /// Set the replay patch activation callback from an optional value.
-    #[doc(cfg(feature = "experimental"))]
-    pub fn maybe_patch_activation_callback(
-        self,
-        value: Option<PatchActivationCallback>,
-    ) -> WorkflowReplayerOptionsBuilder<
-        workflow_replayer_options_builder::SetPatchActivationCallback<S>,
-    >
-    where
-        S::PatchActivationCallback: workflow_replayer_options_builder::IsUnset,
-    {
-        self.__maybe_patch_activation_callback(value)
-    }
 }
 
 impl<S: workflow_replayer_options_builder::State> WorkflowReplayerOptionsBuilder<S> {
@@ -540,9 +495,6 @@ impl WorkflowReplayer {
         #[cfg(feature = "experimental")]
         let worker_options =
             worker_options.with_worker_plugins(self.options.worker_plugins.clone());
-        #[cfg(feature = "experimental")]
-        let worker_options = worker_options
-            .maybe_patch_activation_callback(self.options.patch_activation_callback.clone());
         #[cfg(feature = "wasm-workflows")]
         let worker_options = worker_options
             .with_wasm_workflow_components(self.options.wasm_workflow_components.clone());

--- a/crates/sdk/src/workflow_replayer.rs
+++ b/crates/sdk/src/workflow_replayer.rs
@@ -1,7 +1,8 @@
+#[cfg(feature = "experimental")]
+use crate::plugins::WorkerPlugin;
 use crate::{
     Worker, WorkerOptions, WorkerRunError,
     interceptors::{self, Next, WithWorkflowReplayWorkerInput, WorkerInterceptor},
-    plugins::WorkerPlugin,
     runtime::WorkflowErrorType,
     workflow_interceptors::WorkflowInterceptorConstructor,
     workflow_registry::{WorkflowDefinitions, WorkflowRegistrationError},
@@ -12,9 +13,9 @@ use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
 };
-use temporalio_client::{
-    ClientOptions, PluginApplyError, WorkflowHistory, errors::WorkflowInteractionError,
-};
+#[cfg(feature = "experimental")]
+use temporalio_client::PluginApplyError;
+use temporalio_client::{ClientOptions, WorkflowHistory, errors::WorkflowInteractionError};
 use temporalio_common::{
     WorkflowDefinition,
     data_converters::DataConverter,
@@ -30,7 +31,9 @@ use temporalio_sdk_core::{
     init_replay_worker,
     replay::{HistoryForReplay, ReplayWorkerInput},
 };
-use temporalio_workflow::{PatchActivationCallback, runtime::entry::WorkflowImplementation};
+#[cfg(feature = "experimental")]
+use temporalio_workflow::InternalPatchActivationCallback as PatchActivationCallback;
+use temporalio_workflow::runtime::entry::WorkflowImplementation;
 
 #[cfg(feature = "wasm-workflows")]
 use crate::WasmWorkflowComponent;
@@ -54,6 +57,7 @@ pub struct WorkflowReplayerOptions {
     pub(super) workflow_interceptor_constructors: Vec<WorkflowInterceptorConstructor>,
 
     #[builder(field)]
+    #[cfg(feature = "experimental")]
     pub(super) worker_plugins: Vec<Arc<dyn WorkerPlugin>>,
 
     #[cfg(feature = "wasm-workflows")]
@@ -85,19 +89,63 @@ pub struct WorkflowReplayerOptions {
     pub detect_nondeterministic_futures: bool,
 
     /// Callback controlling first non-replay patch decisions.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+    #[cfg_attr(
+        docsrs,
+        builder(setters(
+            some_fn(name = __patch_activation_callback, vis = "pub(crate)"),
+            option_fn(name = __maybe_patch_activation_callback, vis = "pub(crate)")
+        ))
+    )]
     pub patch_activation_callback: Option<PatchActivationCallback>,
+}
+
+#[cfg(all(feature = "experimental", docsrs))]
+impl<S: workflow_replayer_options_builder::State> WorkflowReplayerOptionsBuilder<S> {
+    /// Set the callback used to decide whether a patch should activate during replay.
+    #[doc(cfg(feature = "experimental"))]
+    pub fn patch_activation_callback(
+        self,
+        value: PatchActivationCallback,
+    ) -> WorkflowReplayerOptionsBuilder<
+        workflow_replayer_options_builder::SetPatchActivationCallback<S>,
+    >
+    where
+        S::PatchActivationCallback: workflow_replayer_options_builder::IsUnset,
+    {
+        self.__patch_activation_callback(value)
+    }
+
+    /// Set the replay patch activation callback from an optional value.
+    #[doc(cfg(feature = "experimental"))]
+    pub fn maybe_patch_activation_callback(
+        self,
+        value: Option<PatchActivationCallback>,
+    ) -> WorkflowReplayerOptionsBuilder<
+        workflow_replayer_options_builder::SetPatchActivationCallback<S>,
+    >
+    where
+        S::PatchActivationCallback: workflow_replayer_options_builder::IsUnset,
+    {
+        self.__maybe_patch_activation_callback(value)
+    }
 }
 
 impl<S: workflow_replayer_options_builder::State> WorkflowReplayerOptionsBuilder<S> {
     /// Register a worker plugin with this replayer.
     ///
     /// **Experimental:** This API may change or be removed.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn worker_plugin<P: WorkerPlugin>(mut self, plugin: P) -> Self {
         self.worker_plugins.push(Arc::new(plugin));
         self
     }
 
     /// Append a worker interceptor used during replay.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn worker_interceptor<I: WorkerInterceptor + 'static>(mut self, interceptor: I) -> Self {
         self.worker_interceptors.push(Arc::new(interceptor));
         self
@@ -162,6 +210,8 @@ impl<S: workflow_replayer_options_builder::State> WorkflowReplayerOptionsBuilder
 
 impl WorkflowReplayerOptions {
     /// Append a worker interceptor used during replay.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn worker_interceptor<I: WorkerInterceptor + 'static>(
         &mut self,
         interceptor: I,
@@ -317,6 +367,8 @@ pub enum WorkflowReplayError {
 #[non_exhaustive]
 pub enum WorkflowReplayWorkerError {
     /// A plugin failed while configuring replay options.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[error(transparent)]
     Plugin(#[from] PluginApplyError),
     /// No workflow definitions were registered after plugin configuration.
@@ -346,7 +398,10 @@ pub struct WorkflowReplayer {
 
 impl WorkflowReplayer {
     /// Construct a replayer and apply its worker plugins.
-    pub fn new(mut options: WorkflowReplayerOptions) -> Result<Self, WorkflowReplayError> {
+    pub fn new(options: WorkflowReplayerOptions) -> Result<Self, WorkflowReplayError> {
+        #[cfg(feature = "experimental")]
+        let mut options = options;
+        #[cfg(feature = "experimental")]
         crate::plugins::apply_workflow_replayer_plugins(&mut options)
             .map_err(WorkflowReplayWorkerError::Plugin)?;
         if options.workflows.is_empty() {
@@ -479,10 +534,14 @@ impl WorkflowReplayer {
             .with_workflow_interceptor_constructors(
                 self.options.workflow_interceptor_constructors.clone(),
             )
-            .with_worker_plugins(self.options.worker_plugins.clone())
             .workflow_failure_errors(self.options.workflow_failure_errors.clone())
             .workflow_types_to_failure_errors(self.options.workflow_types_to_failure_errors.clone())
-            .detect_nondeterministic_futures(self.options.detect_nondeterministic_futures)
+            .detect_nondeterministic_futures(self.options.detect_nondeterministic_futures);
+        #[cfg(feature = "experimental")]
+        let worker_options =
+            worker_options.with_worker_plugins(self.options.worker_plugins.clone());
+        #[cfg(feature = "experimental")]
+        let worker_options = worker_options
             .maybe_patch_activation_callback(self.options.patch_activation_callback.clone());
         #[cfg(feature = "wasm-workflows")]
         let worker_options = worker_options

--- a/crates/workflow/Cargo.toml
+++ b/crates/workflow/Cargo.toml
@@ -10,6 +10,12 @@ repository = "https://github.com/temporalio/sdk-core"
 keywords = ["temporal", "workflow"]
 categories = ["development-tools"]
 
+[package.metadata.docs.rs]
+features = ["experimental"]
+
+[features]
+experimental = []
+
 [dependencies]
 anyhow = "1.0"
 bon = { workspace = true }

--- a/crates/workflow/src/component.rs
+++ b/crates/workflow/src/component.rs
@@ -2,7 +2,7 @@
 //!
 //! Everything in this module is internal SDK/component glue.
 use crate::{
-    BaseWorkflowContext, PatchActivationCallback,
+    BaseWorkflowContext, InternalPatchActivationCallback as PatchActivationCallback,
     runtime::{
         entry::WorkflowImplementation,
         guest::WorkflowInstance as RuntimeWorkflowInstance,

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -30,12 +30,14 @@ pub use temporalio_common_wasm::error::{
     ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowStartError,
     WorkflowSignalError,
 };
+#[cfg(feature = "experimental")]
+pub use workflow_context::ContinueAsNewVersioningBehavior;
 pub use workflow_context::{
     ActivityCloseTimeouts, ActivityOptions, BaseWorkflowContext, CancellableFuture,
-    ChildWorkflowOptions, ContinueAsNewOptions, ContinueAsNewVersioningBehavior,
-    ExternalWorkflowHandle, LocalActivityOptions, NexusOperationOptions, ParentWorkflowInfo,
-    RootWorkflowInfo, Signal, SignalData, StartChildWorkflowExecutionFailedCause,
-    StartedChildWorkflow, SyncWorkflowContext, TimerOptions, WorkflowContext, WorkflowContextView,
+    ChildWorkflowOptions, ContinueAsNewOptions, ExternalWorkflowHandle, LocalActivityOptions,
+    NexusOperationOptions, ParentWorkflowInfo, RootWorkflowInfo, Signal, SignalData,
+    StartChildWorkflowExecutionFailedCause, StartedChildWorkflow, SyncWorkflowContext,
+    TimerOptions, WorkflowContext, WorkflowContextView,
 };
 pub use workflows::{join, join_all, select};
 

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 
 //! Temporal workflow authoring APIs and runtime glue.
@@ -36,20 +37,25 @@ pub use temporalio_common_wasm::{
         TimeoutType, WorkflowSignalError,
     },
 };
-#[cfg(feature = "experimental")]
-pub use workflow_context::ContinueAsNewVersioningBehavior;
 pub use workflow_context::{
     ActivityCancellationType, ActivityOptions, BaseWorkflowContext, CancellableFuture,
     CancellableFutureWithReason, ChildWorkflowCancellationType, ChildWorkflowOptions,
     ContinueAsNewOptions, ExternalWorkflowHandle, LocalActivityOptions, NamespacedWorkflowInfo,
-    NexusOperationCancellationType, NexusOperationOptions, ParentClosePolicy,
-    SignalWorkflowOptions, StartChildWorkflowExecutionFailedCause, StartChildWorkflowOutput,
-    StartedChildWorkflow, StartedNexusOperation, SyncWorkflowContext, TimerOptions,
+    ParentClosePolicy, SignalWorkflowOptions, StartChildWorkflowExecutionFailedCause,
+    StartChildWorkflowOutput, StartedChildWorkflow, SyncWorkflowContext, TimerOptions,
     VersioningIntent, WaitConditionOptions, WorkflowContext, WorkflowContextView,
     WorkflowIdReusePolicy, WorkflowRandomStream, WorkflowRandomValue,
 };
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+pub use workflow_context::{
+    ContinueAsNewVersioningBehavior, NexusOperationCancellationType, NexusOperationOptions,
+    PatchActivationCallback, PatchActivationInput, StartedNexusOperation,
+};
 #[doc(hidden)]
-pub use workflow_context::{PatchActivationCallback, PatchActivationCaller};
+pub use workflow_context::{
+    PatchActivationCallback as InternalPatchActivationCallback, PatchActivationCaller,
+};
 pub use workflows::{join, join_all, select};
 
 #[macro_export]

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -47,7 +47,6 @@ pub use workflow_context::{
     WorkflowIdReusePolicy, WorkflowRandomStream, WorkflowRandomValue,
 };
 #[cfg(feature = "experimental")]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub use workflow_context::{
     ContinueAsNewVersioningBehavior, NexusOperationCancellationType, NexusOperationOptions,
     PatchActivationCallback, PatchActivationInput, StartedNexusOperation,

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -36,16 +36,17 @@ pub use temporalio_common_wasm::{
         TimeoutType, WorkflowSignalError,
     },
 };
+#[cfg(feature = "experimental")]
+pub use workflow_context::ContinueAsNewVersioningBehavior;
 pub use workflow_context::{
     ActivityCancellationType, ActivityOptions, BaseWorkflowContext, CancellableFuture,
     CancellableFutureWithReason, ChildWorkflowCancellationType, ChildWorkflowOptions,
-    ContinueAsNewOptions, ContinueAsNewVersioningBehavior, ExternalWorkflowHandle,
-    LocalActivityOptions, NamespacedWorkflowInfo, NexusOperationCancellationType,
-    NexusOperationOptions, ParentClosePolicy, SignalWorkflowOptions,
-    StartChildWorkflowExecutionFailedCause, StartChildWorkflowOutput, StartedChildWorkflow,
-    StartedNexusOperation, SyncWorkflowContext, TimerOptions, VersioningIntent,
-    WaitConditionOptions, WorkflowContext, WorkflowContextView, WorkflowIdReusePolicy,
-    WorkflowRandomStream, WorkflowRandomValue,
+    ContinueAsNewOptions, ExternalWorkflowHandle, LocalActivityOptions, NamespacedWorkflowInfo,
+    NexusOperationCancellationType, NexusOperationOptions, ParentClosePolicy,
+    SignalWorkflowOptions, StartChildWorkflowExecutionFailedCause, StartChildWorkflowOutput,
+    StartedChildWorkflow, StartedNexusOperation, SyncWorkflowContext, TimerOptions,
+    VersioningIntent, WaitConditionOptions, WorkflowContext, WorkflowContextView,
+    WorkflowIdReusePolicy, WorkflowRandomStream, WorkflowRandomValue,
 };
 #[doc(hidden)]
 pub use workflow_context::{PatchActivationCallback, PatchActivationCaller};

--- a/crates/workflow/src/runtime/model.rs
+++ b/crates/workflow/src/runtime/model.rs
@@ -1,11 +1,14 @@
 //! Runtime protocol and execution model types shared by workflow code and native hosts.
 
+#[cfg(feature = "experimental")]
+mod nexus;
+#[cfg(feature = "experimental")]
+pub(crate) use nexus::NexusStartResult;
+
 use crate::{
     WorkflowCancellationError,
     runtime::types::ContinueAsNewRequest,
-    workflow_context::{
-        ChildWfCommon, NexusUnblockData, PendingChildWorkflow, StartedNexusOperation,
-    },
+    workflow_context::{ChildWfCommon, PendingChildWorkflow},
     workflow_interceptors::WorkflowOutputValue,
 };
 use temporalio_common_wasm::{
@@ -138,53 +141,6 @@ impl Unblockable for CancelExternalWfResult {
                 maybefail.map_or(Ok(CancelExternalOk), Err)
             }
             _ => panic!("Invalid unblock event for cancel external workflow result"),
-        }
-    }
-}
-
-pub(crate) type NexusStartResult = Result<StartedNexusOperation, Failure>;
-
-impl Unblockable for NexusStartResult {
-    type OtherDat = NexusUnblockData;
-
-    fn unblock(ue: UnblockEvent, od: Self::OtherDat) -> Self {
-        let NexusUnblockData {
-            result_future,
-            schedule_seq,
-            base_ctx,
-        } = od;
-        match ue {
-            UnblockEvent::NexusOperationStart(_, result) => match *result {
-                resolve_nexus_operation_start::Status::OperationToken(op_token) => {
-                    Ok(StartedNexusOperation {
-                        operation_token: Some(op_token),
-                        result_future,
-                        schedule_seq,
-                        base_ctx,
-                    })
-                }
-                resolve_nexus_operation_start::Status::StartedSync(_) => {
-                    Ok(StartedNexusOperation {
-                        operation_token: None,
-                        result_future,
-                        schedule_seq,
-                        base_ctx,
-                    })
-                }
-                resolve_nexus_operation_start::Status::Failed(f) => Err(f),
-            },
-            _ => panic!("Invalid unblock event for nexus operation"),
-        }
-    }
-}
-
-impl Unblockable for NexusOperationResult {
-    type OtherDat = ();
-
-    fn unblock(ue: UnblockEvent, _: Self::OtherDat) -> Self {
-        match ue {
-            UnblockEvent::NexusOperationComplete(_, result) => *result,
-            _ => panic!("Invalid unblock event for nexus operation complete"),
         }
     }
 }

--- a/crates/workflow/src/runtime/model/nexus.rs
+++ b/crates/workflow/src/runtime/model/nexus.rs
@@ -1,0 +1,49 @@
+use super::*;
+use crate::workflow_context::{NexusUnblockData, StartedNexusOperation};
+
+pub(crate) type NexusStartResult = Result<StartedNexusOperation, Failure>;
+
+impl Unblockable for NexusStartResult {
+    type OtherDat = NexusUnblockData;
+
+    fn unblock(ue: UnblockEvent, od: Self::OtherDat) -> Self {
+        let NexusUnblockData {
+            result_future,
+            schedule_seq,
+            base_ctx,
+        } = od;
+        match ue {
+            UnblockEvent::NexusOperationStart(_, result) => match *result {
+                resolve_nexus_operation_start::Status::OperationToken(op_token) => {
+                    Ok(StartedNexusOperation {
+                        operation_token: Some(op_token),
+                        result_future,
+                        schedule_seq,
+                        base_ctx,
+                    })
+                }
+                resolve_nexus_operation_start::Status::StartedSync(_) => {
+                    Ok(StartedNexusOperation {
+                        operation_token: None,
+                        result_future,
+                        schedule_seq,
+                        base_ctx,
+                    })
+                }
+                resolve_nexus_operation_start::Status::Failed(f) => Err(f),
+            },
+            _ => panic!("Invalid unblock event for nexus operation"),
+        }
+    }
+}
+
+impl Unblockable for NexusOperationResult {
+    type OtherDat = ();
+
+    fn unblock(ue: UnblockEvent, _: Self::OtherDat) -> Self {
+        match ue {
+            UnblockEvent::NexusOperationComplete(_, result) => *result,
+            _ => panic!("Invalid unblock event for nexus operation complete"),
+        }
+    }
+}

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -1,9 +1,10 @@
 mod options;
 
+#[cfg(feature = "experimental")]
+pub use options::ContinueAsNewVersioningBehavior;
 pub use options::{
     ActivityCloseTimeouts, ActivityOptions, ChildWorkflowOptions, ContinueAsNewOptions,
-    ContinueAsNewVersioningBehavior, LocalActivityOptions, NexusOperationOptions, Signal,
-    SignalData, TimerOptions,
+    LocalActivityOptions, NexusOperationOptions, Signal, SignalData, TimerOptions,
 };
 pub use temporalio_common_wasm::protos::coresdk::child_workflow::StartChildWorkflowExecutionFailedCause;
 
@@ -821,6 +822,7 @@ impl<W> SyncWorkflowContext<W> {
     /// Returns true if the workflow's target worker deployment version changed.
     ///
     /// This experimental signal is intended for workers using worker deployment versioning.
+    #[cfg(feature = "experimental")]
     pub fn target_worker_deployment_version_changed(&self) -> bool {
         self.base
             .inner
@@ -1198,6 +1200,7 @@ impl<W> WorkflowContext<W> {
     /// Returns true if the workflow's target worker deployment version changed.
     ///
     /// This experimental signal is intended for workers using worker deployment versioning.
+    #[cfg(feature = "experimental")]
     pub fn target_worker_deployment_version_changed(&self) -> bool {
         self.sync.target_worker_deployment_version_changed()
     }

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -1,12 +1,13 @@
 mod options;
 mod view;
 
+#[cfg(feature = "experimental")]
+pub use options::ContinueAsNewVersioningBehavior;
 pub use options::{
     ActivityCancellationType, ActivityOptions, ChildWorkflowCancellationType, ChildWorkflowOptions,
-    ContinueAsNewOptions, ContinueAsNewVersioningBehavior, LocalActivityOptions,
-    NexusOperationCancellationType, NexusOperationOptions, ParentClosePolicy,
-    SignalWorkflowOptions, TimerOptions, VersioningIntent, WaitConditionOptions,
-    WorkflowIdReusePolicy,
+    ContinueAsNewOptions, LocalActivityOptions, NexusOperationCancellationType,
+    NexusOperationOptions, ParentClosePolicy, SignalWorkflowOptions, TimerOptions,
+    VersioningIntent, WaitConditionOptions, WorkflowIdReusePolicy,
 };
 pub use temporalio_common_wasm::protos::coresdk::child_workflow::StartChildWorkflowExecutionFailedCause;
 pub use view::{NamespacedWorkflowInfo, WorkflowContextView};
@@ -1571,6 +1572,7 @@ impl<W> SyncWorkflowContext<W> {
     /// Returns true if the workflow's target worker deployment version changed.
     ///
     /// This experimental signal is intended for workers using worker deployment versioning.
+    #[cfg(feature = "experimental")]
     pub fn target_worker_deployment_version_changed(&self) -> bool {
         self.base
             .inner
@@ -2079,6 +2081,7 @@ impl<W> WorkflowContext<W> {
     /// Returns true if the workflow's target worker deployment version changed.
     ///
     /// This experimental signal is intended for workers using worker deployment versioning.
+    #[cfg(feature = "experimental")]
     pub fn target_worker_deployment_version_changed(&self) -> bool {
         self.sync.target_worker_deployment_version_changed()
     }

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -6,7 +6,6 @@ mod view;
 #[cfg(feature = "experimental")]
 pub(crate) use nexus::NexusUnblockData;
 #[cfg(feature = "experimental")]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub use nexus::StartedNexusOperation;
 pub use options::{
     ActivityCancellationType, ActivityOptions, ChildWorkflowCancellationType, ChildWorkflowOptions,
@@ -14,7 +13,6 @@ pub use options::{
     TimerOptions, VersioningIntent, WaitConditionOptions, WorkflowIdReusePolicy,
 };
 #[cfg(feature = "experimental")]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub use options::{
     ContinueAsNewVersioningBehavior, NexusOperationCancellationType, NexusOperationOptions,
 };
@@ -205,7 +203,6 @@ pub struct BaseWorkflowContext {
 }
 
 /// Input provided to a worker's patch activation callback.
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct PatchActivationInput {
@@ -216,7 +213,6 @@ pub struct PatchActivationInput {
 }
 
 /// Callback that decides whether a newly encountered patch should be activated.
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub type PatchActivationCallback =
     Arc<dyn Fn(PatchActivationInput) -> bool + Send + Sync + 'static>;
 
@@ -1524,7 +1520,6 @@ impl<W> SyncWorkflowContext<W> {
     ///
     /// This experimental signal is intended for workers using worker deployment versioning.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn target_worker_deployment_version_changed(&self) -> bool {
         self.base
             .inner
@@ -2026,7 +2021,6 @@ impl<W> WorkflowContext<W> {
     ///
     /// This experimental signal is intended for workers using worker deployment versioning.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn target_worker_deployment_version_changed(&self) -> bool {
         self.sync.target_worker_deployment_version_changed()
     }

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -1,13 +1,22 @@
+#[cfg(feature = "experimental")]
+mod nexus;
 mod options;
 mod view;
 
 #[cfg(feature = "experimental")]
-pub use options::ContinueAsNewVersioningBehavior;
+pub(crate) use nexus::NexusUnblockData;
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+pub use nexus::StartedNexusOperation;
 pub use options::{
     ActivityCancellationType, ActivityOptions, ChildWorkflowCancellationType, ChildWorkflowOptions,
-    ContinueAsNewOptions, LocalActivityOptions, NexusOperationCancellationType,
-    NexusOperationOptions, ParentClosePolicy, SignalWorkflowOptions, TimerOptions,
-    VersioningIntent, WaitConditionOptions, WorkflowIdReusePolicy,
+    ContinueAsNewOptions, LocalActivityOptions, ParentClosePolicy, SignalWorkflowOptions,
+    TimerOptions, VersioningIntent, WaitConditionOptions, WorkflowIdReusePolicy,
+};
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+pub use options::{
+    ContinueAsNewVersioningBehavior, NexusOperationCancellationType, NexusOperationOptions,
 };
 pub use temporalio_common_wasm::protos::coresdk::child_workflow::StartChildWorkflowExecutionFailedCause;
 pub use view::{NamespacedWorkflowInfo, WorkflowContextView};
@@ -15,13 +24,13 @@ pub use view::{NamespacedWorkflowInfo, WorkflowContextView};
 use crate::{
     MemoValue, WorkflowCancellationError, WorkflowCancellationToken,
     runtime::{
-        SdkGuardedFuture, SdkWakeGuard,
+        SdkWakeGuard,
         entry::WorkflowImplementation,
         host::WorkflowHost,
         mark_intercepted_future_activation,
         model::{
-            CancelExternalWfResult, CancellableID, NexusStartResult, SignalExternalWfResult,
-            TimerResult, UnblockEvent, Unblockable, WorkflowTermination,
+            CancelExternalWfResult, CancellableID, SignalExternalWfResult, TimerResult,
+            UnblockEvent, Unblockable, WorkflowTermination,
         },
         types::WorkflowInit,
     },
@@ -29,21 +38,16 @@ use crate::{
         CancelExternalWorkflowInput, CancellableWorkflowOutboundFuture,
         ChildWorkflowOutboundResult, ContinueAsNewInput, ScheduleActivityInput,
         ScheduleLocalActivityInput, SignalWorkflowInput, SignalWorkflowResult,
-        SignalWorkflowTarget, StartChildWorkflowInput, StartChildWorkflowResult,
-        StartNexusOperationInput, StartTimerInput, WorkflowCancellationHandle, WorkflowInterceptor,
-        WorkflowInterceptorConstructor, WorkflowInterceptorContext, WorkflowNext,
-        WorkflowOutboundFuture, WorkflowOutboundValue, call_cancel_external_workflow,
-        call_continue_as_new, call_schedule_activity, call_schedule_local_activity,
-        call_signal_workflow, call_start_child_workflow, call_start_nexus_operation,
+        SignalWorkflowTarget, StartChildWorkflowInput, StartChildWorkflowResult, StartTimerInput,
+        WorkflowCancellationHandle, WorkflowInterceptor, WorkflowInterceptorConstructor,
+        WorkflowInterceptorContext, WorkflowNext, WorkflowOutboundFuture, WorkflowOutboundValue,
+        call_cancel_external_workflow, call_continue_as_new, call_schedule_activity,
+        call_schedule_local_activity, call_signal_workflow, call_start_child_workflow,
         call_start_timer,
     },
 };
 use futures_channel::oneshot;
-use futures_util::{
-    FutureExt,
-    future::{FusedFuture, Shared},
-    task::Context,
-};
+use futures_util::{FutureExt, future::FusedFuture, task::Context};
 use rand::SeedableRng;
 use rand_pcg::Pcg64Mcg;
 use siphasher::sip::SipHasher13;
@@ -79,7 +83,6 @@ use temporalio_common_wasm::{
             activity_result::{ActivityResolution, Cancellation, activity_resolution},
             child_workflow::{ChildWorkflowResult, child_workflow_result},
             common::NamespacedWorkflowExecution,
-            nexus::NexusOperationResult,
             workflow_activation::{
                 InitializeWorkflow, WorkflowActivation as CoreWorkflowActivation,
                 resolve_child_workflow_execution_start::Status as ChildWorkflowStartStatus,
@@ -202,6 +205,7 @@ pub struct BaseWorkflowContext {
 }
 
 /// Input provided to a worker's patch activation callback.
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct PatchActivationInput {
@@ -212,6 +216,7 @@ pub struct PatchActivationInput {
 }
 
 /// Callback that decides whether a newly encountered patch should be activated.
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub type PatchActivationCallback =
     Arc<dyn Fn(PatchActivationInput) -> bool + Send + Sync + 'static>;
 
@@ -711,6 +716,7 @@ impl BaseWorkflowContext {
                     next_child_workflow_sequence_number: 1,
                     next_cancel_external_wf_sequence_number: 1,
                     next_signal_external_wf_sequence_number: 1,
+                    #[cfg(feature = "experimental")]
                     next_nexus_op_sequence_number: 1,
                 }),
                 data_converter,
@@ -1383,61 +1389,6 @@ impl BaseWorkflowContext {
         );
         self.prepare_outbound_future(future)
     }
-
-    pub(crate) fn start_nexus_operation(
-        &self,
-        opts: NexusOperationOptions,
-    ) -> impl CancellableFuture<Output = NexusStartResult> {
-        let input = StartNexusOperationInput::new(opts);
-        let base_ctx = self.clone();
-        let next = WorkflowNext::new(move |input: StartNexusOperationInput| {
-            let mut opts = input.into_options();
-            let cancellation_token = opts
-                .cancellation_token
-                .take()
-                .unwrap_or_else(|| base_ctx.cancellation_token());
-            let seq = base_ctx.inner.seq_nums.borrow_mut().next_nexus_op_seq();
-            let (result_future, unblocker) =
-                CancellableWFCommandFut::new(CancellableID::NexusOp(seq), base_ctx.clone());
-            base_ctx
-                .inner
-                .runtime
-                .register_unblocker(PendingCommandId::NexusOpComplete(seq), unblocker);
-            base_ctx
-                .inner
-                .runtime
-                .host
-                .push_command(opts.into_command(seq));
-            let result_future = CancellableWorkflowOutboundFuture::new(
-                result_future,
-                base_ctx.cancellation_handle(CancellableID::NexusOp(seq)),
-            )
-            .with_cancellation_token(cancellation_token)
-            .shared();
-            let (cmd, unblocker) = CancellableWFCommandFut::new_with_dat(
-                CancellableID::NexusOp(seq),
-                NexusUnblockData {
-                    result_future: result_future.clone(),
-                    schedule_seq: seq,
-                    base_ctx: base_ctx.clone(),
-                },
-                base_ctx.clone(),
-            );
-            base_ctx
-                .inner
-                .runtime
-                .register_unblocker(PendingCommandId::NexusOpStart(seq), unblocker);
-            cancellable_outbound(cmd)
-        });
-        let interceptors = self.inner.workflow_interceptors.clone();
-        let future = call_start_nexus_operation(
-            interceptors,
-            WorkflowInterceptorContext::new(self.clone()),
-            input,
-            next,
-        );
-        self.prepare_cancellable_outbound_future(future)
-    }
 }
 
 impl<W> SyncWorkflowContext<W> {
@@ -1573,6 +1524,7 @@ impl<W> SyncWorkflowContext<W> {
     ///
     /// This experimental signal is intended for workers using worker deployment versioning.
     #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn target_worker_deployment_version_changed(&self) -> bool {
         self.base
             .inner
@@ -1919,14 +1871,6 @@ impl<W> SyncWorkflowContext<W> {
         self.base.inner.runtime.set_forced_wft_failure(with.into());
     }
 
-    /// Start a nexus operation
-    pub fn start_nexus_operation(
-        &self,
-        opts: NexusOperationOptions,
-    ) -> impl CancellableFuture<Output = NexusStartResult> {
-        self.base.start_nexus_operation(opts)
-    }
-
     /// Create a read-only view of this context.
     pub(crate) fn view(&self) -> WorkflowContextView {
         self.base.view()
@@ -2082,6 +2026,7 @@ impl<W> WorkflowContext<W> {
     ///
     /// This experimental signal is intended for workers using worker deployment versioning.
     #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn target_worker_deployment_version_changed(&self) -> bool {
         self.sync.target_worker_deployment_version_changed()
     }
@@ -2259,14 +2204,6 @@ impl<W> WorkflowContext<W> {
         self.sync.force_task_fail(with)
     }
 
-    /// Start a nexus operation
-    pub fn start_nexus_operation(
-        &self,
-        opts: NexusOperationOptions,
-    ) -> impl CancellableFuture<Output = NexusStartResult> {
-        self.sync.start_nexus_operation(opts)
-    }
-
     /// Access workflow state immutably via closure.
     ///
     /// The borrow is scoped to the closure and cannot escape, preventing
@@ -2355,6 +2292,7 @@ struct WfCtxProtectedDat {
     next_child_workflow_sequence_number: u32,
     next_cancel_external_wf_sequence_number: u32,
     next_signal_external_wf_sequence_number: u32,
+    #[cfg(feature = "experimental")]
     next_nexus_op_sequence_number: u32,
 }
 
@@ -2382,11 +2320,6 @@ impl WfCtxProtectedDat {
     fn next_signal_external_wf_seq(&mut self) -> u32 {
         let seq = self.next_signal_external_wf_sequence_number;
         self.next_signal_external_wf_sequence_number += 1;
-        seq
-    }
-    fn next_nexus_op_seq(&mut self) -> u32 {
-        let seq = self.next_nexus_op_sequence_number;
-        self.next_nexus_op_sequence_number += 1;
         seq
     }
 }
@@ -2695,6 +2628,7 @@ impl Future for LATimerBackoffFut {
                     .expect("duration converts ok"),
                 cancellation_token: Some(self.cancellation_token.clone()),
                 summary: None,
+                #[cfg(feature = "experimental")]
                 event_group_markers: self.la_opts.event_group_markers.clone(),
             });
             self.timer_fut = Some(Box::pin(timer_f));
@@ -3352,41 +3286,6 @@ impl ExternalWorkflowHandle {
     }
 }
 
-#[derive(derive_more::Debug)]
-#[debug("StartedNexusOperation{{ operation_token: {operation_token:?} }}")]
-/// Handle to a started Nexus operation.
-pub struct StartedNexusOperation {
-    /// The operation token, if the operation started asynchronously
-    pub operation_token: Option<String>,
-    #[debug(skip)]
-    pub(crate) result_future: Shared<CancellableWorkflowOutboundFuture<NexusOperationResult>>,
-    pub(crate) schedule_seq: u32,
-    #[debug(skip)]
-    pub(crate) base_ctx: BaseWorkflowContext,
-}
-
-pub(crate) struct NexusUnblockData {
-    pub(crate) result_future: Shared<CancellableWorkflowOutboundFuture<NexusOperationResult>>,
-    pub(crate) schedule_seq: u32,
-    pub(crate) base_ctx: BaseWorkflowContext,
-}
-
-impl StartedNexusOperation {
-    /// Wait for the operation result.
-    pub async fn result(&self) -> NexusOperationResult {
-        // The result future is a `Shared`; poll it inside an `SdkWakeGuard` (via
-        // `SdkGuardedFuture`) so its internal waker machinery isn't mistaken for a non-SDK wake on
-        // replay (which would fail the workflow task with TMPRL1100).
-        SdkGuardedFuture(self.result_future.clone()).await
-    }
-
-    /// Request cancellation of the operation.
-    pub fn cancel(&self) {
-        self.base_ctx
-            .cancel(CancellableID::NexusOp(self.schedule_seq));
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3401,23 +3300,18 @@ mod tests {
         time::Duration,
     };
     use temporalio_common_wasm::{
-        RetryPolicy,
         data_converters::{TemporalDeserializable, TemporalSerializable},
         error::OutgoingWorkflowError,
         protos::{
             coresdk::{
                 AsJsonPayloadExt, FromJsonPayloadExt,
                 common::VersioningIntent as ProtoVersioningIntent,
-                workflow_activation::{
-                    ResolveChildWorkflowExecutionStartSuccess, UpdateRandomSeed,
-                    WorkflowActivationJob, resolve_nexus_operation_start,
-                },
+                workflow_activation::{UpdateRandomSeed, WorkflowActivationJob},
                 workflow_commands::WorkflowCommand,
             },
             temporal::api::{
-                common::v1::{Payload, RetryPolicy as ProtoRetryPolicy},
+                common::v1::Payload,
                 enums::v1::ContinueAsNewVersioningBehavior as ProtoContinueAsNewVersioningBehavior,
-                sdk::v1::{EventGroupMarker, event_group_marker},
             },
         },
     };
@@ -3487,17 +3381,6 @@ mod tests {
         #[signal]
         fn test_signal(&mut self, _ctx: &mut SyncWorkflowContext<Self>, _input: String) {
             unreachable!("test workflow signal should not be dispatched")
-        }
-    }
-
-    struct TestActivity;
-
-    impl ActivityDefinition for TestActivity {
-        type Input = ();
-        type Output = ();
-
-        fn name(&self) -> &str {
-            "test_activity"
         }
     }
 
@@ -3622,295 +3505,319 @@ mod tests {
         assert_eq!(timer.seq, 1);
     }
 
-    #[test]
-    fn custom_token_cancels_command_backed_operations() {
-        let host = Rc::new(RecordingHost::default());
-        let init = WorkflowInit {
-            namespace: "default".to_string(),
-            task_queue: "task-queue".to_string(),
-            run_id: "run-id".to_string(),
-            initialize_workflow: InitializeWorkflow {
-                workflow_type: TestWorkflow.name().to_string(),
-                ..Default::default()
+    #[cfg(feature = "experimental")]
+    mod experimental_operation_tests {
+        use super::*;
+        use temporalio_common_wasm::protos::{
+            coresdk::workflow_activation::{
+                ResolveChildWorkflowExecutionStartSuccess, resolve_nexus_operation_start,
             },
+            temporal::api::sdk::v1::{EventGroupMarker, event_group_marker},
         };
-        let base = BaseWorkflowContext::from_raw(
-            init,
-            DataConverter::default(),
-            host.clone(),
-            None,
-            Vec::new(),
-        );
-        let token = WorkflowCancellationToken::new();
 
-        let timer = base.timer(TimerOptions {
-            duration: Duration::from_secs(1),
-            cancellation_token: Some(token.clone()),
-            summary: None,
-            event_group_markers: vec![],
-        });
+        struct TestActivity;
 
-        let mut activity_options = ActivityOptions::start_to_close_timeout(Duration::from_secs(1));
-        activity_options.cancellation_token = Some(token.clone());
-        let activity = base.execute_activity(TestActivity, (), activity_options);
+        impl ActivityDefinition for TestActivity {
+            type Input = ();
+            type Output = ();
 
-        let mut local_activity_options = LocalActivityOptions {
-            schedule_to_close_timeout: Some(Duration::from_secs(1)),
-            ..Default::default()
-        };
-        local_activity_options.cancellation_token = Some(token.clone());
-        let local_activity = base.execute_local_activity(TestActivity, (), local_activity_options);
+            fn name(&self) -> &str {
+                "test_activity"
+            }
+        }
 
-        let child_options = ChildWorkflowOptions {
-            cancellation_token: Some(token.clone()),
-            ..Default::default()
-        };
-        let child = base.start_child_workflow(TestWorkflow::run, 1, child_options);
+        #[test]
+        fn custom_token_cancels_command_backed_operations() {
+            let host = Rc::new(RecordingHost::default());
+            let init = WorkflowInit {
+                namespace: "default".to_string(),
+                task_queue: "task-queue".to_string(),
+                run_id: "run-id".to_string(),
+                initialize_workflow: InitializeWorkflow {
+                    workflow_type: TestWorkflow.name().to_string(),
+                    ..Default::default()
+                },
+            };
+            let base = BaseWorkflowContext::from_raw(
+                init,
+                DataConverter::default(),
+                host.clone(),
+                None,
+                Vec::new(),
+            );
+            let token = WorkflowCancellationToken::new();
 
-        let signal = base.external_workflow("external", None).signal(
-            TestWorkflow::test_signal,
-            "input".to_string(),
-            SignalWorkflowOptions::builder()
+            let timer = base.timer(TimerOptions {
+                duration: Duration::from_secs(1),
+                cancellation_token: Some(token.clone()),
+                summary: None,
+                event_group_markers: vec![],
+            });
+
+            let mut activity_options =
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(1));
+            activity_options.cancellation_token = Some(token.clone());
+            let activity = base.execute_activity(TestActivity, (), activity_options);
+
+            let mut local_activity_options = LocalActivityOptions {
+                schedule_to_close_timeout: Some(Duration::from_secs(1)),
+                ..Default::default()
+            };
+            local_activity_options.cancellation_token = Some(token.clone());
+            let local_activity =
+                base.execute_local_activity(TestActivity, (), local_activity_options);
+
+            let child_options = ChildWorkflowOptions {
+                cancellation_token: Some(token.clone()),
+                ..Default::default()
+            };
+            let child = base.start_child_workflow(TestWorkflow::run, 1, child_options);
+
+            let signal = base.external_workflow("external", None).signal(
+                TestWorkflow::test_signal,
+                "input".to_string(),
+                SignalWorkflowOptions::builder()
+                    .cancellation_token(token.clone())
+                    .build(),
+            );
+
+            let nexus_options = NexusOperationOptions::builder()
+                .endpoint("endpoint")
+                .service("service")
+                .operation("operation")
                 .cancellation_token(token.clone())
-                .build(),
-        );
+                .build();
+            let nexus = base.start_nexus_operation(nexus_options);
 
-        let nexus_options = NexusOperationOptions::builder()
-            .endpoint("endpoint")
-            .service("service")
-            .operation("operation")
-            .cancellation_token(token.clone())
-            .build();
-        let nexus = base.start_nexus_operation(nexus_options);
+            token.cancel_with_reason("group cancelled");
+            timer.cancel();
+            activity.cancel();
+            local_activity.cancel();
+            child.cancel_with_reason("explicit cancellation".to_string());
+            signal.cancel();
+            nexus.cancel();
 
-        token.cancel_with_reason("group cancelled");
-        timer.cancel();
-        activity.cancel();
-        local_activity.cancel();
-        child.cancel_with_reason("explicit cancellation".to_string());
-        signal.cancel();
-        nexus.cancel();
+            let commands = host.commands.borrow();
+            assert_eq!(
+                commands
+                    .iter()
+                    .filter(|command| matches!(
+                        &command.variant,
+                        Some(workflow_command::Variant::CancelTimer(_))
+                    ))
+                    .count(),
+                1
+            );
+            assert_eq!(
+                commands
+                    .iter()
+                    .filter(|command| matches!(
+                        &command.variant,
+                        Some(workflow_command::Variant::RequestCancelActivity(_))
+                    ))
+                    .count(),
+                1
+            );
+            assert_eq!(
+                commands
+                    .iter()
+                    .filter(|command| matches!(
+                        &command.variant,
+                        Some(workflow_command::Variant::RequestCancelLocalActivity(_))
+                    ))
+                    .count(),
+                1
+            );
+            let child_cancellations = commands
+                .iter()
+                .filter_map(|command| match &command.variant {
+                    Some(workflow_command::Variant::CancelChildWorkflowExecution(cancel)) => {
+                        Some(cancel)
+                    }
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(child_cancellations.len(), 1);
+            assert_eq!(child_cancellations[0].reason, "group cancelled");
+            assert_eq!(
+                commands
+                    .iter()
+                    .filter(|command| matches!(
+                        &command.variant,
+                        Some(workflow_command::Variant::CancelSignalWorkflow(_))
+                    ))
+                    .count(),
+                1
+            );
+            assert_eq!(
+                commands
+                    .iter()
+                    .filter(|command| matches!(
+                        &command.variant,
+                        Some(workflow_command::Variant::RequestCancelNexusOperation(_))
+                    ))
+                    .count(),
+                1
+            );
+        }
 
-        let commands = host.commands.borrow();
-        assert_eq!(
-            commands
-                .iter()
-                .filter(|command| matches!(
-                    &command.variant,
-                    Some(workflow_command::Variant::CancelTimer(_))
-                ))
-                .count(),
-            1
-        );
-        assert_eq!(
-            commands
-                .iter()
-                .filter(|command| matches!(
-                    &command.variant,
-                    Some(workflow_command::Variant::RequestCancelActivity(_))
-                ))
-                .count(),
-            1
-        );
-        assert_eq!(
-            commands
-                .iter()
-                .filter(|command| matches!(
-                    &command.variant,
-                    Some(workflow_command::Variant::RequestCancelLocalActivity(_))
-                ))
-                .count(),
-            1
-        );
-        let child_cancellations = commands
-            .iter()
-            .filter_map(|command| match &command.variant {
-                Some(workflow_command::Variant::CancelChildWorkflowExecution(cancel)) => {
-                    Some(cancel)
-                }
-                _ => None,
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(child_cancellations.len(), 1);
-        assert_eq!(child_cancellations[0].reason, "group cancelled");
-        assert_eq!(
-            commands
-                .iter()
-                .filter(|command| matches!(
-                    &command.variant,
-                    Some(workflow_command::Variant::CancelSignalWorkflow(_))
-                ))
-                .count(),
-            1
-        );
-        assert_eq!(
-            commands
-                .iter()
-                .filter(|command| matches!(
-                    &command.variant,
-                    Some(workflow_command::Variant::RequestCancelNexusOperation(_))
-                ))
-                .count(),
-            1
-        );
-    }
-
-    #[test]
-    fn child_and_nexus_tokens_remain_active_after_start() {
-        let host = Rc::new(RecordingHost::default());
-        let init = WorkflowInit {
-            namespace: "default".to_string(),
-            task_queue: "task-queue".to_string(),
-            run_id: "run-id".to_string(),
-            initialize_workflow: InitializeWorkflow {
-                workflow_type: TestWorkflow.name().to_string(),
-                ..Default::default()
-            },
-        };
-        let base = BaseWorkflowContext::from_raw(
-            init,
-            DataConverter::default(),
-            host.clone(),
-            None,
-            Vec::new(),
-        );
-
-        let child_token = WorkflowCancellationToken::new();
-        let child_options = ChildWorkflowOptions {
-            cancellation_token: Some(child_token.clone()),
-            ..Default::default()
-        };
-        let child = base.start_child_workflow(TestWorkflow::run, 1, child_options);
-        base.unblock(UnblockEvent::WorkflowStart(
-            1,
-            Box::new(ChildWorkflowStartStatus::Succeeded(
-                ResolveChildWorkflowExecutionStartSuccess {
-                    run_id: "child-run".to_string(),
+        #[test]
+        fn child_and_nexus_tokens_remain_active_after_start() {
+            let host = Rc::new(RecordingHost::default());
+            let init = WorkflowInit {
+                namespace: "default".to_string(),
+                task_queue: "task-queue".to_string(),
+                run_id: "run-id".to_string(),
+                initialize_workflow: InitializeWorkflow {
+                    workflow_type: TestWorkflow.name().to_string(),
+                    ..Default::default()
                 },
-            )),
-        ))
-        .unwrap();
-        let started_child = child
-            .now_or_never()
-            .expect("child start should resolve")
-            .unwrap();
-        child_token.cancel();
-        started_child.cancel("explicit cancellation".to_string());
+            };
+            let base = BaseWorkflowContext::from_raw(
+                init,
+                DataConverter::default(),
+                host.clone(),
+                None,
+                Vec::new(),
+            );
 
-        let nexus_token = WorkflowCancellationToken::new();
-        let nexus_options = NexusOperationOptions::builder()
-            .endpoint("endpoint")
-            .service("service")
-            .operation("operation")
-            .cancellation_token(nexus_token.clone())
-            .build();
-        let nexus = base.start_nexus_operation(nexus_options);
-        base.unblock(UnblockEvent::NexusOperationStart(
-            1,
-            Box::new(resolve_nexus_operation_start::Status::OperationToken(
-                "operation-token".to_string(),
-            )),
-        ))
-        .unwrap();
-        let started_nexus = nexus
-            .now_or_never()
-            .expect("Nexus start should resolve")
-            .unwrap();
-        nexus_token.cancel();
-        started_nexus.cancel();
-
-        let commands = host.commands.borrow();
-        assert_eq!(
-            commands
-                .iter()
-                .filter(|command| matches!(
-                    &command.variant,
-                    Some(workflow_command::Variant::CancelChildWorkflowExecution(_))
-                ))
-                .count(),
-            1
-        );
-        assert_eq!(
-            commands
-                .iter()
-                .filter(|command| matches!(
-                    &command.variant,
-                    Some(workflow_command::Variant::RequestCancelNexusOperation(_))
-                ))
-                .count(),
-            1
-        );
-    }
-
-    #[test]
-    fn local_activity_token_cancels_retry_backoff_timer() {
-        let host = Rc::new(RecordingHost::default());
-        let init = WorkflowInit {
-            namespace: "default".to_string(),
-            task_queue: "task-queue".to_string(),
-            run_id: "run-id".to_string(),
-            initialize_workflow: InitializeWorkflow {
-                workflow_type: TestWorkflow.name().to_string(),
+            let child_token = WorkflowCancellationToken::new();
+            let child_options = ChildWorkflowOptions {
+                cancellation_token: Some(child_token.clone()),
                 ..Default::default()
-            },
-        };
-        let base = BaseWorkflowContext::from_raw(
-            init,
-            DataConverter::default(),
-            host.clone(),
-            None,
-            Vec::new(),
-        );
-        let token = WorkflowCancellationToken::new();
-        let marker = EventGroupMarker {
-            variant: Some(event_group_marker::Variant::Label(
-                event_group_marker::Label {
-                    id: "la-group".to_string(),
-                    label: Some("la-group".as_json_payload().unwrap()),
-                },
-            )),
-        };
-        let mut options = LocalActivityOptions {
-            schedule_to_close_timeout: Some(Duration::from_secs(10)),
-            event_group_markers: vec![marker.clone()],
-            ..Default::default()
-        };
-        options.cancellation_token = Some(token.clone());
-        let activity = base.execute_local_activity(TestActivity, (), options);
-        futures_util::pin_mut!(activity);
-        base.unblock(UnblockEvent::Activity(
-            1,
-            Box::new(ActivityResolution {
-                status: Some(activity_resolution::Status::Backoff(
-                    temporalio_common_wasm::protos::coresdk::activity_result::DoBackoff {
-                        attempt: 2,
-                        backoff_duration: Some(Duration::from_secs(5).try_into().unwrap()),
-                        original_schedule_time: None,
+            };
+            let child = base.start_child_workflow(TestWorkflow::run, 1, child_options);
+            base.unblock(UnblockEvent::WorkflowStart(
+                1,
+                Box::new(ChildWorkflowStartStatus::Succeeded(
+                    ResolveChildWorkflowExecutionStartSuccess {
+                        run_id: "child-run".to_string(),
                     },
                 )),
-            }),
-        ))
-        .unwrap();
+            ))
+            .unwrap();
+            let started_child = child
+                .now_or_never()
+                .expect("child start should resolve")
+                .unwrap();
+            child_token.cancel();
+            started_child.cancel("explicit cancellation".to_string());
 
-        assert!(activity.as_mut().now_or_never().is_none());
-        token.cancel();
+            let nexus_token = WorkflowCancellationToken::new();
+            let nexus_options = NexusOperationOptions::builder()
+                .endpoint("endpoint")
+                .service("service")
+                .operation("operation")
+                .cancellation_token(nexus_token.clone())
+                .build();
+            let nexus = base.start_nexus_operation(nexus_options);
+            base.unblock(UnblockEvent::NexusOperationStart(
+                1,
+                Box::new(resolve_nexus_operation_start::Status::OperationToken(
+                    "operation-token".to_string(),
+                )),
+            ))
+            .unwrap();
+            let started_nexus = nexus
+                .now_or_never()
+                .expect("Nexus start should resolve")
+                .unwrap();
+            nexus_token.cancel();
+            started_nexus.cancel();
 
-        let commands = host.commands.borrow();
-        assert!(commands.iter().any(|command| matches!(
-            &command.variant,
-            Some(workflow_command::Variant::CancelTimer(_))
-        )));
+            let commands = host.commands.borrow();
+            assert_eq!(
+                commands
+                    .iter()
+                    .filter(|command| matches!(
+                        &command.variant,
+                        Some(workflow_command::Variant::CancelChildWorkflowExecution(_))
+                    ))
+                    .count(),
+                1
+            );
+            assert_eq!(
+                commands
+                    .iter()
+                    .filter(|command| matches!(
+                        &command.variant,
+                        Some(workflow_command::Variant::RequestCancelNexusOperation(_))
+                    ))
+                    .count(),
+                1
+            );
+        }
 
-        let start_timer = commands
-            .iter()
-            .find(|command| {
-                matches!(
-                    &command.variant,
-                    Some(workflow_command::Variant::StartTimer(_))
-                )
-            })
-            .expect("backoff StartTimer is issued");
-        assert_eq!(start_timer.event_group_markers, [marker]);
+        #[test]
+        fn local_activity_token_cancels_retry_backoff_timer() {
+            let host = Rc::new(RecordingHost::default());
+            let init = WorkflowInit {
+                namespace: "default".to_string(),
+                task_queue: "task-queue".to_string(),
+                run_id: "run-id".to_string(),
+                initialize_workflow: InitializeWorkflow {
+                    workflow_type: TestWorkflow.name().to_string(),
+                    ..Default::default()
+                },
+            };
+            let base = BaseWorkflowContext::from_raw(
+                init,
+                DataConverter::default(),
+                host.clone(),
+                None,
+                Vec::new(),
+            );
+            let token = WorkflowCancellationToken::new();
+            let marker = EventGroupMarker {
+                variant: Some(event_group_marker::Variant::Label(
+                    event_group_marker::Label {
+                        id: "la-group".to_string(),
+                        label: Some("la-group".as_json_payload().unwrap()),
+                    },
+                )),
+            };
+            let mut options = LocalActivityOptions {
+                schedule_to_close_timeout: Some(Duration::from_secs(10)),
+                event_group_markers: vec![marker.clone()],
+                ..Default::default()
+            };
+            options.cancellation_token = Some(token.clone());
+            let activity = base.execute_local_activity(TestActivity, (), options);
+            futures_util::pin_mut!(activity);
+            base.unblock(UnblockEvent::Activity(
+                1,
+                Box::new(ActivityResolution {
+                    status: Some(activity_resolution::Status::Backoff(
+                        temporalio_common_wasm::protos::coresdk::activity_result::DoBackoff {
+                            attempt: 2,
+                            backoff_duration: Some(Duration::from_secs(5).try_into().unwrap()),
+                            original_schedule_time: None,
+                        },
+                    )),
+                }),
+            ))
+            .unwrap();
+
+            assert!(activity.as_mut().now_or_never().is_none());
+            token.cancel();
+
+            let commands = host.commands.borrow();
+            assert!(commands.iter().any(|command| matches!(
+                &command.variant,
+                Some(workflow_command::Variant::CancelTimer(_))
+            )));
+
+            let start_timer = commands
+                .iter()
+                .find(|command| {
+                    matches!(
+                        &command.variant,
+                        Some(workflow_command::Variant::StartTimer(_))
+                    )
+                })
+                .expect("backoff StartTimer is issued");
+            assert_eq!(start_timer.event_group_markers, [marker]);
+        }
     }
 
     #[test]
@@ -4111,48 +4018,196 @@ mod tests {
         assert_eq!(stream.random::<u64>(), expected.random::<u64>());
     }
 
-    struct MutatingRemainingOutboundInterceptor;
+    #[cfg(feature = "experimental")]
+    mod experimental_interceptor_tests {
+        use super::*;
+        use crate::workflow_interceptors::StartNexusOperationInput;
 
-    impl WorkflowInterceptor for MutatingRemainingOutboundInterceptor {
-        fn signal_workflow(
-            &self,
-            _ctx: WorkflowInterceptorContext,
-            mut input: SignalWorkflowInput,
-            next: WorkflowNext<
-                'static,
-                SignalWorkflowInput,
-                CancellableWorkflowOutboundFuture<SignalWorkflowResult>,
-            >,
-        ) -> CancellableWorkflowOutboundFuture<SignalWorkflowResult> {
-            *input.signal_name_mut() = "mutated-signal".to_string();
-            *input.input_mut::<String>().unwrap() = "mutated-input".to_string();
-            *input.target_mut() = SignalWorkflowTarget::External {
-                namespace: "mutated-namespace".to_string(),
-                workflow_id: "mutated-workflow".to_string(),
-                run_id: Some("mutated-run".to_string()),
+        struct MutatingRemainingOutboundInterceptor;
+
+        impl WorkflowInterceptor for MutatingRemainingOutboundInterceptor {
+            fn signal_workflow(
+                &self,
+                _ctx: WorkflowInterceptorContext,
+                mut input: SignalWorkflowInput,
+                next: WorkflowNext<
+                    'static,
+                    SignalWorkflowInput,
+                    CancellableWorkflowOutboundFuture<SignalWorkflowResult>,
+                >,
+            ) -> CancellableWorkflowOutboundFuture<SignalWorkflowResult> {
+                *input.signal_name_mut() = "mutated-signal".to_string();
+                *input.input_mut::<String>().unwrap() = "mutated-input".to_string();
+                *input.target_mut() = SignalWorkflowTarget::External {
+                    namespace: "mutated-namespace".to_string(),
+                    workflow_id: "mutated-workflow".to_string(),
+                    run_id: Some("mutated-run".to_string()),
+                };
+                input
+                    .headers_mut()
+                    .insert("signal-header".to_string(), Payload::default());
+                next.run(input)
+            }
+
+            fn cancel_external_workflow(
+                &self,
+                _ctx: WorkflowInterceptorContext,
+                mut input: CancelExternalWorkflowInput,
+                next: WorkflowNext<
+                    'static,
+                    CancelExternalWorkflowInput,
+                    WorkflowOutboundFuture<CancelExternalWfResult>,
+                >,
+            ) -> WorkflowOutboundFuture<CancelExternalWfResult> {
+                input.workflow_id = "mutated-cancel-workflow".to_string();
+                input.run_id = Some("mutated-cancel-run".to_string());
+                input.reason = Some("mutated-reason".to_string());
+                next.run(input)
+            }
+
+            fn continue_as_new(
+                &self,
+                _ctx: crate::workflow_interceptors::SyncWorkflowInterceptorContext,
+                mut input: ContinueAsNewInput,
+                next: WorkflowNext<
+                    'static,
+                    ContinueAsNewInput,
+                    crate::workflow_interceptors::ContinueAsNewResult,
+                >,
+            ) -> crate::workflow_interceptors::ContinueAsNewResult {
+                *input.input_mut::<u8>().unwrap() = 42;
+                input.options_mut().workflow_type = Some("mutated-workflow-type".to_string());
+                input.headers_mut().insert(
+                    "continue-header".to_string(),
+                    Payload::from(b"continue-header-value".as_slice()),
+                );
+                next.run(input)
+            }
+
+            fn start_nexus_operation(
+                &self,
+                _ctx: WorkflowInterceptorContext,
+                mut input: StartNexusOperationInput,
+                next: WorkflowNext<
+                    'static,
+                    StartNexusOperationInput,
+                    CancellableWorkflowOutboundFuture<
+                        crate::workflow_interceptors::StartNexusOperationResult,
+                    >,
+                >,
+            ) -> CancellableWorkflowOutboundFuture<
+                crate::workflow_interceptors::StartNexusOperationResult,
+            > {
+                input.options_mut().endpoint = "mutated-endpoint".to_string();
+                input.options_mut().service = "mutated-service".to_string();
+                input.options_mut().operation = "mutated-operation".to_string();
+                next.run(input)
+            }
+        }
+
+        #[test]
+        fn outbound_interceptors_mutate_signal_cancel_continue_as_new_and_nexus() {
+            let host = Rc::new(RecordingHost::default());
+            let init = InitializeWorkflow {
+                workflow_type: TestWorkflow.name().to_string(),
+                ..Default::default()
             };
-            input
-                .headers_mut()
-                .insert("signal-header".to_string(), Payload::default());
-            next.run(input)
-        }
+            let init = WorkflowInit {
+                namespace: "default".to_string(),
+                task_queue: "task-queue".to_string(),
+                run_id: "run-id".to_string(),
+                initialize_workflow: init,
+            };
+            let base = BaseWorkflowContext::from_raw(
+                init,
+                DataConverter::default(),
+                host.clone(),
+                None,
+                vec![WorkflowInterceptorConstructor::new(|_| {
+                    MutatingRemainingOutboundInterceptor
+                })],
+            );
+            let ctx = WorkflowContext::from_base(base, Rc::new(RefCell::new(TestWorkflow)));
 
-        fn cancel_external_workflow(
-            &self,
-            _ctx: WorkflowInterceptorContext,
-            mut input: CancelExternalWorkflowInput,
-            next: WorkflowNext<
-                'static,
-                CancelExternalWorkflowInput,
-                WorkflowOutboundFuture<CancelExternalWfResult>,
-            >,
-        ) -> WorkflowOutboundFuture<CancelExternalWfResult> {
-            input.workflow_id = "mutated-cancel-workflow".to_string();
-            input.run_id = Some("mutated-cancel-run".to_string());
-            input.reason = Some("mutated-reason".to_string());
-            next.run(input)
-        }
+            let signal = ctx
+                .external_workflow("original-workflow", Some("original-run".to_string()))
+                .signal(
+                    TestWorkflow::test_signal,
+                    "original-input".to_string(),
+                    Default::default(),
+                );
+            let cancel_target =
+                ctx.external_workflow("cancel-workflow", Some("cancel-run".to_string()));
+            let cancel = cancel_target.cancel(Some("original-reason".to_string()));
+            let termination = ctx
+                .continue_as_new(7, ContinueAsNewOptions::default())
+                .expect_err("continue_as_new should terminate the workflow");
+            let sync_ctx = ctx.sync_context();
+            let nexus = sync_ctx.start_nexus_operation(
+                NexusOperationOptions::builder()
+                    .endpoint("original-endpoint")
+                    .service("original-service")
+                    .operation("original-operation")
+                    .build(),
+            );
+            drop((signal, cancel, nexus));
 
+            let WorkflowTermination::ContinueAsNew(continue_as_new) = termination else {
+                panic!("expected continue-as-new termination")
+            };
+            assert_eq!(continue_as_new.workflow_type, "mutated-workflow-type");
+            assert_eq!(
+                continue_as_new.arguments,
+                vec![42u8.as_json_payload().unwrap()]
+            );
+            assert!(continue_as_new.headers.contains_key("continue-header"));
+
+            let commands = host.commands.borrow();
+            assert_eq!(commands.len(), 3);
+            let Some(workflow_command::Variant::SignalExternalWorkflowExecution(signal)) =
+                &commands[0].variant
+            else {
+                panic!("expected signal command")
+            };
+            assert_eq!(signal.signal_name, "mutated-signal");
+            assert_eq!(
+                signal.args,
+                vec!["mutated-input".to_string().as_json_payload().unwrap()]
+            );
+            assert!(signal.headers.contains_key("signal-header"));
+            let Some(signal_external_workflow_execution::Target::WorkflowExecution(target)) =
+                &signal.target
+            else {
+                panic!("expected external workflow signal target")
+            };
+            assert_eq!(target.namespace, "mutated-namespace");
+            assert_eq!(target.workflow_id, "mutated-workflow");
+            assert_eq!(target.run_id, "mutated-run");
+
+            let Some(workflow_command::Variant::RequestCancelExternalWorkflowExecution(cancel)) =
+                &commands[1].variant
+            else {
+                panic!("expected external cancellation command")
+            };
+            let target = cancel.workflow_execution.as_ref().unwrap();
+            assert_eq!(target.workflow_id, "mutated-cancel-workflow");
+            assert_eq!(target.run_id, "mutated-cancel-run");
+            assert_eq!(cancel.reason, "mutated-reason");
+
+            let Some(workflow_command::Variant::ScheduleNexusOperation(nexus)) =
+                &commands[2].variant
+            else {
+                panic!("expected Nexus operation command")
+            };
+            assert_eq!(nexus.endpoint, "mutated-endpoint");
+            assert_eq!(nexus.service, "mutated-service");
+            assert_eq!(nexus.operation, "mutated-operation");
+        }
+    }
+
+    struct HeaderAddingContinueAsNewInterceptor;
+
+    impl WorkflowInterceptor for HeaderAddingContinueAsNewInterceptor {
         fn continue_as_new(
             &self,
             _ctx: crate::workflow_interceptors::SyncWorkflowInterceptorContext,
@@ -4163,132 +4218,12 @@ mod tests {
                 crate::workflow_interceptors::ContinueAsNewResult,
             >,
         ) -> crate::workflow_interceptors::ContinueAsNewResult {
-            *input.input_mut::<u8>().unwrap() = 42;
-            input.options_mut().workflow_type = Some("mutated-workflow-type".to_string());
             input.headers_mut().insert(
                 "continue-header".to_string(),
                 Payload::from(b"continue-header-value".as_slice()),
             );
             next.run(input)
         }
-
-        fn start_nexus_operation(
-            &self,
-            _ctx: WorkflowInterceptorContext,
-            mut input: StartNexusOperationInput,
-            next: WorkflowNext<
-                'static,
-                StartNexusOperationInput,
-                CancellableWorkflowOutboundFuture<
-                    crate::workflow_interceptors::StartNexusOperationResult,
-                >,
-            >,
-        ) -> CancellableWorkflowOutboundFuture<
-            crate::workflow_interceptors::StartNexusOperationResult,
-        > {
-            input.options_mut().endpoint = "mutated-endpoint".to_string();
-            input.options_mut().service = "mutated-service".to_string();
-            input.options_mut().operation = "mutated-operation".to_string();
-            next.run(input)
-        }
-    }
-
-    #[test]
-    fn outbound_interceptors_mutate_signal_cancel_continue_as_new_and_nexus() {
-        let host = Rc::new(RecordingHost::default());
-        let init = InitializeWorkflow {
-            workflow_type: TestWorkflow.name().to_string(),
-            ..Default::default()
-        };
-        let init = WorkflowInit {
-            namespace: "default".to_string(),
-            task_queue: "task-queue".to_string(),
-            run_id: "run-id".to_string(),
-            initialize_workflow: init,
-        };
-        let base = BaseWorkflowContext::from_raw(
-            init,
-            DataConverter::default(),
-            host.clone(),
-            None,
-            vec![WorkflowInterceptorConstructor::new(|_| {
-                MutatingRemainingOutboundInterceptor
-            })],
-        );
-        let ctx = WorkflowContext::from_base(base, Rc::new(RefCell::new(TestWorkflow)));
-
-        let signal = ctx
-            .external_workflow("original-workflow", Some("original-run".to_string()))
-            .signal(
-                TestWorkflow::test_signal,
-                "original-input".to_string(),
-                Default::default(),
-            );
-        let cancel_target =
-            ctx.external_workflow("cancel-workflow", Some("cancel-run".to_string()));
-        let cancel = cancel_target.cancel(Some("original-reason".to_string()));
-        let termination = ctx
-            .continue_as_new(7, ContinueAsNewOptions::default())
-            .expect_err("continue_as_new should terminate the workflow");
-        let sync_ctx = ctx.sync_context();
-        let nexus = sync_ctx.start_nexus_operation(
-            NexusOperationOptions::builder()
-                .endpoint("original-endpoint")
-                .service("original-service")
-                .operation("original-operation")
-                .build(),
-        );
-        drop((signal, cancel, nexus));
-
-        let WorkflowTermination::ContinueAsNew(continue_as_new) = termination else {
-            panic!("expected continue-as-new termination")
-        };
-        assert_eq!(continue_as_new.workflow_type, "mutated-workflow-type");
-        assert_eq!(
-            continue_as_new.arguments,
-            vec![42u8.as_json_payload().unwrap()]
-        );
-        assert!(continue_as_new.headers.contains_key("continue-header"));
-
-        let commands = host.commands.borrow();
-        assert_eq!(commands.len(), 3);
-        let Some(workflow_command::Variant::SignalExternalWorkflowExecution(signal)) =
-            &commands[0].variant
-        else {
-            panic!("expected signal command")
-        };
-        assert_eq!(signal.signal_name, "mutated-signal");
-        assert_eq!(
-            signal.args,
-            vec!["mutated-input".to_string().as_json_payload().unwrap()]
-        );
-        assert!(signal.headers.contains_key("signal-header"));
-        let Some(signal_external_workflow_execution::Target::WorkflowExecution(target)) =
-            &signal.target
-        else {
-            panic!("expected external workflow signal target")
-        };
-        assert_eq!(target.namespace, "mutated-namespace");
-        assert_eq!(target.workflow_id, "mutated-workflow");
-        assert_eq!(target.run_id, "mutated-run");
-
-        let Some(workflow_command::Variant::RequestCancelExternalWorkflowExecution(cancel)) =
-            &commands[1].variant
-        else {
-            panic!("expected external cancellation command")
-        };
-        let target = cancel.workflow_execution.as_ref().unwrap();
-        assert_eq!(target.workflow_id, "mutated-cancel-workflow");
-        assert_eq!(target.run_id, "mutated-cancel-run");
-        assert_eq!(cancel.reason, "mutated-reason");
-
-        let Some(workflow_command::Variant::ScheduleNexusOperation(nexus)) = &commands[2].variant
-        else {
-            panic!("expected Nexus operation command")
-        };
-        assert_eq!(nexus.endpoint, "mutated-endpoint");
-        assert_eq!(nexus.service, "mutated-service");
-        assert_eq!(nexus.operation, "mutated-operation");
     }
 
     #[test]
@@ -4309,7 +4244,7 @@ mod tests {
             Rc::new(NoopHost),
             None,
             vec![WorkflowInterceptorConstructor::new(|_| {
-                MutatingRemainingOutboundInterceptor
+                HeaderAddingContinueAsNewInterceptor
             })],
         );
         let ctx = WorkflowContext::from_base(base, Rc::new(RefCell::new(TestWorkflow)));
@@ -4375,72 +4310,105 @@ mod tests {
         );
     }
 
-    #[test]
-    fn sync_workflow_context_continue_as_new_applies_options() {
-        let ctx = test_context();
-        let sync = ctx.sync_context();
-        let mut memo = MemoValues::new();
-        memo.insert("memo-key", "memo-value".to_string());
-        let mut proto_search_attributes = ProtoSearchAttributes::default();
-        proto_search_attributes.indexed_fields.insert(
-            "CustomKeywordField".to_string(),
-            Payload::from(b"value".as_slice()),
-        );
-        let search_attributes = SearchAttributes::from_proto(&proto_search_attributes);
-
-        let termination = sync
-            .continue_as_new(
-                11,
-                ContinueAsNewOptions {
-                    workflow_type: Some("next-workflow".to_string()),
-                    task_queue: Some("next-task-queue".to_string()),
-                    run_timeout: Some(Duration::from_secs(10)),
-                    task_timeout: Some(Duration::from_secs(3)),
-                    backoff_start_interval: Some(Duration::from_secs(4)),
-                    memo: Some(memo.clone()),
-                    search_attributes: Some(search_attributes.clone()),
-                    retry_policy: Some(RetryPolicy::builder().maximum_attempts(5).build()),
-                    versioning_intent: Some(ProtoVersioningIntent::Compatible.into()),
-                    initial_versioning_behavior: Some(
-                        ContinueAsNewVersioningBehavior::UseRampingVersion,
-                    ),
-                },
-            )
-            .expect_err("continue_as_new should terminate the workflow");
-        assert!(
-            matches!(termination, WorkflowTermination::ContinueAsNew(_)),
-            "expected continue-as-new termination, got {termination:?}"
-        );
-        let WorkflowTermination::ContinueAsNew(cmd) = termination else {
-            unreachable!()
+    #[cfg(feature = "experimental")]
+    mod experimental_continue_as_new_tests {
+        use super::*;
+        use temporalio_common_wasm::{
+            RetryPolicy, protos::temporal::api::common::v1::RetryPolicy as ProtoRetryPolicy,
         };
 
-        assert_eq!(
-            *cmd,
-            crate::runtime::types::ContinueAsNewRequest {
-                workflow_type: "next-workflow".to_string(),
-                task_queue: "next-task-queue".to_string(),
-                arguments: vec![11u8.as_json_payload().unwrap()],
-                workflow_run_timeout: Some(Duration::from_secs(10).try_into().unwrap()),
-                workflow_task_timeout: Some(Duration::from_secs(3).try_into().unwrap()),
-                backoff_start_interval: Some(Duration::from_secs(4).try_into().unwrap()),
-                memo: HashMap::from([(
-                    "memo-key".to_string(),
-                    "memo-value".as_json_payload().unwrap(),
-                )]),
-                headers: HashMap::new(),
-                search_attributes: Some(proto_search_attributes),
-                retry_policy: Some(ProtoRetryPolicy {
-                    initial_interval: Some(Duration::from_secs(1).try_into().unwrap()),
-                    backoff_coefficient: 2.0,
-                    maximum_attempts: 5,
-                    ..Default::default()
-                }),
-                versioning_intent: ProtoVersioningIntent::Compatible.into(),
-                initial_versioning_behavior: ProtoContinueAsNewVersioningBehavior::UseRampingVersion
-                    as i32,
-            }
-        );
+        #[test]
+        fn sync_workflow_context_continue_as_new_applies_options() {
+            let ctx = test_context();
+            let sync = ctx.sync_context();
+            let mut memo = MemoValues::new();
+            memo.insert("memo-key", "memo-value".to_string());
+            let mut proto_search_attributes = ProtoSearchAttributes::default();
+            proto_search_attributes.indexed_fields.insert(
+                "CustomKeywordField".to_string(),
+                Payload::from(b"value".as_slice()),
+            );
+            let search_attributes = SearchAttributes::from_proto(&proto_search_attributes);
+
+            let termination = sync
+                .continue_as_new(
+                    11,
+                    ContinueAsNewOptions {
+                        workflow_type: Some("next-workflow".to_string()),
+                        task_queue: Some("next-task-queue".to_string()),
+                        run_timeout: Some(Duration::from_secs(10)),
+                        task_timeout: Some(Duration::from_secs(3)),
+                        backoff_start_interval: Some(Duration::from_secs(4)),
+                        memo: Some(memo.clone()),
+                        search_attributes: Some(search_attributes.clone()),
+                        retry_policy: Some(RetryPolicy::builder().maximum_attempts(5).build()),
+                        versioning_intent: Some(ProtoVersioningIntent::Compatible.into()),
+                        initial_versioning_behavior: Some(
+                            ContinueAsNewVersioningBehavior::UseRampingVersion,
+                        ),
+                    },
+                )
+                .expect_err("continue_as_new should terminate the workflow");
+            assert!(
+                matches!(termination, WorkflowTermination::ContinueAsNew(_)),
+                "expected continue-as-new termination, got {termination:?}"
+            );
+            let WorkflowTermination::ContinueAsNew(cmd) = termination else {
+                unreachable!()
+            };
+
+            assert_eq!(
+                *cmd,
+                crate::runtime::types::ContinueAsNewRequest {
+                    workflow_type: "next-workflow".to_string(),
+                    task_queue: "next-task-queue".to_string(),
+                    arguments: vec![11u8.as_json_payload().unwrap()],
+                    workflow_run_timeout: Some(Duration::from_secs(10).try_into().unwrap()),
+                    workflow_task_timeout: Some(Duration::from_secs(3).try_into().unwrap()),
+                    backoff_start_interval: Some(Duration::from_secs(4).try_into().unwrap()),
+                    memo: HashMap::from([(
+                        "memo-key".to_string(),
+                        "memo-value".as_json_payload().unwrap(),
+                    )]),
+                    headers: HashMap::new(),
+                    search_attributes: Some(proto_search_attributes),
+                    retry_policy: Some(ProtoRetryPolicy {
+                        initial_interval: Some(Duration::from_secs(1).try_into().unwrap()),
+                        backoff_coefficient: 2.0,
+                        maximum_attempts: 5,
+                        ..Default::default()
+                    }),
+                    versioning_intent: ProtoVersioningIntent::Compatible.into(),
+                    initial_versioning_behavior:
+                        ProtoContinueAsNewVersioningBehavior::UseRampingVersion as i32,
+                }
+            );
+        }
+
+        #[test]
+        fn workflow_context_continue_as_new_applies_auto_upgrade_versioning_behavior() {
+            let ctx = test_context();
+
+            let termination = ctx
+                .continue_as_new(
+                    13,
+                    ContinueAsNewOptions {
+                        initial_versioning_behavior: Some(
+                            ContinueAsNewVersioningBehavior::AutoUpgrade,
+                        ),
+                        ..Default::default()
+                    },
+                )
+                .expect_err("continue_as_new should terminate the workflow");
+            let WorkflowTermination::ContinueAsNew(cmd) = termination else {
+                unreachable!()
+            };
+
+            assert_eq!(
+                cmd.initial_versioning_behavior,
+                ProtoContinueAsNewVersioningBehavior::AutoUpgrade as i32
+            );
+        }
     }
 
     #[test]
@@ -4464,29 +4432,6 @@ mod tests {
         assert_eq!(
             cmd.search_attributes,
             Some(ProtoSearchAttributes::default())
-        );
-    }
-
-    #[test]
-    fn workflow_context_continue_as_new_applies_auto_upgrade_versioning_behavior() {
-        let ctx = test_context();
-
-        let termination = ctx
-            .continue_as_new(
-                13,
-                ContinueAsNewOptions {
-                    initial_versioning_behavior: Some(ContinueAsNewVersioningBehavior::AutoUpgrade),
-                    ..Default::default()
-                },
-            )
-            .expect_err("continue_as_new should terminate the workflow");
-        let WorkflowTermination::ContinueAsNew(cmd) = termination else {
-            unreachable!()
-        };
-
-        assert_eq!(
-            cmd.initial_versioning_behavior,
-            ProtoContinueAsNewVersioningBehavior::AutoUpgrade as i32
         );
     }
 

--- a/crates/workflow/src/workflow_context/nexus.rs
+++ b/crates/workflow/src/workflow_context/nexus.rs
@@ -65,7 +65,6 @@ impl BaseWorkflowContext {
 
 impl<W> SyncWorkflowContext<W> {
     /// Start a Nexus operation.
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn start_nexus_operation(
         &self,
         opts: NexusOperationOptions,
@@ -76,7 +75,6 @@ impl<W> SyncWorkflowContext<W> {
 
 impl<W> WorkflowContext<W> {
     /// Start a Nexus operation.
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn start_nexus_operation(
         &self,
         opts: NexusOperationOptions,
@@ -96,7 +94,6 @@ impl WfCtxProtectedDat {
 #[derive(derive_more::Debug)]
 #[debug("StartedNexusOperation{{ operation_token: {operation_token:?} }}")]
 /// Handle to a started Nexus operation.
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub struct StartedNexusOperation {
     /// The operation token, if the operation started asynchronously
     pub operation_token: Option<String>,

--- a/crates/workflow/src/workflow_context/nexus.rs
+++ b/crates/workflow/src/workflow_context/nexus.rs
@@ -1,0 +1,130 @@
+use super::*;
+use crate::{
+    runtime::{SdkGuardedFuture, model::NexusStartResult},
+    workflow_interceptors::{StartNexusOperationInput, call_start_nexus_operation},
+};
+use futures_util::{FutureExt, future::Shared};
+use temporalio_common_wasm::protos::coresdk::nexus::NexusOperationResult;
+
+impl BaseWorkflowContext {
+    pub(crate) fn start_nexus_operation(
+        &self,
+        opts: NexusOperationOptions,
+    ) -> impl CancellableFuture<Output = NexusStartResult> {
+        let input = StartNexusOperationInput::new(opts);
+        let base_ctx = self.clone();
+        let next = WorkflowNext::new(move |input: StartNexusOperationInput| {
+            let mut opts = input.into_options();
+            let cancellation_token = opts
+                .cancellation_token
+                .take()
+                .unwrap_or_else(|| base_ctx.cancellation_token());
+            let seq = base_ctx.inner.seq_nums.borrow_mut().next_nexus_op_seq();
+            let (result_future, unblocker) =
+                CancellableWFCommandFut::new(CancellableID::NexusOp(seq), base_ctx.clone());
+            base_ctx
+                .inner
+                .runtime
+                .register_unblocker(PendingCommandId::NexusOpComplete(seq), unblocker);
+            base_ctx
+                .inner
+                .runtime
+                .host
+                .push_command(opts.into_command(seq));
+            let result_future = CancellableWorkflowOutboundFuture::new(
+                result_future,
+                base_ctx.cancellation_handle(CancellableID::NexusOp(seq)),
+            )
+            .with_cancellation_token(cancellation_token)
+            .shared();
+            let (cmd, unblocker) = CancellableWFCommandFut::new_with_dat(
+                CancellableID::NexusOp(seq),
+                NexusUnblockData {
+                    result_future: result_future.clone(),
+                    schedule_seq: seq,
+                    base_ctx: base_ctx.clone(),
+                },
+                base_ctx.clone(),
+            );
+            base_ctx
+                .inner
+                .runtime
+                .register_unblocker(PendingCommandId::NexusOpStart(seq), unblocker);
+            cancellable_outbound(cmd)
+        });
+        let interceptors = self.inner.workflow_interceptors.clone();
+        let future = call_start_nexus_operation(
+            interceptors,
+            WorkflowInterceptorContext::new(self.clone()),
+            input,
+            next,
+        );
+        self.prepare_cancellable_outbound_future(future)
+    }
+}
+
+impl<W> SyncWorkflowContext<W> {
+    /// Start a Nexus operation.
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+    pub fn start_nexus_operation(
+        &self,
+        opts: NexusOperationOptions,
+    ) -> impl CancellableFuture<Output = NexusStartResult> {
+        self.base.start_nexus_operation(opts)
+    }
+}
+
+impl<W> WorkflowContext<W> {
+    /// Start a Nexus operation.
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+    pub fn start_nexus_operation(
+        &self,
+        opts: NexusOperationOptions,
+    ) -> impl CancellableFuture<Output = NexusStartResult> {
+        self.sync.start_nexus_operation(opts)
+    }
+}
+
+impl WfCtxProtectedDat {
+    fn next_nexus_op_seq(&mut self) -> u32 {
+        let seq = self.next_nexus_op_sequence_number;
+        self.next_nexus_op_sequence_number += 1;
+        seq
+    }
+}
+
+#[derive(derive_more::Debug)]
+#[debug("StartedNexusOperation{{ operation_token: {operation_token:?} }}")]
+/// Handle to a started Nexus operation.
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+pub struct StartedNexusOperation {
+    /// The operation token, if the operation started asynchronously
+    pub operation_token: Option<String>,
+    #[debug(skip)]
+    pub(crate) result_future: Shared<CancellableWorkflowOutboundFuture<NexusOperationResult>>,
+    pub(crate) schedule_seq: u32,
+    #[debug(skip)]
+    pub(crate) base_ctx: BaseWorkflowContext,
+}
+
+pub(crate) struct NexusUnblockData {
+    pub(crate) result_future: Shared<CancellableWorkflowOutboundFuture<NexusOperationResult>>,
+    pub(crate) schedule_seq: u32,
+    pub(crate) base_ctx: BaseWorkflowContext,
+}
+
+impl StartedNexusOperation {
+    /// Wait for the operation result.
+    pub async fn result(&self) -> NexusOperationResult {
+        // The result future is a `Shared`; poll it inside an `SdkWakeGuard` (via
+        // `SdkGuardedFuture`) so its internal waker machinery isn't mistaken for a non-SDK wake on
+        // replay (which would fail the workflow task with TMPRL1100).
+        SdkGuardedFuture(self.result_future.clone()).await
+    }
+
+    /// Request cancellation of the operation.
+    pub fn cancel(&self) {
+        self.base_ctx
+            .cancel(CancellableID::NexusOp(self.schedule_seq));
+    }
+}

--- a/crates/workflow/src/workflow_context/options.rs
+++ b/crates/workflow/src/workflow_context/options.rs
@@ -1,6 +1,8 @@
 use std::{collections::HashMap, time::Duration};
 
 use crate::runtime::types::ContinueAsNewRequest;
+#[cfg(feature = "experimental")]
+use temporalio_common_wasm::protos::temporal::api::enums::v1::ContinueAsNewVersioningBehavior as ProtoContinueAsNewVersioningBehavior;
 use temporalio_common_wasm::{
     Priority,
     data_converters::{
@@ -20,10 +22,7 @@ use temporalio_common_wasm::{
         },
         temporal::api::{
             common::v1::{Payload, RetryPolicy},
-            enums::v1::{
-                ContinueAsNewVersioningBehavior as ProtoContinueAsNewVersioningBehavior,
-                WorkflowIdReusePolicy,
-            },
+            enums::v1::WorkflowIdReusePolicy,
             sdk::v1::UserMetadata,
         },
     },
@@ -494,6 +493,7 @@ impl NexusOperationOptions {
 }
 
 /// Versioning behavior to use for the first workflow task of a new continue-as-new run.
+#[cfg(feature = "experimental")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[non_exhaustive]
 pub enum ContinueAsNewVersioningBehavior {
@@ -506,6 +506,7 @@ pub enum ContinueAsNewVersioningBehavior {
     UseRampingVersion,
 }
 
+#[cfg(feature = "experimental")]
 impl From<ContinueAsNewVersioningBehavior> for ProtoContinueAsNewVersioningBehavior {
     fn from(value: ContinueAsNewVersioningBehavior) -> Self {
         match value {
@@ -522,6 +523,7 @@ impl From<ContinueAsNewVersioningBehavior> for ProtoContinueAsNewVersioningBehav
     }
 }
 
+#[cfg(feature = "experimental")]
 impl From<ProtoContinueAsNewVersioningBehavior> for ContinueAsNewVersioningBehavior {
     fn from(value: ProtoContinueAsNewVersioningBehavior) -> Self {
         match value {
@@ -570,6 +572,7 @@ pub struct ContinueAsNewOptions {
     /// This experimental option is only meaningful for workers using worker deployment
     /// versioning. `AutoUpgrade` routes the new run to the current deployment version;
     /// `UseRampingVersion` routes it to the ramping deployment version when one is configured.
+    #[cfg(feature = "experimental")]
     pub initial_versioning_behavior: Option<ContinueAsNewVersioningBehavior>,
 }
 
@@ -579,6 +582,15 @@ impl ContinueAsNewOptions {
         workflow_type: String,
         arguments: Vec<Payload>,
     ) -> ContinueAsNewRequest {
+        #[cfg(feature = "experimental")]
+        let initial_versioning_behavior = ProtoContinueAsNewVersioningBehavior::from(
+            self.initial_versioning_behavior
+                .unwrap_or(ContinueAsNewVersioningBehavior::Unspecified),
+        )
+        .into();
+        #[cfg(not(feature = "experimental"))]
+        let initial_versioning_behavior = Default::default();
+
         ContinueAsNewWorkflowExecution {
             workflow_type: self.workflow_type.unwrap_or(workflow_type),
             task_queue: self.task_queue.unwrap_or_default(),
@@ -600,11 +612,7 @@ impl ContinueAsNewOptions {
                 .versioning_intent
                 .unwrap_or(VersioningIntent::Unspecified)
                 .into(),
-            initial_versioning_behavior: ProtoContinueAsNewVersioningBehavior::from(
-                self.initial_versioning_behavior
-                    .unwrap_or(ContinueAsNewVersioningBehavior::Unspecified),
-            )
-            .into(),
+            initial_versioning_behavior,
         }
     }
 }

--- a/crates/workflow/src/workflow_context/options.rs
+++ b/crates/workflow/src/workflow_context/options.rs
@@ -16,13 +16,11 @@ use temporalio_common_wasm::{
                 ParentClosePolicy as ProtoParentClosePolicy,
             },
             common::VersioningIntent as ProtoVersioningIntent,
-            nexus::NexusOperationCancellationType as ProtoNexusOperationCancellationType,
             workflow_commands::{
                 ActivityCancellationType as ProtoActivityCancellationType,
                 ContinueAsNewWorkflowExecution, ScheduleActivity, ScheduleLocalActivity,
-                ScheduleNexusOperation, SignalExternalWorkflowExecution,
-                StartChildWorkflowExecution, StartTimer, WorkflowCommand,
-                signal_external_workflow_execution, workflow_command,
+                SignalExternalWorkflowExecution, StartChildWorkflowExecution, StartTimer,
+                WorkflowCommand, signal_external_workflow_execution, workflow_command,
             },
         },
         temporal::api::{
@@ -33,6 +31,18 @@ use temporalio_common_wasm::{
     },
     search_attributes::SearchAttributes,
 };
+
+#[cfg(feature = "experimental")]
+mod continue_as_new_versioning;
+#[cfg(feature = "experimental")]
+mod nexus;
+
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+pub use continue_as_new_versioning::ContinueAsNewVersioningBehavior;
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+pub use nexus::{NexusOperationCancellationType, NexusOperationOptions};
 
 /// Controls when activity cancellation is reported back to a workflow.
 #[derive(
@@ -231,52 +241,6 @@ impl From<ProtoVersioningIntent> for VersioningIntent {
     }
 }
 
-/// Controls when Nexus operation cancellation is reported to a workflow.
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize, serde::Deserialize,
-)]
-#[non_exhaustive]
-pub enum NexusOperationCancellationType {
-    /// Wait until cancellation has completed.
-    #[default]
-    WaitCancellationCompleted,
-    /// Do not request cancellation.
-    Abandon,
-    /// Request cancellation and report it immediately.
-    TryCancel,
-    /// Wait until the cancellation request is acknowledged.
-    WaitCancellationRequested,
-}
-
-impl From<NexusOperationCancellationType> for ProtoNexusOperationCancellationType {
-    fn from(value: NexusOperationCancellationType) -> Self {
-        match value {
-            NexusOperationCancellationType::WaitCancellationCompleted => {
-                Self::WaitCancellationCompleted
-            }
-            NexusOperationCancellationType::Abandon => Self::Abandon,
-            NexusOperationCancellationType::TryCancel => Self::TryCancel,
-            NexusOperationCancellationType::WaitCancellationRequested => {
-                Self::WaitCancellationRequested
-            }
-        }
-    }
-}
-
-impl From<ProtoNexusOperationCancellationType> for NexusOperationCancellationType {
-    fn from(value: ProtoNexusOperationCancellationType) -> Self {
-        match value {
-            ProtoNexusOperationCancellationType::WaitCancellationCompleted => {
-                Self::WaitCancellationCompleted
-            }
-            ProtoNexusOperationCancellationType::Abandon => Self::Abandon,
-            ProtoNexusOperationCancellationType::TryCancel => Self::TryCancel,
-            ProtoNexusOperationCancellationType::WaitCancellationRequested => {
-                Self::WaitCancellationRequested
-            }
-        }
-    }
-}
 /// Options for scheduling an activity
 #[derive(Debug, bon::Builder, Clone)]
 #[non_exhaustive]
@@ -326,6 +290,8 @@ pub struct ActivityOptions {
     ///
     /// **Unstable:** Event Groups are not yet implemented in the Rust SDK; this field exists
     /// only for internal test purposes. This API *will* change.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[doc(hidden)]
     #[builder(default)]
     pub event_group_markers: Vec<EventGroupMarker>,
@@ -365,6 +331,10 @@ impl ActivityOptions {
         args: Vec<Payload>,
         headers: HashMap<String, Payload>,
     ) -> WorkflowCommand {
+        #[cfg(feature = "experimental")]
+        let event_group_markers = self.event_group_markers;
+        #[cfg(not(feature = "experimental"))]
+        let event_group_markers = Vec::new();
         command_with_metadata(
             workflow_command::Variant::ScheduleActivity(ScheduleActivity {
                 seq,
@@ -396,7 +366,7 @@ impl ActivityOptions {
             }),
             self.summary,
             None,
-            self.event_group_markers,
+            event_group_markers,
         )
     }
 }
@@ -454,6 +424,8 @@ pub struct LocalActivityOptions {
     ///
     /// **Unstable:** Event Groups are not yet implemented in the Rust SDK; this field exists
     /// only for internal test purposes. This API *will* change.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[doc(hidden)]
     #[builder(default)]
     pub event_group_markers: Vec<EventGroupMarker>,
@@ -477,6 +449,10 @@ impl LocalActivityOptions {
         // activity timeouts are normalized before the command is emitted.
         self.schedule_to_close_timeout
             .get_or_insert(Duration::from_secs(100));
+        #[cfg(feature = "experimental")]
+        let event_group_markers = self.event_group_markers;
+        #[cfg(not(feature = "experimental"))]
+        let event_group_markers = Vec::new();
         command_with_metadata(
             workflow_command::Variant::ScheduleLocalActivity(ScheduleLocalActivity {
                 seq,
@@ -504,7 +480,7 @@ impl LocalActivityOptions {
             }),
             self.summary,
             None,
-            self.event_group_markers,
+            event_group_markers,
         )
     }
 }
@@ -550,6 +526,8 @@ pub struct ChildWorkflowOptions {
     ///
     /// **Unstable:** Event Groups are not yet implemented in the Rust SDK; this field exists
     /// only for internal test purposes. This API *will* change.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[doc(hidden)]
     #[builder(default)]
     pub event_group_markers: Vec<EventGroupMarker>,
@@ -571,6 +549,10 @@ impl ChildWorkflowOptions {
         headers: HashMap<String, Payload>,
         workflow_id: String,
     ) -> WorkflowCommand {
+        #[cfg(feature = "experimental")]
+        let event_group_markers = self.event_group_markers;
+        #[cfg(not(feature = "experimental"))]
+        let event_group_markers = Vec::new();
         command_with_metadata(
             workflow_command::Variant::StartChildWorkflowExecution(StartChildWorkflowExecution {
                 seq,
@@ -605,7 +587,7 @@ impl ChildWorkflowOptions {
             }),
             self.static_summary,
             self.static_details,
-            self.event_group_markers,
+            event_group_markers,
         )
     }
 }
@@ -625,6 +607,8 @@ pub struct TimerOptions {
     ///
     /// **Unstable:** Event Groups are not yet implemented in the Rust SDK; this field exists
     /// only for internal test purposes. This API *will* change.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[doc(hidden)]
     #[builder(default)]
     pub event_group_markers: Vec<EventGroupMarker>,
@@ -647,6 +631,10 @@ impl From<Duration> for TimerOptions {
 
 impl TimerOptions {
     pub(crate) fn into_command(self, seq: u32) -> WorkflowCommand {
+        #[cfg(feature = "experimental")]
+        let event_group_markers = self.event_group_markers;
+        #[cfg(not(feature = "experimental"))]
+        let event_group_markers = Vec::new();
         command_with_metadata(
             workflow_command::Variant::StartTimer(StartTimer {
                 seq,
@@ -658,7 +646,7 @@ impl TimerOptions {
             }),
             self.summary,
             None,
-            self.event_group_markers,
+            event_group_markers,
         )
     }
 }
@@ -683,6 +671,8 @@ pub struct SignalWorkflowOptions {
     ///
     /// **Unstable:** Event Groups are not yet implemented in the Rust SDK; this field exists
     /// only for internal test purposes. This API *will* change.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[doc(hidden)]
     #[builder(default)]
     pub event_group_markers: Vec<EventGroupMarker>,
@@ -697,6 +687,10 @@ impl SignalWorkflowOptions {
         headers: HashMap<String, Payload>,
         target: signal_external_workflow_execution::Target,
     ) -> WorkflowCommand {
+        #[cfg(feature = "experimental")]
+        let event_group_markers = self.event_group_markers;
+        #[cfg(not(feature = "experimental"))]
+        let event_group_markers = Vec::new();
         command_with_metadata(
             workflow_command::Variant::SignalExternalWorkflowExecution(
                 SignalExternalWorkflowExecution {
@@ -709,131 +703,8 @@ impl SignalWorkflowOptions {
             ),
             self.summary,
             None,
-            self.event_group_markers,
+            event_group_markers,
         )
-    }
-}
-
-/// Options for Nexus Operations
-#[derive(Debug, Clone, bon::Builder)]
-#[builder(on(String, into))]
-#[non_exhaustive]
-pub struct NexusOperationOptions {
-    /// Endpoint name, must exist in the endpoint registry or this command will fail.
-    pub endpoint: String,
-    /// Service name.
-    pub service: String,
-    /// Operation name.
-    pub operation: String,
-    /// Input for the operation. The server converts this into Nexus request content and the
-    /// appropriate content headers internally when sending the StartOperation request. On the
-    /// handler side, if it is also backed by Temporal, the content is transformed back to the
-    /// original Payload sent in this command.
-    pub input: Option<Payload>,
-    /// Schedule-to-close timeout for this operation.
-    /// Indicates how long the caller is willing to wait for operation completion.
-    /// Calls are retried internally by the server.
-    pub schedule_to_close_timeout: Option<Duration>,
-    /// Header to attach to the Nexus request.
-    /// Users are responsible for encrypting sensitive data in this header as it is stored in
-    /// workflow history and transmitted to external services as-is. This is useful for propagating
-    /// tracing information. Note these headers are not the same as Temporal headers on internal
-    /// activities and child workflows, these are transmitted to Nexus operations that may be
-    /// external and are not traditional payloads.
-    #[builder(default)]
-    pub nexus_header: HashMap<String, String>,
-    /// Cancellation type for the operation
-    pub cancellation_type: Option<NexusOperationCancellationType>,
-    /// Cancellation token for this operation. `None` inherits workflow cancellation.
-    pub cancellation_token: Option<WorkflowCancellationToken>,
-    /// Schedule-to-start timeout for this operation.
-    /// Indicates how long the caller is willing to wait for the operation to be started (or completed if synchronous)
-    /// by the handler. If the operation is not started within this timeout, it will fail with
-    /// TIMEOUT_TYPE_SCHEDULE_TO_START.
-    /// If not set or zero, no schedule-to-start timeout is enforced.
-    pub schedule_to_start_timeout: Option<Duration>,
-    /// Start-to-close timeout for this operation.
-    /// Indicates how long the caller is willing to wait for an asynchronous operation to complete after it has been
-    /// started. If the operation does not complete within this timeout after starting, it will fail with
-    /// TIMEOUT_TYPE_START_TO_CLOSE.
-    /// Only applies to asynchronous operations. Synchronous operations ignore this timeout.
-    /// If not set or zero, no start-to-close timeout is enforced.
-    pub start_to_close_timeout: Option<Duration>,
-}
-
-impl NexusOperationOptions {
-    pub(crate) fn into_command(self, seq: u32) -> WorkflowCommand {
-        workflow_command::Variant::ScheduleNexusOperation(ScheduleNexusOperation {
-            seq,
-            endpoint: self.endpoint,
-            service: self.service,
-            operation: self.operation,
-            input: self.input,
-            schedule_to_close_timeout: self
-                .schedule_to_close_timeout
-                .and_then(|duration| duration.try_into().ok()),
-            schedule_to_start_timeout: self
-                .schedule_to_start_timeout
-                .and_then(|duration| duration.try_into().ok()),
-            start_to_close_timeout: self
-                .start_to_close_timeout
-                .and_then(|duration| duration.try_into().ok()),
-            nexus_header: self.nexus_header,
-            cancellation_type: ProtoNexusOperationCancellationType::from(
-                self.cancellation_type
-                    .unwrap_or(NexusOperationCancellationType::WaitCancellationCompleted),
-            )
-            .into(),
-        })
-        .into()
-    }
-}
-
-/// Versioning behavior to use for the first workflow task of a new continue-as-new run.
-#[cfg(feature = "experimental")]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
-#[non_exhaustive]
-pub enum ContinueAsNewVersioningBehavior {
-    /// No initial versioning behavior was specified.
-    #[default]
-    Unspecified,
-    /// Start the new run with AutoUpgrade behavior.
-    AutoUpgrade,
-    /// Start the new run on the task queue's ramping deployment version.
-    UseRampingVersion,
-}
-
-#[cfg(feature = "experimental")]
-impl From<ContinueAsNewVersioningBehavior> for ProtoContinueAsNewVersioningBehavior {
-    fn from(value: ContinueAsNewVersioningBehavior) -> Self {
-        match value {
-            ContinueAsNewVersioningBehavior::Unspecified => {
-                ProtoContinueAsNewVersioningBehavior::Unspecified
-            }
-            ContinueAsNewVersioningBehavior::AutoUpgrade => {
-                ProtoContinueAsNewVersioningBehavior::AutoUpgrade
-            }
-            ContinueAsNewVersioningBehavior::UseRampingVersion => {
-                ProtoContinueAsNewVersioningBehavior::UseRampingVersion
-            }
-        }
-    }
-}
-
-#[cfg(feature = "experimental")]
-impl From<ProtoContinueAsNewVersioningBehavior> for ContinueAsNewVersioningBehavior {
-    fn from(value: ProtoContinueAsNewVersioningBehavior) -> Self {
-        match value {
-            ProtoContinueAsNewVersioningBehavior::Unspecified => {
-                ContinueAsNewVersioningBehavior::Unspecified
-            }
-            ProtoContinueAsNewVersioningBehavior::AutoUpgrade => {
-                ContinueAsNewVersioningBehavior::AutoUpgrade
-            }
-            ProtoContinueAsNewVersioningBehavior::UseRampingVersion => {
-                ContinueAsNewVersioningBehavior::UseRampingVersion
-            }
-        }
     }
 }
 
@@ -869,6 +740,7 @@ pub struct ContinueAsNewOptions {
     /// versioning. `AutoUpgrade` routes the new run to the current deployment version;
     /// `UseRampingVersion` routes it to the ramping deployment version when one is configured.
     #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub initial_versioning_behavior: Option<ContinueAsNewVersioningBehavior>,
 }
 
@@ -1007,10 +879,6 @@ mod tests {
             WorkflowIdReusePolicy::Unspecified
         );
         assert_eq!(VersioningIntent::default(), VersioningIntent::Unspecified);
-        assert_eq!(
-            NexusOperationCancellationType::default(),
-            NexusOperationCancellationType::WaitCancellationCompleted
-        );
     }
 
     #[test]

--- a/crates/workflow/src/workflow_context/options.rs
+++ b/crates/workflow/src/workflow_context/options.rs
@@ -38,10 +38,8 @@ mod continue_as_new_versioning;
 mod nexus;
 
 #[cfg(feature = "experimental")]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub use continue_as_new_versioning::ContinueAsNewVersioningBehavior;
 #[cfg(feature = "experimental")]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub use nexus::{NexusOperationCancellationType, NexusOperationOptions};
 
 /// Controls when activity cancellation is reported back to a workflow.
@@ -291,7 +289,6 @@ pub struct ActivityOptions {
     /// **Unstable:** Event Groups are not yet implemented in the Rust SDK; this field exists
     /// only for internal test purposes. This API *will* change.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[doc(hidden)]
     #[builder(default)]
     pub event_group_markers: Vec<EventGroupMarker>,
@@ -425,7 +422,6 @@ pub struct LocalActivityOptions {
     /// **Unstable:** Event Groups are not yet implemented in the Rust SDK; this field exists
     /// only for internal test purposes. This API *will* change.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[doc(hidden)]
     #[builder(default)]
     pub event_group_markers: Vec<EventGroupMarker>,
@@ -527,7 +523,6 @@ pub struct ChildWorkflowOptions {
     /// **Unstable:** Event Groups are not yet implemented in the Rust SDK; this field exists
     /// only for internal test purposes. This API *will* change.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[doc(hidden)]
     #[builder(default)]
     pub event_group_markers: Vec<EventGroupMarker>,
@@ -608,7 +603,6 @@ pub struct TimerOptions {
     /// **Unstable:** Event Groups are not yet implemented in the Rust SDK; this field exists
     /// only for internal test purposes. This API *will* change.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[doc(hidden)]
     #[builder(default)]
     pub event_group_markers: Vec<EventGroupMarker>,
@@ -672,7 +666,6 @@ pub struct SignalWorkflowOptions {
     /// **Unstable:** Event Groups are not yet implemented in the Rust SDK; this field exists
     /// only for internal test purposes. This API *will* change.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     #[doc(hidden)]
     #[builder(default)]
     pub event_group_markers: Vec<EventGroupMarker>,
@@ -740,7 +733,6 @@ pub struct ContinueAsNewOptions {
     /// versioning. `AutoUpgrade` routes the new run to the current deployment version;
     /// `UseRampingVersion` routes it to the ramping deployment version when one is configured.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub initial_versioning_behavior: Option<ContinueAsNewVersioningBehavior>,
 }
 

--- a/crates/workflow/src/workflow_context/options.rs
+++ b/crates/workflow/src/workflow_context/options.rs
@@ -1,6 +1,8 @@
 use std::{collections::HashMap, time::Duration};
 
 use crate::{MemoValues, WorkflowCancellationToken, runtime::types::ContinueAsNewRequest};
+#[cfg(feature = "experimental")]
+use temporalio_common_wasm::protos::temporal::api::enums::v1::ContinueAsNewVersioningBehavior as ProtoContinueAsNewVersioningBehavior;
 use temporalio_common_wasm::{
     ActivityCloseTimeouts, Priority, RetryPolicy,
     data_converters::{
@@ -25,10 +27,7 @@ use temporalio_common_wasm::{
         },
         temporal::api::{
             common::v1::Payload,
-            enums::v1::{
-                ContinueAsNewVersioningBehavior as ProtoContinueAsNewVersioningBehavior,
-                WorkflowIdReusePolicy as ProtoWorkflowIdReusePolicy,
-            },
+            enums::v1::WorkflowIdReusePolicy as ProtoWorkflowIdReusePolicy,
             sdk::v1::{EventGroupMarker, UserMetadata},
         },
     },
@@ -791,6 +790,7 @@ impl NexusOperationOptions {
 }
 
 /// Versioning behavior to use for the first workflow task of a new continue-as-new run.
+#[cfg(feature = "experimental")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[non_exhaustive]
 pub enum ContinueAsNewVersioningBehavior {
@@ -803,6 +803,7 @@ pub enum ContinueAsNewVersioningBehavior {
     UseRampingVersion,
 }
 
+#[cfg(feature = "experimental")]
 impl From<ContinueAsNewVersioningBehavior> for ProtoContinueAsNewVersioningBehavior {
     fn from(value: ContinueAsNewVersioningBehavior) -> Self {
         match value {
@@ -819,6 +820,7 @@ impl From<ContinueAsNewVersioningBehavior> for ProtoContinueAsNewVersioningBehav
     }
 }
 
+#[cfg(feature = "experimental")]
 impl From<ProtoContinueAsNewVersioningBehavior> for ContinueAsNewVersioningBehavior {
     fn from(value: ProtoContinueAsNewVersioningBehavior) -> Self {
         match value {
@@ -866,6 +868,7 @@ pub struct ContinueAsNewOptions {
     /// This experimental option is only meaningful for workers using worker deployment
     /// versioning. `AutoUpgrade` routes the new run to the current deployment version;
     /// `UseRampingVersion` routes it to the ramping deployment version when one is configured.
+    #[cfg(feature = "experimental")]
     pub initial_versioning_behavior: Option<ContinueAsNewVersioningBehavior>,
 }
 
@@ -892,6 +895,14 @@ impl ContinueAsNewOptions {
             })
             .transpose()?
             .unwrap_or_default();
+        #[cfg(feature = "experimental")]
+        let initial_versioning_behavior = ProtoContinueAsNewVersioningBehavior::from(
+            self.initial_versioning_behavior
+                .unwrap_or(ContinueAsNewVersioningBehavior::Unspecified),
+        )
+        .into();
+        #[cfg(not(feature = "experimental"))]
+        let initial_versioning_behavior = Default::default();
         Ok(ContinueAsNewWorkflowExecution {
             workflow_type: self.workflow_type.unwrap_or(workflow_type),
             task_queue: self.task_queue.unwrap_or_default(),
@@ -914,11 +925,7 @@ impl ContinueAsNewOptions {
                     .unwrap_or(VersioningIntent::Unspecified),
             )
             .into(),
-            initial_versioning_behavior: ProtoContinueAsNewVersioningBehavior::from(
-                self.initial_versioning_behavior
-                    .unwrap_or(ContinueAsNewVersioningBehavior::Unspecified),
-            )
-            .into(),
+            initial_versioning_behavior,
         })
     }
 }

--- a/crates/workflow/src/workflow_context/options/continue_as_new_versioning.rs
+++ b/crates/workflow/src/workflow_context/options/continue_as_new_versioning.rs
@@ -1,7 +1,6 @@
 use temporalio_common_wasm::protos::temporal::api::enums::v1::ContinueAsNewVersioningBehavior as ProtoContinueAsNewVersioningBehavior;
 
 /// Versioning behavior to use for the first workflow task of a new continue-as-new run.
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[non_exhaustive]
 pub enum ContinueAsNewVersioningBehavior {

--- a/crates/workflow/src/workflow_context/options/continue_as_new_versioning.rs
+++ b/crates/workflow/src/workflow_context/options/continue_as_new_versioning.rs
@@ -1,0 +1,47 @@
+use temporalio_common_wasm::protos::temporal::api::enums::v1::ContinueAsNewVersioningBehavior as ProtoContinueAsNewVersioningBehavior;
+
+/// Versioning behavior to use for the first workflow task of a new continue-as-new run.
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum ContinueAsNewVersioningBehavior {
+    /// No initial versioning behavior was specified.
+    #[default]
+    Unspecified,
+    /// Start the new run with AutoUpgrade behavior.
+    AutoUpgrade,
+    /// Start the new run on the task queue's ramping deployment version.
+    UseRampingVersion,
+}
+
+impl From<ContinueAsNewVersioningBehavior> for ProtoContinueAsNewVersioningBehavior {
+    fn from(value: ContinueAsNewVersioningBehavior) -> Self {
+        match value {
+            ContinueAsNewVersioningBehavior::Unspecified => {
+                ProtoContinueAsNewVersioningBehavior::Unspecified
+            }
+            ContinueAsNewVersioningBehavior::AutoUpgrade => {
+                ProtoContinueAsNewVersioningBehavior::AutoUpgrade
+            }
+            ContinueAsNewVersioningBehavior::UseRampingVersion => {
+                ProtoContinueAsNewVersioningBehavior::UseRampingVersion
+            }
+        }
+    }
+}
+
+impl From<ProtoContinueAsNewVersioningBehavior> for ContinueAsNewVersioningBehavior {
+    fn from(value: ProtoContinueAsNewVersioningBehavior) -> Self {
+        match value {
+            ProtoContinueAsNewVersioningBehavior::Unspecified => {
+                ContinueAsNewVersioningBehavior::Unspecified
+            }
+            ProtoContinueAsNewVersioningBehavior::AutoUpgrade => {
+                ContinueAsNewVersioningBehavior::AutoUpgrade
+            }
+            ProtoContinueAsNewVersioningBehavior::UseRampingVersion => {
+                ContinueAsNewVersioningBehavior::UseRampingVersion
+            }
+        }
+    }
+}

--- a/crates/workflow/src/workflow_context/options/nexus.rs
+++ b/crates/workflow/src/workflow_context/options/nexus.rs
@@ -1,0 +1,147 @@
+use std::{collections::HashMap, time::Duration};
+
+use crate::WorkflowCancellationToken;
+use temporalio_common_wasm::protos::{
+    coresdk::{
+        nexus::NexusOperationCancellationType as ProtoNexusOperationCancellationType,
+        workflow_commands::{ScheduleNexusOperation, WorkflowCommand, workflow_command},
+    },
+    temporal::api::common::v1::Payload,
+};
+
+/// Controls when Nexus operation cancellation is reported to a workflow.
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize, serde::Deserialize,
+)]
+#[non_exhaustive]
+pub enum NexusOperationCancellationType {
+    /// Wait until cancellation has completed.
+    #[default]
+    WaitCancellationCompleted,
+    /// Do not request cancellation.
+    Abandon,
+    /// Request cancellation and report it immediately.
+    TryCancel,
+    /// Wait until the cancellation request is acknowledged.
+    WaitCancellationRequested,
+}
+
+impl From<NexusOperationCancellationType> for ProtoNexusOperationCancellationType {
+    fn from(value: NexusOperationCancellationType) -> Self {
+        match value {
+            NexusOperationCancellationType::WaitCancellationCompleted => {
+                Self::WaitCancellationCompleted
+            }
+            NexusOperationCancellationType::Abandon => Self::Abandon,
+            NexusOperationCancellationType::TryCancel => Self::TryCancel,
+            NexusOperationCancellationType::WaitCancellationRequested => {
+                Self::WaitCancellationRequested
+            }
+        }
+    }
+}
+
+impl From<ProtoNexusOperationCancellationType> for NexusOperationCancellationType {
+    fn from(value: ProtoNexusOperationCancellationType) -> Self {
+        match value {
+            ProtoNexusOperationCancellationType::WaitCancellationCompleted => {
+                Self::WaitCancellationCompleted
+            }
+            ProtoNexusOperationCancellationType::Abandon => Self::Abandon,
+            ProtoNexusOperationCancellationType::TryCancel => Self::TryCancel,
+            ProtoNexusOperationCancellationType::WaitCancellationRequested => {
+                Self::WaitCancellationRequested
+            }
+        }
+    }
+}
+
+/// Options for Nexus Operations
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+#[derive(Debug, Clone, bon::Builder)]
+#[builder(on(String, into))]
+#[non_exhaustive]
+pub struct NexusOperationOptions {
+    /// Endpoint name, must exist in the endpoint registry or this command will fail.
+    pub endpoint: String,
+    /// Service name.
+    pub service: String,
+    /// Operation name.
+    pub operation: String,
+    /// Input for the operation. The server converts this into Nexus request content and the
+    /// appropriate content headers internally when sending the StartOperation request. On the
+    /// handler side, if it is also backed by Temporal, the content is transformed back to the
+    /// original Payload sent in this command.
+    pub input: Option<Payload>,
+    /// Schedule-to-close timeout for this operation.
+    /// Indicates how long the caller is willing to wait for operation completion.
+    /// Calls are retried internally by the server.
+    pub schedule_to_close_timeout: Option<Duration>,
+    /// Header to attach to the Nexus request.
+    /// Users are responsible for encrypting sensitive data in this header as it is stored in
+    /// workflow history and transmitted to external services as-is. This is useful for propagating
+    /// tracing information. Note these headers are not the same as Temporal headers on internal
+    /// activities and child workflows, these are transmitted to Nexus operations that may be
+    /// external and are not traditional payloads.
+    #[builder(default)]
+    pub nexus_header: HashMap<String, String>,
+    /// Cancellation type for the operation
+    pub cancellation_type: Option<NexusOperationCancellationType>,
+    /// Cancellation token for this operation. `None` inherits workflow cancellation.
+    pub cancellation_token: Option<WorkflowCancellationToken>,
+    /// Schedule-to-start timeout for this operation.
+    /// Indicates how long the caller is willing to wait for the operation to be started (or completed if synchronous)
+    /// by the handler. If the operation is not started within this timeout, it will fail with
+    /// TIMEOUT_TYPE_SCHEDULE_TO_START.
+    /// If not set or zero, no schedule-to-start timeout is enforced.
+    pub schedule_to_start_timeout: Option<Duration>,
+    /// Start-to-close timeout for this operation.
+    /// Indicates how long the caller is willing to wait for an asynchronous operation to complete after it has been
+    /// started. If the operation does not complete within this timeout after starting, it will fail with
+    /// TIMEOUT_TYPE_START_TO_CLOSE.
+    /// Only applies to asynchronous operations. Synchronous operations ignore this timeout.
+    /// If not set or zero, no start-to-close timeout is enforced.
+    pub start_to_close_timeout: Option<Duration>,
+}
+
+impl NexusOperationOptions {
+    pub(crate) fn into_command(self, seq: u32) -> WorkflowCommand {
+        workflow_command::Variant::ScheduleNexusOperation(ScheduleNexusOperation {
+            seq,
+            endpoint: self.endpoint,
+            service: self.service,
+            operation: self.operation,
+            input: self.input,
+            schedule_to_close_timeout: self
+                .schedule_to_close_timeout
+                .and_then(|duration| duration.try_into().ok()),
+            schedule_to_start_timeout: self
+                .schedule_to_start_timeout
+                .and_then(|duration| duration.try_into().ok()),
+            start_to_close_timeout: self
+                .start_to_close_timeout
+                .and_then(|duration| duration.try_into().ok()),
+            nexus_header: self.nexus_header,
+            cancellation_type: ProtoNexusOperationCancellationType::from(
+                self.cancellation_type
+                    .unwrap_or(NexusOperationCancellationType::WaitCancellationCompleted),
+            )
+            .into(),
+        })
+        .into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cancellation_defaults_to_wait_for_completion() {
+        assert_eq!(
+            NexusOperationCancellationType::default(),
+            NexusOperationCancellationType::WaitCancellationCompleted
+        );
+    }
+}

--- a/crates/workflow/src/workflow_context/options/nexus.rs
+++ b/crates/workflow/src/workflow_context/options/nexus.rs
@@ -10,7 +10,6 @@ use temporalio_common_wasm::protos::{
 };
 
 /// Controls when Nexus operation cancellation is reported to a workflow.
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize, serde::Deserialize,
 )]
@@ -58,7 +57,6 @@ impl From<ProtoNexusOperationCancellationType> for NexusOperationCancellationTyp
 }
 
 /// Options for Nexus Operations
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[derive(Debug, Clone, bon::Builder)]
 #[builder(on(String, into))]
 #[non_exhaustive]

--- a/crates/workflow/src/workflow_interceptors.rs
+++ b/crates/workflow/src/workflow_interceptors.rs
@@ -84,16 +84,12 @@
 use crate::{
     ActivityOptions, BaseWorkflowContext, CancellableFuture, CancellableFutureWithReason,
     ChildWorkflowOptions, ContinueAsNewOptions, ExternalWorkflowHandle, LocalActivityOptions,
-    NexusOperationOptions, SignalWorkflowOptions, StartChildWorkflowOutput, StartedChildWorkflow,
-    StartedNexusOperation, TimerOptions, WorkflowCancellationToken, WorkflowContextView,
-    WorkflowRandomStream,
+    SignalWorkflowOptions, StartChildWorkflowOutput, StartedChildWorkflow, TimerOptions,
+    WorkflowCancellationToken, WorkflowContextView, WorkflowRandomStream,
     cancellation::WorkflowCancellationRegistration,
     runtime::{
         entry::WorkflowError,
-        model::{
-            CancelExternalWfResult, NexusStartResult, TimerResult, WorkflowResult,
-            WorkflowTermination,
-        },
+        model::{CancelExternalWfResult, TimerResult, WorkflowResult, WorkflowTermination},
     },
 };
 use futures_util::{
@@ -122,9 +118,15 @@ use temporalio_common_wasm::{
         ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowStartError,
         WorkflowSignalError,
     },
-    protos::temporal::api::{common::v1::Payload, failure::v1::Failure},
+    protos::temporal::api::common::v1::Payload,
     search_attributes::SearchAttributes,
 };
+
+#[cfg(feature = "experimental")]
+pub(crate) use nexus::call_start_nexus_operation;
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+pub use nexus::{StartNexusOperationInput, StartNexusOperationResult};
 
 mod workflow_output_value {
     use super::*;
@@ -404,14 +406,6 @@ impl WorkflowInterceptorContext {
         run_id: Option<String>,
     ) -> ExternalWorkflowHandle {
         self.base.external_workflow(workflow_id, run_id)
-    }
-
-    /// Start a Nexus operation through the workflow outbound interceptor chain.
-    pub fn start_nexus_operation(
-        &self,
-        opts: NexusOperationOptions,
-    ) -> impl CancellableFuture<Output = NexusStartResult> {
-        self.base.start_nexus_operation(opts)
     }
 }
 
@@ -1374,32 +1368,6 @@ impl ContinueAsNewInput {
 
 typed_outbound_input!(ContinueAsNewInput);
 
-/// Input passed to [`WorkflowInterceptor::start_nexus_operation`].
-#[non_exhaustive]
-pub struct StartNexusOperationInput {
-    options: NexusOperationOptions,
-}
-
-impl StartNexusOperationInput {
-    pub(crate) fn new(options: NexusOperationOptions) -> Self {
-        Self { options }
-    }
-
-    pub(crate) fn into_options(self) -> NexusOperationOptions {
-        self.options
-    }
-
-    /// Nexus operation options.
-    pub fn options(&self) -> &NexusOperationOptions {
-        &self.options
-    }
-
-    /// Mutably access Nexus operation options.
-    pub fn options_mut(&mut self) -> &mut NexusOperationOptions {
-        &mut self.options
-    }
-}
-
 /// Result of an intercepted activity call.
 pub type ScheduleActivityResult = Result<Box<dyn WorkflowOutboundValue>, ActivityExecutionError>;
 
@@ -1412,9 +1380,6 @@ pub type SignalWorkflowResult = Result<(), WorkflowSignalError>;
 
 /// Result of an intercepted child workflow start.
 pub type StartChildWorkflowResult = Result<StartChildWorkflowOutput, ChildWorkflowStartError>;
-
-/// Result of an intercepted Nexus operation start.
-pub type StartNexusOperationResult = Result<StartedNexusOperation, Failure>;
 
 /// Result of an intercepted continue-as-new call.
 pub type ContinueAsNewResult = Result<Infallible, WorkflowTermination>;
@@ -1616,6 +1581,8 @@ pub trait WorkflowInterceptor: 'static {
     }
 
     /// Called when the workflow starts a Nexus operation.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     fn start_nexus_operation(
         &self,
         _ctx: WorkflowInterceptorContext,
@@ -1662,6 +1629,9 @@ macro_rules! outbound_chain {
         }
     };
 }
+
+#[cfg(feature = "experimental")]
+mod nexus;
 
 outbound_chain!(
     call_start_timer,
@@ -1712,14 +1682,6 @@ outbound_chain!(
     ContinueAsNewInput,
     ContinueAsNewResult
 );
-outbound_chain!(
-    call_start_nexus_operation,
-    start_nexus_operation,
-    WorkflowInterceptorContext,
-    StartNexusOperationInput,
-    CancellableWorkflowOutboundFuture<StartNexusOperationResult>
-);
-
 type WorkflowInterceptorConstructorFn =
     dyn Fn(&WorkflowContextView) -> Arc<dyn WorkflowInterceptor> + Send + Sync + 'static;
 

--- a/crates/workflow/src/workflow_interceptors.rs
+++ b/crates/workflow/src/workflow_interceptors.rs
@@ -125,7 +125,6 @@ use temporalio_common_wasm::{
 #[cfg(feature = "experimental")]
 pub(crate) use nexus::call_start_nexus_operation;
 #[cfg(feature = "experimental")]
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub use nexus::{StartNexusOperationInput, StartNexusOperationResult};
 
 mod workflow_output_value {
@@ -1582,7 +1581,6 @@ pub trait WorkflowInterceptor: 'static {
 
     /// Called when the workflow starts a Nexus operation.
     #[cfg(feature = "experimental")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     fn start_nexus_operation(
         &self,
         _ctx: WorkflowInterceptorContext,

--- a/crates/workflow/src/workflow_interceptors/nexus.rs
+++ b/crates/workflow/src/workflow_interceptors/nexus.rs
@@ -4,7 +4,6 @@ use temporalio_common_wasm::protos::temporal::api::failure::v1::Failure;
 
 impl WorkflowInterceptorContext {
     /// Start a Nexus operation through the workflow outbound interceptor chain.
-    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
     pub fn start_nexus_operation(
         &self,
         opts: NexusOperationOptions,
@@ -14,7 +13,6 @@ impl WorkflowInterceptorContext {
 }
 
 /// Input passed to [`WorkflowInterceptor::start_nexus_operation`].
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 #[non_exhaustive]
 pub struct StartNexusOperationInput {
     options: NexusOperationOptions,
@@ -41,7 +39,6 @@ impl StartNexusOperationInput {
 }
 
 /// Result of an intercepted Nexus operation start.
-#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub type StartNexusOperationResult = Result<StartedNexusOperation, Failure>;
 
 outbound_chain!(

--- a/crates/workflow/src/workflow_interceptors/nexus.rs
+++ b/crates/workflow/src/workflow_interceptors/nexus.rs
@@ -1,0 +1,53 @@
+use super::*;
+use crate::{NexusOperationOptions, StartedNexusOperation, runtime::model::NexusStartResult};
+use temporalio_common_wasm::protos::temporal::api::failure::v1::Failure;
+
+impl WorkflowInterceptorContext {
+    /// Start a Nexus operation through the workflow outbound interceptor chain.
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+    pub fn start_nexus_operation(
+        &self,
+        opts: NexusOperationOptions,
+    ) -> impl CancellableFuture<Output = NexusStartResult> {
+        self.base.start_nexus_operation(opts)
+    }
+}
+
+/// Input passed to [`WorkflowInterceptor::start_nexus_operation`].
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+#[non_exhaustive]
+pub struct StartNexusOperationInput {
+    options: NexusOperationOptions,
+}
+
+impl StartNexusOperationInput {
+    pub(crate) fn new(options: NexusOperationOptions) -> Self {
+        Self { options }
+    }
+
+    pub(crate) fn into_options(self) -> NexusOperationOptions {
+        self.options
+    }
+
+    /// Nexus operation options.
+    pub fn options(&self) -> &NexusOperationOptions {
+        &self.options
+    }
+
+    /// Mutably access Nexus operation options.
+    pub fn options_mut(&mut self) -> &mut NexusOperationOptions {
+        &mut self.options
+    }
+}
+
+/// Result of an intercepted Nexus operation start.
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+pub type StartNexusOperationResult = Result<StartedNexusOperation, Failure>;
+
+outbound_chain!(
+    call_start_nexus_operation,
+    start_nexus_operation,
+    WorkflowInterceptorContext,
+    StartNexusOperationInput,
+    CancellableWorkflowOutboundFuture<StartNexusOperationResult>
+);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Gate any API and required code marked as "experimental" behind a new `experimental` feature gate.
- Build docs with new feature enabled so APIs are discoverable
- Enable doc_cfg for docsrs so APIs that are gated behind a feature will get the little "feature" badge
- For fields that are on Bon builders we need to a little song and dance around making the bon setters crate public, and then conditionally compiling public methods that call these setters.

## Why?
Make it explicit at a language level what APIs are experimental compared to just a comment. Will allow us to do breaking changes on these APIs with a clear consciousness. 

## Checklist
<!--- add/delete as needed --->

1. Closes N/A
2. How was this tested:
Existing test suite, ensured we still check that crates compile without feature enabled in CI

3. Any docs updates needed?
Worth a mention on the Rust docs site since this is a different approach than other SDKs.
