### PR TITLE
feat(client): add update-with-start support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ relevant information.
 ### Fixed
 * The Prometheus exporter now respects `PrometheusExporterOptions::counters_total_suffix`,
   appending `_total` to counter metric names when enabled.
+* Workflow start requests now include the client's identity.
 * An activity failure caused by oversized final heartbeat details is now counted in the
   `temporal_activity_execution_failed` metric as `failure_reason="PayloadsTooLarge"`. Previously it
   was counted under the reason for the failure the activity itself reported, and was not counted at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@ relevant information.
   metrics now carry a `failure_reason` attribute. Each is now split into one time series per
   reason, which may affect existing dashboards.
 * Workflow task completions larger than the gRPC request size limit are now paginated automatically when the namespace supports it. Paginated workflow task completions require Temporal Server 1.32.0 or later.
+* Update-with-Start support: `Client::start_update_with_start_workflow` and
+  `Client::execute_update_with_start_workflow` start a workflow and send it an update in one atomic
+  operation. `WorkflowUpdateWithStartOptions` requires an ID conflict policy (use `UseExisting` to
+  attach an update to an already-running workflow), provides distinct start and update headers,
+  and controls the atomic RPC. The operation can be intercepted via
+  `ClientInterceptor::update_with_start_workflow`.
 
 ### Breaking Changes :boom:
 * The following types are now non-exhaustive: `Priority`, `WorkerDeploymentVersion`,

--- a/crates/client/src/errors.rs
+++ b/crates/client/src/errors.rs
@@ -259,10 +259,11 @@ impl WorkflowUpdateWithStartError {
             .into_iter()
             .enumerate()
             .find(|(_, op_status)| {
-                !op_status
-                    .details
-                    .iter()
-                    .any(|detail| detail.type_url.ends_with(MULTI_OPERATION_ABORTED_NAME))
+                op_status.code != Code::Ok as i32
+                    && !op_status
+                        .details
+                        .iter()
+                        .any(|detail| detail.type_url.ends_with(MULTI_OPERATION_ABORTED_NAME))
             });
         match culprit {
             Some((0, op_status)) => Self::Start(WorkflowStartError::from_status(
@@ -667,6 +668,32 @@ mod tests {
         let detail = decode_status_detail::<NotFoundFailure>(inner.details())
             .expect("operation details must be preserved");
         assert_eq!(detail.current_cluster, "here");
+    }
+
+    #[test]
+    fn update_with_start_error_skips_successful_start() {
+        let status = multi_op_status(
+            Code::NotFound,
+            vec![
+                OperationStatus {
+                    code: Code::Ok as i32,
+                    message: String::new(),
+                    details: vec![],
+                },
+                OperationStatus {
+                    code: Code::NotFound as i32,
+                    message: "update failed".to_owned(),
+                    details: vec![],
+                },
+            ],
+        );
+
+        let err = WorkflowUpdateWithStartError::from_status(status);
+        assert_matches!(
+            err,
+            WorkflowUpdateWithStartError::Update(WorkflowUpdateError::NotFound(status))
+                if status.message() == "update failed"
+        );
     }
 
     #[test]

--- a/crates/client/src/errors.rs
+++ b/crates/client/src/errors.rs
@@ -6,10 +6,16 @@ use temporalio_common::{
     data_converters::{DecodablePayloads, PayloadConversionError},
     error::{IncomingError, TimeoutType},
     protos::{
+        google::rpc::Status as RpcStatus,
         temporal::api::{
-            errordetails::v1::ActivityExecutionAlreadyStartedFailure, failure::v1::Failure,
+            errordetails::v1::{
+                ActivityExecutionAlreadyStartedFailure, MultiOperationExecutionFailure,
+                WorkflowExecutionAlreadyStartedFailure,
+                multi_operation_execution_failure::OperationStatus,
+            },
+            failure::v1::Failure,
         },
-        utilities::decode_status_detail,
+        utilities::{decode_status_detail, encode_status_details},
     },
 };
 use tonic::Code;
@@ -109,6 +115,22 @@ pub enum WorkflowStartError {
     Rpc(#[from] tonic::Status),
 }
 
+impl WorkflowStartError {
+    pub(crate) fn from_status(status: tonic::Status) -> Self {
+        if status.code() == Code::AlreadyExists {
+            let run_id =
+                decode_status_detail::<WorkflowExecutionAlreadyStartedFailure>(status.details())
+                    .map(|failure| failure.run_id);
+            Self::AlreadyStarted {
+                run_id,
+                source: status,
+            }
+        } else {
+            Self::Rpc(status)
+        }
+    }
+}
+
 /// Errors returned by query operations on [crate::WorkflowHandle].
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -178,6 +200,78 @@ impl WorkflowUpdateError {
             Self::NotFound(status)
         } else {
             Self::Rpc(status)
+        }
+    }
+}
+
+/// Errors returned by update-with-start operations
+/// (see [crate::Client::start_update_with_start_workflow]).
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum WorkflowUpdateWithStartError {
+    /// The start operation failed.
+    #[error("Workflow start failed: {0}")]
+    Start(#[source] WorkflowStartError),
+
+    /// The update operation failed, or waiting for the update result failed.
+    #[error("Workflow update failed: {0}")]
+    Update(#[source] WorkflowUpdateError),
+
+    /// Error serializing the workflow input or update arguments.
+    #[error("Payload conversion error: {0}")]
+    PayloadConversion(#[from] PayloadConversionError),
+
+    /// An RPC error from the server that could not be attributed to either operation.
+    #[error("Server error: {0}")]
+    Rpc(tonic::Status),
+
+    /// Other errors.
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+const MULTI_OPERATION_ABORTED_NAME: &str = "temporal.api.failure.v1.MultiOperationExecutionAborted";
+
+/// Reconstruct a standalone gRPC status from a multi-operation `OperationStatus`, re-encoding
+/// its details so the operation-specific failure information stays available to callers.
+fn operation_status_to_tonic(op_status: OperationStatus) -> tonic::Status {
+    let code = Code::from(op_status.code);
+    let details = encode_status_details(&RpcStatus {
+        code: op_status.code,
+        message: op_status.message.clone(),
+        details: op_status.details,
+    });
+    tonic::Status::with_details(code, op_status.message, details.into())
+}
+
+impl WorkflowUpdateWithStartError {
+    /// A multi-operation failure carries one status per operation; all operations except the
+    /// failed one are marked aborted. Attribute the error to the operation that actually failed
+    /// (index 0 is the start operation, index 1 the update).
+    pub(crate) fn from_status(status: tonic::Status) -> Self {
+        let Some(failure) =
+            decode_status_detail::<MultiOperationExecutionFailure>(status.details())
+        else {
+            return Self::Rpc(status);
+        };
+        let culprit = failure
+            .statuses
+            .into_iter()
+            .enumerate()
+            .find(|(_, op_status)| {
+                !op_status
+                    .details
+                    .iter()
+                    .any(|detail| detail.type_url.ends_with(MULTI_OPERATION_ABORTED_NAME))
+            });
+        match culprit {
+            Some((0, op_status)) => Self::Start(WorkflowStartError::from_status(
+                operation_status_to_tonic(op_status),
+            )),
+            Some((_, op_status)) => Self::Update(WorkflowUpdateError::from_status(
+                operation_status_to_tonic(op_status),
+            )),
+            None => Self::Rpc(status),
         }
     }
 }
@@ -458,5 +552,127 @@ impl From<tonic::Status> for ActivityResultError {
         } else {
             Self::Rpc(status)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+    use prost::Message;
+    use temporalio_common::protos::{
+        temporal::api::{
+            errordetails::v1::NotFoundFailure, failure::v1::MultiOperationExecutionAborted,
+        },
+        utilities::pack_any,
+    };
+
+    fn multi_op_status(code: Code, statuses: Vec<OperationStatus>) -> tonic::Status {
+        let failure = MultiOperationExecutionFailure { statuses };
+        let rpc_status = RpcStatus {
+            code: code as i32,
+            message: "multi-op failure".to_owned(),
+            details: vec![
+                pack_any(
+                    "type.googleapis.com/temporal.api.errordetails.v1.MultiOperationExecutionFailure"
+                        .to_owned(),
+                    &failure,
+                )
+                .unwrap(),
+            ],
+        };
+        tonic::Status::with_details(code, "multi-op failure", rpc_status.encode_to_vec().into())
+    }
+
+    fn aborted_status() -> OperationStatus {
+        OperationStatus {
+            code: Code::Aborted as i32,
+            message: "aborted".to_owned(),
+            details: vec![
+                pack_any(
+                    "type.googleapis.com/temporal.api.failure.v1.MultiOperationExecutionAborted"
+                        .to_owned(),
+                    &MultiOperationExecutionAborted {},
+                )
+                .unwrap(),
+            ],
+        }
+    }
+
+    #[test]
+    fn update_with_start_error_attributes_start_already_started() {
+        let status = multi_op_status(
+            Code::AlreadyExists,
+            vec![
+                OperationStatus {
+                    code: Code::AlreadyExists as i32,
+                    message: "already started".to_owned(),
+                    details: vec![
+                        pack_any(
+                            "type.googleapis.com/temporal.api.errordetails.v1.WorkflowExecutionAlreadyStartedFailure"
+                                .to_owned(),
+                            &WorkflowExecutionAlreadyStartedFailure {
+                                run_id: "existing-run".to_owned(),
+                                ..Default::default()
+                            },
+                        )
+                        .unwrap(),
+                    ],
+                },
+                aborted_status(),
+            ],
+        );
+
+        let err = WorkflowUpdateWithStartError::from_status(status);
+        assert_matches!(
+            err,
+            WorkflowUpdateWithStartError::Start(WorkflowStartError::AlreadyStarted {
+                run_id: Some(run_id),
+                ..
+            }) if run_id == "existing-run"
+        );
+    }
+
+    #[test]
+    fn update_with_start_error_attributes_update_failure() {
+        let status = multi_op_status(
+            Code::NotFound,
+            vec![
+                aborted_status(),
+                OperationStatus {
+                    code: Code::NotFound as i32,
+                    message: "no such workflow".to_owned(),
+                    details: vec![
+                        pack_any(
+                            "type.googleapis.com/temporal.api.errordetails.v1.NotFoundFailure"
+                                .to_owned(),
+                            &NotFoundFailure {
+                                current_cluster: "here".to_owned(),
+                                ..Default::default()
+                            },
+                        )
+                        .unwrap(),
+                    ],
+                },
+            ],
+        );
+
+        let err = WorkflowUpdateWithStartError::from_status(status);
+        let inner = assert_matches!(
+            err,
+            WorkflowUpdateWithStartError::Update(WorkflowUpdateError::NotFound(status)) => status
+        );
+        assert_eq!(inner.message(), "no such workflow");
+        // The operation's own failure details must survive reconstruction of the inner status.
+        let detail = decode_status_detail::<NotFoundFailure>(inner.details())
+            .expect("operation details must be preserved");
+        assert_eq!(detail.current_cluster, "here");
+    }
+
+    #[test]
+    fn update_with_start_error_without_details_is_rpc() {
+        let err =
+            WorkflowUpdateWithStartError::from_status(tonic::Status::new(Code::Internal, "boom"));
+        assert_matches!(err, WorkflowUpdateWithStartError::Rpc(status) if status.code() == Code::Internal);
     }
 }

--- a/crates/client/src/grpc.rs
+++ b/crates/client/src/grpc.rs
@@ -1342,8 +1342,22 @@ proxier! {
         ExecuteMultiOperationRequest,
         ExecuteMultiOperationResponse,
         |r| {
-            let labels = namespaced_request!(r);
-            r.extensions_mut().insert(labels);
+            let mut labels = namespaced_request!(r);
+            if let Some(execute_multi_operation_request::operation::Operation::StartWorkflow(
+                start_req,
+            )) = r
+                .get_ref()
+                .operations
+                .first()
+                .and_then(|op| op.operation.as_ref())
+            {
+                labels.task_q(start_req.task_queue.clone());
+            }
+            let exts = r.extensions_mut();
+            exts.insert(labels);
+            // Update-with-start blocks until the update reaches the requested wait stage, so it
+            // must be retried/timed out like other user long-polls.
+            exts.insert(IsUserLongPoll);
         }
     );
     (

--- a/crates/client/src/interceptors.rs
+++ b/crates/client/src/interceptors.rs
@@ -4,10 +4,10 @@ use crate::{
     ActivityHeartbeatResponse, ActivityIdentifier, WorkflowCancelOptions, WorkflowCountOptions,
     WorkflowDescribeOptions, WorkflowFetchHistoryOptions, WorkflowQueryOptions,
     WorkflowSignalOptions, WorkflowStartError, WorkflowStartOptions, WorkflowStartUpdateOptions,
-    WorkflowTerminateOptions,
+    WorkflowTerminateOptions, WorkflowUpdateWithStartOptions,
     errors::{
         AsyncActivityError, ClientError, WorkflowInteractionError, WorkflowQueryError,
-        WorkflowUpdateError,
+        WorkflowUpdateError, WorkflowUpdateWithStartError,
     },
     schedules::{
         CreateScheduleOptions, ScheduleBackfill, ScheduleError, ScheduleOverlapPolicy,
@@ -629,6 +629,114 @@ impl StartWorkflowUpdateOutput {
         Self {
             update_id: update_id.into(),
             workflow_id: workflow_id.into(),
+            run_id,
+            known_outcome,
+        }
+    }
+}
+
+/// Input to [`ClientInterceptor::update_with_start_workflow`].
+#[non_exhaustive]
+#[derive(derive_more::Debug)]
+pub struct UpdateWithStartWorkflowInput {
+    /// The workflow type sent to the server.
+    pub workflow_type: String,
+    /// Update name sent to the workflow.
+    pub update_name: String,
+    /// Options for the atomic start-and-update operation.
+    pub options: WorkflowUpdateWithStartOptions,
+    /// Controls for the multi-operation RPC.
+    pub rpc_options: crate::RpcOptions,
+    #[debug(skip)]
+    pub(crate) workflow_args: Box<dyn TemporalClientValue>,
+    #[debug(skip)]
+    pub(crate) update_args: Box<dyn TemporalClientValue>,
+}
+
+impl UpdateWithStartWorkflowInput {
+    pub(crate) fn new<WA, UA>(
+        workflow_type: String,
+        workflow_args: WA,
+        update_name: String,
+        update_args: UA,
+        mut options: WorkflowUpdateWithStartOptions,
+    ) -> Self
+    where
+        WA: TemporalSerializable + Send + 'static,
+        UA: TemporalSerializable + Send + 'static,
+    {
+        let rpc_options = std::mem::take(&mut options.rpc_options);
+        Self {
+            workflow_type,
+            update_name,
+            options,
+            rpc_options,
+            workflow_args: Box::new(workflow_args),
+            update_args: Box::new(update_args),
+        }
+    }
+
+    /// Attempt to access the workflow start arguments as a concrete type.
+    pub fn workflow_args_ref<T: Any>(&self) -> Option<&T> {
+        self.workflow_args.as_any().downcast_ref()
+    }
+
+    /// Attempt to mutably access the workflow start arguments as a concrete type.
+    pub fn workflow_args_mut<T: Any>(&mut self) -> Option<&mut T> {
+        self.workflow_args.as_any_mut().downcast_mut()
+    }
+
+    /// Replace the workflow start arguments with another serializable value.
+    pub fn replace_workflow_args<T>(&mut self, args: T)
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        self.workflow_args = Box::new(args);
+    }
+
+    /// Attempt to access the update arguments as a concrete type.
+    pub fn update_args_ref<T: Any>(&self) -> Option<&T> {
+        self.update_args.as_any().downcast_ref()
+    }
+
+    /// Attempt to mutably access the update arguments as a concrete type.
+    pub fn update_args_mut<T: Any>(&mut self) -> Option<&mut T> {
+        self.update_args.as_any_mut().downcast_mut()
+    }
+
+    /// Replace the update arguments with another serializable value.
+    pub fn replace_update_args<T>(&mut self, args: T)
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        self.update_args = Box::new(args);
+    }
+}
+
+/// Result of an intercepted update-with-start operation.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct UpdateWithStartWorkflowOutput {
+    /// Workflow ID used by the operation.
+    pub workflow_id: String,
+    /// Update ID used by the operation.
+    pub update_id: String,
+    /// Run ID associated with the update, when available.
+    pub run_id: Option<String>,
+    /// Outcome returned when the requested wait stage completed the update.
+    pub known_outcome: Option<Outcome>,
+}
+
+impl UpdateWithStartWorkflowOutput {
+    pub(crate) fn new(
+        workflow_id: impl Into<String>,
+        update_id: impl Into<String>,
+        run_id: Option<String>,
+        known_outcome: Option<Outcome>,
+    ) -> Self {
+        Self {
+            workflow_id: workflow_id.into(),
+            update_id: update_id.into(),
             run_id,
             known_outcome,
         }
@@ -1262,6 +1370,19 @@ pub trait ClientInterceptor: Send + Sync + 'static {
         next.run(input)
     }
 
+    /// Intercept an `update_with_start_workflow` operation.
+    fn update_with_start_workflow<'a>(
+        &'a self,
+        input: UpdateWithStartWorkflowInput,
+        next: Next<
+            'a,
+            UpdateWithStartWorkflowInput,
+            BoxFuture<'a, Result<UpdateWithStartWorkflowOutput, WorkflowUpdateWithStartError>>,
+        >,
+    ) -> BoxFuture<'a, Result<UpdateWithStartWorkflowOutput, WorkflowUpdateWithStartError>> {
+        next.run(input)
+    }
+
     /// Intercept a `poll_workflow_update` operation.
     fn poll_workflow_update<'a>(
         &'a self,
@@ -1518,6 +1639,13 @@ interceptor_chain!(
     start_workflow_update,
     StartWorkflowUpdateInput,
     BoxFuture<'a, Result<StartWorkflowUpdateOutput, WorkflowUpdateError>>
+);
+
+interceptor_chain!(
+    call_update_with_start_workflow,
+    update_with_start_workflow,
+    UpdateWithStartWorkflowInput,
+    BoxFuture<'a, Result<UpdateWithStartWorkflowOutput, WorkflowUpdateWithStartError>>
 );
 
 interceptor_chain!(

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -61,6 +61,7 @@ pub use interceptors::{
     SignalWithStartWorkflowInput, SignalWorkflowInput, StartWorkflowInput, StartWorkflowOutput,
     StartWorkflowUpdateInput, StartWorkflowUpdateOutput, TemporalClientValue,
     TerminateWorkflowInput, TriggerScheduleInput, UnpauseScheduleInput, UpdateScheduleInput,
+    UpdateWithStartWorkflowInput, UpdateWithStartWorkflowOutput,
 };
 pub use metrics::{LONG_REQUEST_LATENCY_HISTOGRAM_NAME, REQUEST_LATENCY_HISTOGRAM_NAME};
 pub use options_structs::*;
@@ -115,7 +116,11 @@ use crate::{
     worker::ClientWorkerSet,
 };
 use errors::*;
-use futures_util::{future::BoxFuture, stream, stream::Stream};
+use futures_util::{
+    future::{BoxFuture, try_join},
+    stream,
+    stream::Stream,
+};
 use http::Uri;
 use parking_lot::RwLock;
 use std::{
@@ -129,7 +134,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 use temporalio_common::{
-    ActivityDefinition, HasWorkflowDefinition, SignalDefinition, UntypedActivity,
+    ActivityDefinition, HasWorkflowDefinition, SignalDefinition, UntypedActivity, UpdateDefinition,
     data_converters::{DataConverter, SerializationContext, SerializationContextData},
     payload_visitor::decode_payloads,
     protos::{
@@ -138,23 +143,23 @@ use temporalio_common::{
         proto_ts_to_system_time,
         temporal::api::{
             cloud::cloudservice::v1::cloud_service_client::CloudServiceClient,
-            common::v1::{ActivityType, Payloads, WorkflowType},
+            common::v1::{ActivityType, Memo as ProtoMemo, Payloads, WorkflowType},
             enums::v1::{
                 ActivityIdConflictPolicy as ProtoActivityIdConflictPolicy,
                 ActivityIdReusePolicy as ProtoActivityIdReusePolicy, TaskQueueKind,
             },
-            errordetails::v1::WorkflowExecutionAlreadyStartedFailure,
             operatorservice::v1::operator_service_client::OperatorServiceClient,
             sdk::v1::UserMetadata,
             taskqueue::v1::TaskQueue,
             testservice::v1::test_service_client::TestServiceClient,
             workflow::v1 as workflow,
             workflowservice::v1::{
-                count_workflow_executions_response, workflow_service_client::WorkflowServiceClient,
-                *,
+                count_workflow_executions_response,
+                execute_multi_operation_request::operation::Operation as MultiOperationRequest,
+                execute_multi_operation_response::response::Response as MultiOperationResponse,
+                workflow_service_client::WorkflowServiceClient, *,
             },
         },
-        utilities::decode_status_detail,
     },
     search_attributes::{SearchAttributeError, SearchAttributeValue, SearchAttributes},
 };
@@ -1181,6 +1186,64 @@ impl Client {
         .await
     }
 
+    /// Start a workflow and send it an update as a single atomic operation.
+    ///
+    /// Returns once the update has been accepted by the workflow, yielding a
+    /// [`WorkflowUpdateHandle`] that can be used to wait for the update result.
+    pub async fn start_update_with_start_workflow<W, U>(
+        &self,
+        workflow: W,
+        workflow_input: W::Input,
+        update: U,
+        update_input: U::Input,
+        options: WorkflowUpdateWithStartOptions,
+    ) -> Result<WorkflowUpdateHandle<Self, U::Output>, WorkflowUpdateWithStartError>
+    where
+        W: HasWorkflowDefinition,
+        W::Input: Send,
+        U: UpdateDefinition<Workflow = W::Run>,
+        U::Input: Send,
+    {
+        WorkflowClientTrait::start_update_with_start_workflow(
+            self,
+            workflow,
+            workflow_input,
+            update,
+            update_input,
+            options,
+        )
+        .await
+    }
+
+    /// Start a workflow and send it an update as a single atomic operation, waiting for the
+    /// update to complete and returning its result.
+    ///
+    /// See [Client::start_update_with_start_workflow] for details on option requirements.
+    pub async fn execute_update_with_start_workflow<W, U>(
+        &self,
+        workflow: W,
+        workflow_input: W::Input,
+        update: U,
+        update_input: U::Input,
+        options: WorkflowUpdateWithStartOptions,
+    ) -> Result<U::Output, WorkflowUpdateWithStartError>
+    where
+        W: HasWorkflowDefinition,
+        W::Input: Send,
+        U: UpdateDefinition<Workflow = W::Run>,
+        U::Input: Send,
+    {
+        WorkflowClientTrait::execute_update_with_start_workflow(
+            self,
+            workflow,
+            workflow_input,
+            update,
+            update_input,
+            options,
+        )
+        .await
+    }
+
     /// Get a handle to an existing workflow.
     ///
     /// For untyped access, use `get_workflow_handle::<UntypedWorkflow>(...)`.
@@ -1361,6 +1424,40 @@ pub(crate) trait WorkflowClientTrait: NamespacedClient {
         W::Input: Send,
         S: SignalDefinition<Workflow = W::Run>,
         S::Input: Send;
+
+    /// Start a workflow and send it an update as a single atomic operation, returning once the
+    /// update reaches the requested wait stage.
+    fn start_update_with_start_workflow<W, U>(
+        &self,
+        workflow: W,
+        workflow_input: W::Input,
+        update: U,
+        update_input: U::Input,
+        options: WorkflowUpdateWithStartOptions,
+    ) -> impl Future<Output = Result<WorkflowUpdateHandle<Self, U::Output>, WorkflowUpdateWithStartError>>
+    where
+        Self: Sized,
+        W: HasWorkflowDefinition,
+        W::Input: Send,
+        U: UpdateDefinition<Workflow = W::Run>,
+        U::Input: Send;
+
+    /// Start a workflow and send it an update as a single atomic operation, waiting for the
+    /// update to complete and returning its result.
+    fn execute_update_with_start_workflow<W, U>(
+        &self,
+        workflow: W,
+        workflow_input: W::Input,
+        update: U,
+        update_input: U::Input,
+        options: WorkflowUpdateWithStartOptions,
+    ) -> impl Future<Output = Result<U::Output, WorkflowUpdateWithStartError>>
+    where
+        Self: Sized,
+        W: HasWorkflowDefinition,
+        W::Input: Send,
+        U: UpdateDefinition<Workflow = W::Run>,
+        U::Input: Send;
 
     /// Get a handle to an existing workflow. `run_id` may be left blank to specify the most recent
     /// execution having the provided `workflow_id`.
@@ -1697,6 +1794,56 @@ impl WorkflowCountAggregationGroup {
     }
 }
 
+/// Shared by `start_workflow` and update-with-start, which sends the same start request as one of
+/// its operations. `identity` is left unset because the two RPC paths populate it differently.
+fn build_start_workflow_request(
+    namespace: String,
+    workflow_type: String,
+    input: Option<Payloads>,
+    memo: Option<ProtoMemo>,
+    user_metadata: Option<UserMetadata>,
+    options: WorkflowStartOptions,
+) -> StartWorkflowExecutionRequest {
+    StartWorkflowExecutionRequest {
+        namespace,
+        input,
+        workflow_id: options.workflow_id,
+        workflow_type: Some(WorkflowType {
+            name: workflow_type,
+        }),
+        task_queue: Some(TaskQueue {
+            name: options.task_queue,
+            kind: TaskQueueKind::Unspecified as i32,
+            normal_name: String::new(),
+        }),
+        request_id: Uuid::new_v4().to_string(),
+        workflow_id_reuse_policy: options.id_reuse_policy as i32,
+        workflow_id_conflict_policy: options.id_conflict_policy as i32,
+        workflow_execution_timeout: options
+            .execution_timeout
+            .and_then(|duration| duration.try_into().ok()),
+        workflow_run_timeout: options
+            .run_timeout
+            .and_then(|duration| duration.try_into().ok()),
+        workflow_task_timeout: options
+            .task_timeout
+            .and_then(|duration| duration.try_into().ok()),
+        search_attributes: options
+            .search_attributes
+            .map(|attributes| attributes.into_proto()),
+        cron_schedule: options.cron_schedule.unwrap_or_default(),
+        request_eager_execution: options.enable_eager_workflow_start,
+        retry_policy: options.retry_policy.map(Into::into),
+        links: options.links,
+        completion_callbacks: options.completion_callbacks,
+        priority: Some(options.priority.into()),
+        memo,
+        header: options.header,
+        user_metadata,
+        ..Default::default()
+    }
+}
+
 impl<T> WorkflowClientTrait for T
 where
     T: WorkflowService + NamespacedClient + Clone + Send + Sync + 'static,
@@ -1738,75 +1885,24 @@ where
                             .await?;
                         let namespace = client.namespace();
                         let workflow_id = options.workflow_id.clone();
-                        let task_queue_name = options.task_queue.clone();
-
                         let user_metadata = options.user_metadata();
-
                         let memo = options.encoded_memo(&data_converter).await?;
-
-                        let run_id = {
-                            let mut request = StartWorkflowExecutionRequest {
-                                namespace,
-                                input: payloads.into_payloads(),
-                                workflow_id: workflow_id.clone(),
-                                workflow_type: Some(WorkflowType {
-                                    name: workflow_type,
-                                }),
-                                task_queue: Some(TaskQueue {
-                                    name: task_queue_name,
-                                    kind: TaskQueueKind::Unspecified as i32,
-                                    normal_name: String::new(),
-                                }),
-                                request_id: Uuid::new_v4().to_string(),
-                                workflow_id_reuse_policy: options.id_reuse_policy as i32,
-                                workflow_id_conflict_policy: options.id_conflict_policy as i32,
-                                workflow_execution_timeout: options
-                                    .execution_timeout
-                                    .and_then(|duration| duration.try_into().ok()),
-                                workflow_run_timeout: options
-                                    .run_timeout
-                                    .and_then(|duration| duration.try_into().ok()),
-                                workflow_task_timeout: options
-                                    .task_timeout
-                                    .and_then(|duration| duration.try_into().ok()),
-                                search_attributes: options
-                                    .search_attributes
-                                    .map(|attributes| attributes.into_proto()),
-                                cron_schedule: options.cron_schedule.unwrap_or_default(),
-                                request_eager_execution: options.enable_eager_workflow_start,
-                                retry_policy: options.retry_policy.map(Into::into),
-                                links: options.links,
-                                completion_callbacks: options.completion_callbacks,
-                                priority: Some(options.priority.into()),
-                                memo,
-                                header: options.header,
-                                user_metadata,
-                                ..Default::default()
-                            }
-                            .into_request();
-                            rpc_options.apply_to(&mut request);
-                            client
-                                .start_workflow_execution(request)
-                                .await
-                                .map_err(|status| {
-                                    if status.code() == Code::AlreadyExists {
-                                        let run_id = decode_status_detail::<
-                                            WorkflowExecutionAlreadyStartedFailure,
-                                        >(
-                                            status.details()
-                                        )
-                                        .map(|failure| failure.run_id);
-                                        WorkflowStartError::AlreadyStarted {
-                                            run_id,
-                                            source: status,
-                                        }
-                                    } else {
-                                        WorkflowStartError::Rpc(status)
-                                    }
-                                })?
-                                .into_inner()
-                            .run_id
-                        };
+                        let mut request = build_start_workflow_request(
+                            namespace,
+                            workflow_type,
+                            payloads.into_payloads(),
+                            memo,
+                            user_metadata,
+                            options,
+                        )
+                        .into_request();
+                        rpc_options.apply_to(&mut request);
+                        let run_id = client
+                            .start_workflow_execution(request)
+                            .await
+                            .map_err(WorkflowStartError::from_status)?
+                            .into_inner()
+                            .run_id;
 
                         Ok(StartWorkflowOutput::new(workflow_id, run_id))
                     })
@@ -1960,6 +2056,201 @@ where
                 first_execution_run_id: Some(run_id),
             },
         ))
+    }
+
+    async fn start_update_with_start_workflow<W, U>(
+        &self,
+        workflow: W,
+        workflow_input: W::Input,
+        update: U,
+        update_input: U::Input,
+        options: WorkflowUpdateWithStartOptions,
+    ) -> Result<WorkflowUpdateHandle<Self, U::Output>, WorkflowUpdateWithStartError>
+    where
+        W: HasWorkflowDefinition,
+        W::Input: Send,
+        U: UpdateDefinition<Workflow = W::Run>,
+        U::Input: Send,
+    {
+        let output = interceptors::call_update_with_start_workflow(
+            self.client_interceptors(),
+            UpdateWithStartWorkflowInput::new(
+                workflow.name().to_owned(),
+                workflow_input,
+                update.name().to_owned(),
+                update_input,
+                options,
+            ),
+            Next::new({
+                let client = (*self).clone();
+                move |input: UpdateWithStartWorkflowInput| -> BoxFuture<
+                    '_,
+                    Result<UpdateWithStartWorkflowOutput, WorkflowUpdateWithStartError>,
+                > {
+                    let mut client = client;
+                    Box::pin(async move {
+                        let UpdateWithStartWorkflowInput {
+                            workflow_type,
+                            update_name,
+                            options,
+                            rpc_options,
+                            workflow_args,
+                            update_args,
+                        } = input;
+                        let (start_options, update_id, update_header) = options.into_parts();
+
+                        let data_converter = client.data_converter().clone();
+                        let (unencoded_workflow_payloads, unencoded_update_payloads) = {
+                            let payload_converter = data_converter.payload_converter();
+                            let context = SerializationContext::new(
+                                &SerializationContextData::Workflow,
+                                payload_converter,
+                            );
+                            (
+                                workflow_args.serialize_payloads(&context),
+                                update_args.serialize_payloads(&context),
+                            )
+                        };
+                        drop(workflow_args);
+                        drop(update_args);
+                        // The codec may do expensive work per call (e.g. remote encryption), so
+                        // encode both payload sets concurrently.
+                        let (workflow_payloads, update_payloads) = try_join(
+                            data_converter.codec().encode(
+                                &SerializationContextData::Workflow,
+                                unencoded_workflow_payloads?,
+                            ),
+                            data_converter.codec().encode(
+                                &SerializationContextData::Workflow,
+                                unencoded_update_payloads?,
+                            ),
+                        )
+                        .await?;
+
+                        let namespace = client.namespace();
+                        let workflow_id = start_options.workflow_id.clone();
+                        let user_metadata = start_options.user_metadata();
+                        let memo = start_options.encoded_memo(&data_converter).await?;
+                        let mut start_request = build_start_workflow_request(
+                            namespace.clone(),
+                            workflow_type,
+                            workflow_payloads.into_payloads(),
+                            memo,
+                            user_metadata,
+                            start_options,
+                        );
+                        start_request.identity = client.identity();
+
+                        let update_id = update_id.unwrap_or_else(|| Uuid::new_v4().to_string());
+                        let update_request = workflow_handle::build_update_workflow_request(
+                            namespace.clone(),
+                            client.identity(),
+                            workflow_id.clone(),
+                            String::new(),
+                            update_id.clone(),
+                            update_name,
+                            update_header,
+                            update_payloads,
+                        );
+
+                        let mut request = ExecuteMultiOperationRequest {
+                            namespace,
+                            operations: vec![
+                                execute_multi_operation_request::Operation {
+                                    operation: Some(MultiOperationRequest::StartWorkflow(
+                                        start_request,
+                                    )),
+                                },
+                                execute_multi_operation_request::Operation {
+                                    operation: Some(MultiOperationRequest::UpdateWorkflow(
+                                        update_request,
+                                    )),
+                                },
+                            ],
+                            resource_id: workflow_id.clone(),
+                        }
+                        .into_request();
+                        rpc_options.apply_to(&mut request);
+
+                        let response =
+                            WorkflowService::execute_multi_operation(&mut client, request)
+                                .await
+                                .map_err(WorkflowUpdateWithStartError::from_status)?
+                                .into_inner();
+
+                        // Responses mirror the order of the request's operations.
+                        let mut responses =
+                            response.responses.into_iter().filter_map(|r| r.response);
+                        let (
+                            Some(MultiOperationResponse::StartWorkflow(start_response)),
+                            Some(MultiOperationResponse::UpdateWorkflow(update_response)),
+                        ) = (responses.next(), responses.next())
+                        else {
+                            return Err(WorkflowUpdateWithStartError::Other(
+                                "Server response did not include both start and update \
+                                 operation responses"
+                                    .into(),
+                            ));
+                        };
+
+                        let run_id = update_response
+                            .update_ref
+                            .as_ref()
+                            .and_then(|reference| reference.workflow_execution.as_ref())
+                            .map(|execution| execution.run_id.clone())
+                            .filter(|run_id| !run_id.is_empty())
+                            .or_else(|| {
+                                (!start_response.run_id.is_empty()).then_some(start_response.run_id)
+                            });
+                        Ok(UpdateWithStartWorkflowOutput::new(
+                            workflow_id,
+                            update_id,
+                            run_id,
+                            update_response.outcome,
+                        ))
+                    })
+                }
+            }),
+        )
+        .await?;
+        Ok(WorkflowUpdateHandle::new(
+            self.clone(),
+            output.update_id,
+            output.workflow_id,
+            output.run_id,
+            output.known_outcome,
+        ))
+    }
+
+    async fn execute_update_with_start_workflow<W, U>(
+        &self,
+        workflow: W,
+        workflow_input: W::Input,
+        update: U,
+        update_input: U::Input,
+        options: WorkflowUpdateWithStartOptions,
+    ) -> Result<U::Output, WorkflowUpdateWithStartError>
+    where
+        W: HasWorkflowDefinition,
+        W::Input: Send,
+        U: UpdateDefinition<Workflow = W::Run>,
+        U::Input: Send,
+    {
+        let rpc_options = options.rpc_options.clone();
+        let update_handle = WorkflowClientTrait::start_update_with_start_workflow(
+            self,
+            workflow,
+            workflow_input,
+            update,
+            update_input,
+            options,
+        )
+        .await?;
+        let result = update_handle
+            .get_result(rpc_options)
+            .await
+            .map_err(WorkflowUpdateWithStartError::Update)?;
+        Ok(result)
     }
 
     fn get_workflow_handle<W: HasWorkflowDefinition>(
@@ -3817,6 +4108,313 @@ mod tests {
                 request.metadata().get_bin("connection-meta-bin").unwrap(),
                 &[2][..]
             );
+        }
+    }
+
+    mod update_with_start_tests {
+        use super::*;
+        use assert_matches::assert_matches;
+        use parking_lot::Mutex;
+        use temporalio_common::{
+            UpdateDefinition, WorkflowDefinition,
+            data_converters::{GenericPayloadConverter, PayloadConverter},
+            protos::temporal::api::{
+                common::v1::{
+                    Header, Payload, Payloads, WorkflowExecution as ProtoWorkflowExecution,
+                },
+                enums::v1::{UpdateWorkflowExecutionLifecycleStage, WorkflowIdConflictPolicy},
+                update::v1::{Outcome, UpdateRef, outcome},
+            },
+        };
+        use tonic::{Request, Response};
+
+        struct TestWorkflow;
+
+        impl WorkflowDefinition for TestWorkflow {
+            type Input = String;
+            type Output = ();
+
+            fn name(&self) -> &str {
+                "test-workflow"
+            }
+        }
+
+        impl HasWorkflowDefinition for TestWorkflow {
+            type Run = Self;
+        }
+
+        struct TestUpdate;
+
+        impl UpdateDefinition for TestUpdate {
+            type Workflow = TestWorkflow;
+            type Input = String;
+            type Output = String;
+
+            fn name(&self) -> &str {
+                "test-update"
+            }
+        }
+
+        #[derive(Clone)]
+        struct MockMultiOperationClient {
+            recorded: Arc<Mutex<Option<ExecuteMultiOperationRequest>>>,
+            interceptors: Vec<Arc<dyn ClientInterceptor>>,
+        }
+
+        impl NamespacedClient for MockMultiOperationClient {
+            fn namespace(&self) -> String {
+                "test-namespace".to_owned()
+            }
+
+            fn identity(&self) -> String {
+                "test-identity".to_owned()
+            }
+
+            fn client_interceptors(&self) -> &[Arc<dyn ClientInterceptor>] {
+                &self.interceptors
+            }
+        }
+
+        impl WorkflowService for MockMultiOperationClient {
+            fn execute_multi_operation(
+                &mut self,
+                request: Request<ExecuteMultiOperationRequest>,
+            ) -> futures_util::future::BoxFuture<
+                '_,
+                Result<Response<ExecuteMultiOperationResponse>, tonic::Status>,
+            > {
+                *self.recorded.lock() = Some(request.into_inner());
+                let payload_converter = PayloadConverter::default();
+                let result_payloads = payload_converter
+                    .to_payloads(
+                        &SerializationContext::new(
+                            &SerializationContextData::Workflow,
+                            &payload_converter,
+                        ),
+                        &"update-result".to_owned(),
+                    )
+                    .unwrap();
+                Box::pin(async {
+                    Ok(Response::new(ExecuteMultiOperationResponse {
+                        responses: vec![
+                            execute_multi_operation_response::Response {
+                                response: Some(
+                                    execute_multi_operation_response::response::Response::StartWorkflow(
+                                        StartWorkflowExecutionResponse {
+                                            run_id: "started-run-id".to_owned(),
+                                            first_execution_run_id: "first-run-id".to_owned(),
+                                            started: true,
+                                            ..Default::default()
+                                        },
+                                    ),
+                                ),
+                            },
+                            execute_multi_operation_response::Response {
+                                response: Some(
+                                    execute_multi_operation_response::response::Response::UpdateWorkflow(
+                                        UpdateWorkflowExecutionResponse {
+                                            update_ref: Some(UpdateRef {
+                                                workflow_execution: Some(ProtoWorkflowExecution {
+                                                    workflow_id: "workflow-id".to_owned(),
+                                                    run_id: "update-run-id".to_owned(),
+                                                }),
+                                                update_id: "server-update-id".to_owned(),
+                                            }),
+                                            outcome: Some(Outcome {
+                                                value: Some(outcome::Value::Success(Payloads {
+                                                    payloads: result_payloads,
+                                                })),
+                                            }),
+                                            ..Default::default()
+                                        },
+                                    ),
+                                ),
+                            },
+                        ],
+                    }))
+                })
+            }
+        }
+
+        fn update_with_start_options(
+            conflict_policy: WorkflowIdConflictPolicy,
+        ) -> WorkflowUpdateWithStartOptions {
+            WorkflowUpdateWithStartOptions::new("task-queue", "workflow-id", conflict_policy)
+                .build()
+        }
+
+        #[tokio::test]
+        async fn update_with_start_builds_multi_operation_request() {
+            let recorded = Arc::new(Mutex::new(None));
+            let client = MockMultiOperationClient {
+                recorded: recorded.clone(),
+                interceptors: Vec::new(),
+            };
+
+            let start_header = Header {
+                fields: HashMap::from([("start-header".to_owned(), Payload::default())]),
+            };
+            let update_header = Header {
+                fields: HashMap::from([("update-header".to_owned(), Payload::default())]),
+            };
+            let update_handle = client
+                .start_update_with_start_workflow(
+                    TestWorkflow,
+                    "workflow-input".to_owned(),
+                    TestUpdate,
+                    "update-input".to_owned(),
+                    WorkflowUpdateWithStartOptions::new(
+                        "task-queue",
+                        "workflow-id",
+                        WorkflowIdConflictPolicy::UseExisting,
+                    )
+                    .update_id("my-update-id".to_owned())
+                    .start_header(start_header.clone())
+                    .update_header(update_header.clone())
+                    .build(),
+                )
+                .await
+                .unwrap();
+
+            let request = recorded.lock().take().unwrap();
+            assert_eq!(request.namespace, "test-namespace");
+            assert_eq!(request.resource_id, "workflow-id");
+            assert_eq!(request.operations.len(), 2);
+            let start_request = assert_matches!(
+                &request.operations[0].operation,
+                Some(execute_multi_operation_request::operation::Operation::StartWorkflow(r)) => r
+            );
+            assert_eq!(start_request.workflow_id, "workflow-id");
+            assert_eq!(start_request.identity, "test-identity");
+            assert_eq!(
+                start_request.workflow_type.as_ref().unwrap().name,
+                "test-workflow"
+            );
+            assert_eq!(
+                start_request.task_queue.as_ref().unwrap().name,
+                "task-queue"
+            );
+            assert_eq!(
+                start_request.workflow_id_conflict_policy,
+                WorkflowIdConflictPolicy::UseExisting as i32
+            );
+            assert_eq!(start_request.header.as_ref(), Some(&start_header));
+            let update_request = assert_matches!(
+                &request.operations[1].operation,
+                Some(execute_multi_operation_request::operation::Operation::UpdateWorkflow(r)) => r
+            );
+            let workflow_execution = update_request.workflow_execution.as_ref().unwrap();
+            assert_eq!(workflow_execution.workflow_id, "workflow-id");
+            assert_eq!(workflow_execution.run_id, "");
+            let update_inner = update_request.request.as_ref().unwrap();
+            assert_eq!(
+                update_inner.meta.as_ref().unwrap().update_id,
+                "my-update-id"
+            );
+            assert_eq!(update_inner.input.as_ref().unwrap().name, "test-update");
+            assert_eq!(
+                update_inner.input.as_ref().unwrap().header.as_ref(),
+                Some(&update_header)
+            );
+            assert_eq!(
+                update_request.wait_policy.as_ref().unwrap().lifecycle_stage,
+                UpdateWorkflowExecutionLifecycleStage::Accepted as i32
+            );
+
+            assert_eq!(update_handle.id(), "my-update-id");
+            assert_eq!(update_handle.workflow_run_id(), Some("update-run-id"));
+            // The outcome came back with the multi-operation response, so no poll RPC is needed
+            // (the mock would fail it).
+            let result: String = update_handle
+                .get_result(RpcOptions::default())
+                .await
+                .unwrap();
+            assert_eq!(result, "update-result");
+        }
+
+        #[tokio::test]
+        async fn update_with_start_interceptor_can_mutate_args() {
+            struct ReplaceArgsInterceptor;
+
+            impl ClientInterceptor for ReplaceArgsInterceptor {
+                fn update_with_start_workflow<'a>(
+                    &'a self,
+                    mut input: UpdateWithStartWorkflowInput,
+                    next: Next<
+                        'a,
+                        UpdateWithStartWorkflowInput,
+                        BoxFuture<
+                            'a,
+                            Result<UpdateWithStartWorkflowOutput, WorkflowUpdateWithStartError>,
+                        >,
+                    >,
+                ) -> BoxFuture<
+                    'a,
+                    Result<UpdateWithStartWorkflowOutput, WorkflowUpdateWithStartError>,
+                > {
+                    assert_eq!(
+                        input.workflow_args_ref::<String>().unwrap(),
+                        "workflow-input"
+                    );
+                    input.replace_workflow_args("replaced-workflow-input".to_owned());
+                    *input.update_args_mut::<String>().unwrap() =
+                        "replaced-update-input".to_owned();
+                    next.run(input)
+                }
+            }
+
+            let recorded = Arc::new(Mutex::new(None));
+            let client = MockMultiOperationClient {
+                recorded: recorded.clone(),
+                interceptors: vec![Arc::new(ReplaceArgsInterceptor)],
+            };
+
+            client
+                .start_update_with_start_workflow(
+                    TestWorkflow,
+                    "workflow-input".to_owned(),
+                    TestUpdate,
+                    "update-input".to_owned(),
+                    update_with_start_options(WorkflowIdConflictPolicy::Fail),
+                )
+                .await
+                .unwrap();
+
+            let request = recorded.lock().take().unwrap();
+            let start_request = assert_matches!(
+                &request.operations[0].operation,
+                Some(execute_multi_operation_request::operation::Operation::StartWorkflow(r)) => r
+            );
+            let workflow_input: String = client
+                .data_converter()
+                .from_payloads(
+                    &SerializationContextData::Workflow,
+                    start_request.input.clone().unwrap().payloads,
+                )
+                .await
+                .unwrap();
+            assert_eq!(workflow_input, "replaced-workflow-input");
+            let update_request = assert_matches!(
+                &request.operations[1].operation,
+                Some(execute_multi_operation_request::operation::Operation::UpdateWorkflow(r)) => r
+            );
+            let update_input: String = client
+                .data_converter()
+                .from_payloads(
+                    &SerializationContextData::Workflow,
+                    update_request
+                        .request
+                        .clone()
+                        .unwrap()
+                        .input
+                        .unwrap()
+                        .args
+                        .unwrap()
+                        .payloads,
+                )
+                .await
+                .unwrap();
+            assert_eq!(update_input, "replaced-update-input");
         }
     }
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -147,6 +147,7 @@ use temporalio_common::{
             enums::v1::{
                 ActivityIdConflictPolicy as ProtoActivityIdConflictPolicy,
                 ActivityIdReusePolicy as ProtoActivityIdReusePolicy, TaskQueueKind,
+                UpdateWorkflowExecutionLifecycleStage,
             },
             operatorservice::v1::operator_service_client::OperatorServiceClient,
             sdk::v1::UserMetadata,
@@ -1794,18 +1795,18 @@ impl WorkflowCountAggregationGroup {
     }
 }
 
-/// Shared by `start_workflow` and update-with-start, which sends the same start request as one of
-/// its operations. `identity` is left unset because the two RPC paths populate it differently.
+// Keep the common fields used by start RPC variants in one place so their option handling does
+// not drift as new fields are added.
 fn build_start_workflow_request(
-    namespace: String,
+    client: &impl NamespacedClient,
     workflow_type: String,
     input: Option<Payloads>,
     memo: Option<ProtoMemo>,
-    user_metadata: Option<UserMetadata>,
     options: WorkflowStartOptions,
 ) -> StartWorkflowExecutionRequest {
+    let user_metadata = options.user_metadata();
     StartWorkflowExecutionRequest {
-        namespace,
+        namespace: client.namespace(),
         input,
         workflow_id: options.workflow_id,
         workflow_type: Some(WorkflowType {
@@ -1816,6 +1817,7 @@ fn build_start_workflow_request(
             kind: TaskQueueKind::Unspecified as i32,
             normal_name: String::new(),
         }),
+        identity: client.identity(),
         request_id: Uuid::new_v4().to_string(),
         workflow_id_reuse_policy: options.id_reuse_policy as i32,
         workflow_id_conflict_policy: options.id_conflict_policy as i32,
@@ -1883,16 +1885,13 @@ where
                             .codec()
                             .encode(&SerializationContextData::Workflow, unencoded_payloads?)
                             .await?;
-                        let namespace = client.namespace();
                         let workflow_id = options.workflow_id.clone();
-                        let user_metadata = options.user_metadata();
                         let memo = options.encoded_memo(&data_converter).await?;
                         let mut request = build_start_workflow_request(
-                            namespace,
+                            &client,
                             workflow_type,
                             payloads.into_payloads(),
                             memo,
-                            user_metadata,
                             options,
                         )
                         .into_request();
@@ -1982,49 +1981,45 @@ where
                             .encode(&SerializationContextData::Workflow, signal_payloads?)
                             .await?;
                         let workflow_id = options.workflow_id.clone();
-                        let task_queue_name = options.task_queue.clone();
-
-                        let user_metadata = options.user_metadata();
-
                         let memo = options.encoded_memo(&data_converter).await?;
-
+                        let mut start_request = build_start_workflow_request(
+                            &client,
+                            workflow_type,
+                            workflow_payloads.into_payloads(),
+                            memo,
+                            options,
+                        );
+                        if let Some(task_queue) = &mut start_request.task_queue {
+                            task_queue.kind = TaskQueueKind::Normal as i32;
+                        }
                         let mut request = SignalWithStartWorkflowExecutionRequest {
-                            namespace: client.namespace(),
-                            workflow_id: workflow_id.clone(),
-                            workflow_type: Some(WorkflowType {
-                                name: workflow_type,
-                            }),
-                            task_queue: Some(TaskQueue {
-                                name: task_queue_name,
-                                kind: TaskQueueKind::Normal as i32,
-                                normal_name: String::new(),
-                            }),
-                            input: workflow_payloads.into_payloads(),
+                            namespace: start_request.namespace,
+                            workflow_id: start_request.workflow_id,
+                            workflow_type: start_request.workflow_type,
+                            task_queue: start_request.task_queue,
+                            input: start_request.input,
+                            workflow_execution_timeout: start_request.workflow_execution_timeout,
+                            workflow_run_timeout: start_request.workflow_run_timeout,
+                            workflow_task_timeout: start_request.workflow_task_timeout,
+                            identity: start_request.identity,
+                            request_id: start_request.request_id,
+                            workflow_id_reuse_policy: start_request.workflow_id_reuse_policy,
+                            workflow_id_conflict_policy: start_request.workflow_id_conflict_policy,
                             signal_name,
                             signal_input: Some(Payloads {
                                 payloads: signal_payloads,
                             }),
-                            identity: client.identity(),
-                            request_id: Uuid::new_v4().to_string(),
-                            workflow_id_reuse_policy: options.id_reuse_policy as i32,
-                            workflow_id_conflict_policy: options.id_conflict_policy as i32,
-                            workflow_execution_timeout: options
-                                .execution_timeout
-                                .and_then(|duration| duration.try_into().ok()),
-                            workflow_run_timeout: options
-                                .run_timeout
-                                .and_then(|duration| duration.try_into().ok()),
-                            workflow_task_timeout: options
-                                .task_timeout
-                                .and_then(|duration| duration.try_into().ok()),
-                            search_attributes: options
-                                .search_attributes
-                                .map(|attributes| attributes.into_proto()),
-                            cron_schedule: options.cron_schedule.unwrap_or_default(),
-                            retry_policy: options.retry_policy.map(Into::into),
-                            memo,
-                            header: options.header,
-                            user_metadata,
+                            retry_policy: start_request.retry_policy,
+                            cron_schedule: start_request.cron_schedule,
+                            memo: start_request.memo,
+                            search_attributes: start_request.search_attributes,
+                            header: start_request.header,
+                            workflow_start_delay: start_request.workflow_start_delay,
+                            user_metadata: start_request.user_metadata,
+                            links: start_request.links,
+                            versioning_override: start_request.versioning_override,
+                            priority: start_request.priority,
+                            time_skipping_config: start_request.time_skipping_config,
                             ..Default::default()
                         }
                         .into_request();
@@ -2129,17 +2124,14 @@ where
 
                         let namespace = client.namespace();
                         let workflow_id = start_options.workflow_id.clone();
-                        let user_metadata = start_options.user_metadata();
                         let memo = start_options.encoded_memo(&data_converter).await?;
-                        let mut start_request = build_start_workflow_request(
-                            namespace.clone(),
+                        let start_request = build_start_workflow_request(
+                            &client,
                             workflow_type,
                             workflow_payloads.into_payloads(),
                             memo,
-                            user_metadata,
                             start_options,
                         );
-                        start_request.identity = client.identity();
 
                         let update_id = update_id.unwrap_or_else(|| Uuid::new_v4().to_string());
                         let update_request = workflow_handle::build_update_workflow_request(
@@ -2153,7 +2145,7 @@ where
                             update_payloads,
                         );
 
-                        let mut request = ExecuteMultiOperationRequest {
+                        let request = ExecuteMultiOperationRequest {
                             namespace,
                             operations: vec![
                                 execute_multi_operation_request::Operation {
@@ -2168,29 +2160,43 @@ where
                                 },
                             ],
                             resource_id: workflow_id.clone(),
-                        }
-                        .into_request();
-                        rpc_options.apply_to(&mut request);
+                        };
 
-                        let response =
-                            WorkflowService::execute_multi_operation(&mut client, request)
-                                .await
-                                .map_err(WorkflowUpdateWithStartError::from_status)?
-                                .into_inner();
+                        let (start_response, update_response) = loop {
+                            let mut rpc_request = request.clone().into_request();
+                            rpc_options.apply_to(&mut rpc_request);
+                            let response =
+                                WorkflowService::execute_multi_operation(&mut client, rpc_request)
+                                    .await
+                                    .map_err(WorkflowUpdateWithStartError::from_status)?
+                                    .into_inner();
 
-                        // Responses mirror the order of the request's operations.
-                        let mut responses =
-                            response.responses.into_iter().filter_map(|r| r.response);
-                        let (
-                            Some(MultiOperationResponse::StartWorkflow(start_response)),
-                            Some(MultiOperationResponse::UpdateWorkflow(update_response)),
-                        ) = (responses.next(), responses.next())
-                        else {
-                            return Err(WorkflowUpdateWithStartError::Other(
-                                "Server response did not include both start and update \
-                                 operation responses"
-                                    .into(),
-                            ));
+                            let [start_response, update_response]: [_; 2] =
+                                response.responses.try_into().map_err(|_| {
+                                    WorkflowUpdateWithStartError::Other(
+                                        "Server response did not include exactly two operation \
+                                         responses"
+                                            .into(),
+                                    )
+                                })?;
+                            let (
+                                Some(MultiOperationResponse::StartWorkflow(start_response)),
+                                Some(MultiOperationResponse::UpdateWorkflow(update_response)),
+                            ) = (start_response.response, update_response.response)
+                            else {
+                                return Err(WorkflowUpdateWithStartError::Other(
+                                    "Server response did not include start and update operation \
+                                     responses in request order"
+                                        .into(),
+                                ));
+                            };
+
+                            if update_response.stage
+                                < UpdateWorkflowExecutionLifecycleStage::Accepted as i32
+                            {
+                                continue;
+                            }
+                            break (start_response, update_response);
                         };
 
                         let run_id = update_response
@@ -3257,7 +3263,9 @@ mod tests {
                 SerializationContext, SerializationContextData, TemporalDeserializable,
                 TemporalSerializable,
             },
-            protos::temporal::api::common::v1::{Memo as ProtoMemo, Payload},
+            protos::temporal::api::common::v1::{
+                Link, Memo as ProtoMemo, Payload, Priority as ProtoPriority,
+            },
         };
         use temporalio_macros::{workflow, workflow_methods};
         use temporalio_workflow::{SyncWorkflowContext, WorkflowContext, WorkflowResult};
@@ -3289,6 +3297,9 @@ mod tests {
             payloads: Vec<Payload>,
             signal_name: String,
             signal_payloads: Vec<Payload>,
+            identity: String,
+            links: Vec<Link>,
+            priority: Option<ProtoPriority>,
             ascii_metadata: Option<String>,
             binary_metadata: Option<Vec<u8>>,
             grpc_timeout: Option<String>,
@@ -3374,6 +3385,9 @@ mod tests {
                 recorded.workflow_type = request.workflow_type.unwrap().name;
                 recorded.memo = request.memo;
                 recorded.payloads = request.input.unwrap_or_default().payloads;
+                recorded.identity = request.identity;
+                recorded.links = request.links;
+                recorded.priority = request.priority;
                 recorded.ascii_metadata = ascii_metadata;
                 recorded.binary_metadata = binary_metadata;
                 recorded.grpc_timeout = grpc_timeout;
@@ -3418,6 +3432,9 @@ mod tests {
                 recorded.payloads = request.input.unwrap_or_default().payloads;
                 recorded.signal_name = request.signal_name;
                 recorded.signal_payloads = request.signal_input.unwrap_or_default().payloads;
+                recorded.identity = request.identity;
+                recorded.links = request.links;
+                recorded.priority = request.priority;
                 recorded.ascii_metadata = ascii_metadata;
                 recorded.binary_metadata = binary_metadata;
                 recorded.grpc_timeout = grpc_timeout;
@@ -4115,6 +4132,7 @@ mod tests {
         use super::*;
         use assert_matches::assert_matches;
         use parking_lot::Mutex;
+        use std::collections::VecDeque;
         use temporalio_common::{
             UpdateDefinition, WorkflowDefinition,
             data_converters::{GenericPayloadConverter, PayloadConverter},
@@ -4123,7 +4141,10 @@ mod tests {
                     Header, Payload, Payloads, WorkflowExecution as ProtoWorkflowExecution,
                 },
                 enums::v1::{UpdateWorkflowExecutionLifecycleStage, WorkflowIdConflictPolicy},
-                update::v1::{Outcome, UpdateRef, outcome},
+                update::v1::{
+                    Input as UpdateInput, Meta as UpdateMeta, Outcome, Request as UpdateRequest,
+                    UpdateRef, WaitPolicy, outcome,
+                },
             },
         };
         use tonic::{Request, Response};
@@ -4155,10 +4176,78 @@ mod tests {
             }
         }
 
+        fn successful_multi_operation_response(
+            stage: UpdateWorkflowExecutionLifecycleStage,
+        ) -> ExecuteMultiOperationResponse {
+            let outcome = (stage == UpdateWorkflowExecutionLifecycleStage::Completed).then(|| {
+                let payload_converter = PayloadConverter::default();
+                let result_payloads = payload_converter
+                    .to_payloads(
+                        &SerializationContext::new(
+                            &SerializationContextData::Workflow,
+                            &payload_converter,
+                        ),
+                        &"update-result".to_owned(),
+                    )
+                    .unwrap();
+                Outcome {
+                    value: Some(outcome::Value::Success(Payloads {
+                        payloads: result_payloads,
+                    })),
+                }
+            });
+            ExecuteMultiOperationResponse {
+                responses: vec![
+                    execute_multi_operation_response::Response {
+                        response: Some(MultiOperationResponse::StartWorkflow(
+                            StartWorkflowExecutionResponse {
+                                run_id: "started-run-id".to_owned(),
+                                first_execution_run_id: "first-run-id".to_owned(),
+                                started: true,
+                                ..Default::default()
+                            },
+                        )),
+                    },
+                    execute_multi_operation_response::Response {
+                        response: Some(MultiOperationResponse::UpdateWorkflow(
+                            UpdateWorkflowExecutionResponse {
+                                update_ref: Some(UpdateRef {
+                                    workflow_execution: Some(ProtoWorkflowExecution {
+                                        workflow_id: "workflow-id".to_owned(),
+                                        run_id: "update-run-id".to_owned(),
+                                    }),
+                                    update_id: "server-update-id".to_owned(),
+                                }),
+                                outcome,
+                                stage: stage as i32,
+                                ..Default::default()
+                            },
+                        )),
+                    },
+                ],
+            }
+        }
+
         #[derive(Clone)]
         struct MockMultiOperationClient {
             recorded: Arc<Mutex<Option<ExecuteMultiOperationRequest>>>,
+            responses: Arc<Mutex<VecDeque<ExecuteMultiOperationResponse>>>,
+            call_count: Arc<Mutex<usize>>,
             interceptors: Vec<Arc<dyn ClientInterceptor>>,
+        }
+
+        impl MockMultiOperationClient {
+            fn new(
+                interceptors: Vec<Arc<dyn ClientInterceptor>>,
+                responses: impl IntoIterator<Item = ExecuteMultiOperationResponse>,
+            ) -> Self {
+                Self {
+                    recorded: Arc::new(Mutex::new(None)),
+                    responses: Arc::new(Mutex::new(responses.into_iter().collect())),
+                    call_count: Arc::new(Mutex::new(0)),
+                    interceptors,
+                }
+            }
         }
 
         impl NamespacedClient for MockMultiOperationClient {
@@ -4184,55 +4273,13 @@ mod tests {
                 Result<Response<ExecuteMultiOperationResponse>, tonic::Status>,
             > {
                 *self.recorded.lock() = Some(request.into_inner());
-                let payload_converter = PayloadConverter::default();
-                let result_payloads = payload_converter
-                    .to_payloads(
-                        &SerializationContext::new(
-                            &SerializationContextData::Workflow,
-                            &payload_converter,
-                        ),
-                        &"update-result".to_owned(),
+                *self.call_count.lock() += 1;
+                let response = self.responses.lock().pop_front().unwrap_or_else(|| {
+                    successful_multi_operation_response(
+                        UpdateWorkflowExecutionLifecycleStage::Completed,
                     )
-                    .unwrap();
-                Box::pin(async {
-                    Ok(Response::new(ExecuteMultiOperationResponse {
-                        responses: vec![
-                            execute_multi_operation_response::Response {
-                                response: Some(
-                                    execute_multi_operation_response::response::Response::StartWorkflow(
-                                        StartWorkflowExecutionResponse {
-                                            run_id: "started-run-id".to_owned(),
-                                            first_execution_run_id: "first-run-id".to_owned(),
-                                            started: true,
-                                            ..Default::default()
-                                        },
-                                    ),
-                                ),
-                            },
-                            execute_multi_operation_response::Response {
-                                response: Some(
-                                    execute_multi_operation_response::response::Response::UpdateWorkflow(
-                                        UpdateWorkflowExecutionResponse {
-                                            update_ref: Some(UpdateRef {
-                                                workflow_execution: Some(ProtoWorkflowExecution {
-                                                    workflow_id: "workflow-id".to_owned(),
-                                                    run_id: "update-run-id".to_owned(),
-                                                }),
-                                                update_id: "server-update-id".to_owned(),
-                                            }),
-                                            outcome: Some(Outcome {
-                                                value: Some(outcome::Value::Success(Payloads {
-                                                    payloads: result_payloads,
-                                                })),
-                                            }),
-                                            ..Default::default()
-                                        },
-                                    ),
-                                ),
-                            },
-                        ],
-                    }))
-                })
+                });
+                Box::pin(async { Ok(Response::new(response)) })
             }
         }
 
@@ -4245,11 +4292,8 @@ mod tests {
 
         #[tokio::test]
         async fn update_with_start_builds_multi_operation_request() {
-            let recorded = Arc::new(Mutex::new(None));
-            let client = MockMultiOperationClient {
-                recorded: recorded.clone(),
-                interceptors: Vec::new(),
-            };
+            let client = MockMultiOperationClient::new(Vec::new(), []);
+            let recorded = client.recorded.clone();
 
             let start_header = Header {
                 fields: HashMap::from([("start-header".to_owned(), Payload::default())]),
@@ -4276,49 +4320,86 @@ mod tests {
                 .await
                 .unwrap();
 
+            let payload_converter = PayloadConverter::default();
+            let context =
+                SerializationContext::new(&SerializationContextData::Workflow, &payload_converter);
+            let workflow_payloads = payload_converter
+                .to_payloads(&context, &"workflow-input".to_owned())
+                .unwrap();
+            let update_payloads = payload_converter
+                .to_payloads(&context, &"update-input".to_owned())
+                .unwrap();
+
             let request = recorded.lock().take().unwrap();
-            assert_eq!(request.namespace, "test-namespace");
-            assert_eq!(request.resource_id, "workflow-id");
-            assert_eq!(request.operations.len(), 2);
-            let start_request = assert_matches!(
+            let request_id = assert_matches!(
                 &request.operations[0].operation,
                 Some(execute_multi_operation_request::operation::Operation::StartWorkflow(r)) => r
-            );
-            assert_eq!(start_request.workflow_id, "workflow-id");
-            assert_eq!(start_request.identity, "test-identity");
+            )
+            .request_id
+            .clone();
             assert_eq!(
-                start_request.workflow_type.as_ref().unwrap().name,
-                "test-workflow"
-            );
-            assert_eq!(
-                start_request.task_queue.as_ref().unwrap().name,
-                "task-queue"
-            );
-            assert_eq!(
-                start_request.workflow_id_conflict_policy,
-                WorkflowIdConflictPolicy::UseExisting as i32
-            );
-            assert_eq!(start_request.header.as_ref(), Some(&start_header));
-            let update_request = assert_matches!(
-                &request.operations[1].operation,
-                Some(execute_multi_operation_request::operation::Operation::UpdateWorkflow(r)) => r
-            );
-            let workflow_execution = update_request.workflow_execution.as_ref().unwrap();
-            assert_eq!(workflow_execution.workflow_id, "workflow-id");
-            assert_eq!(workflow_execution.run_id, "");
-            let update_inner = update_request.request.as_ref().unwrap();
-            assert_eq!(
-                update_inner.meta.as_ref().unwrap().update_id,
-                "my-update-id"
-            );
-            assert_eq!(update_inner.input.as_ref().unwrap().name, "test-update");
-            assert_eq!(
-                update_inner.input.as_ref().unwrap().header.as_ref(),
-                Some(&update_header)
-            );
-            assert_eq!(
-                update_request.wait_policy.as_ref().unwrap().lifecycle_stage,
-                UpdateWorkflowExecutionLifecycleStage::Accepted as i32
+                request,
+                ExecuteMultiOperationRequest {
+                    namespace: "test-namespace".to_owned(),
+                    operations: vec![
+                        execute_multi_operation_request::Operation {
+                            operation: Some(MultiOperationRequest::StartWorkflow(
+                                StartWorkflowExecutionRequest {
+                                    namespace: "test-namespace".to_owned(),
+                                    workflow_id: "workflow-id".to_owned(),
+                                    workflow_type: Some(WorkflowType {
+                                        name: "test-workflow".to_owned(),
+                                    }),
+                                    task_queue: Some(TaskQueue {
+                                        name: "task-queue".to_owned(),
+                                        ..Default::default()
+                                    }),
+                                    input: Some(Payloads {
+                                        payloads: workflow_payloads,
+                                    }),
+                                    request_id,
+                                    identity: "test-identity".to_owned(),
+                                    workflow_id_conflict_policy:
+                                        WorkflowIdConflictPolicy::UseExisting as i32,
+                                    header: Some(start_header),
+                                    priority: Some(Default::default()),
+                                    ..Default::default()
+                                },
+                            )),
+                        },
+                        execute_multi_operation_request::Operation {
+                            operation: Some(MultiOperationRequest::UpdateWorkflow(
+                                UpdateWorkflowExecutionRequest {
+                                    namespace: "test-namespace".to_owned(),
+                                    workflow_execution: Some(ProtoWorkflowExecution {
+                                        workflow_id: "workflow-id".to_owned(),
+                                        run_id: String::new(),
+                                    }),
+                                    wait_policy: Some(WaitPolicy {
+                                        lifecycle_stage:
+                                            UpdateWorkflowExecutionLifecycleStage::Accepted as i32,
+                                    }),
+                                    request: Some(UpdateRequest {
+                                        meta: Some(UpdateMeta {
+                                            update_id: "my-update-id".to_owned(),
+                                            identity: "test-identity".to_owned(),
+                                        }),
+                                        input: Some(UpdateInput {
+                                            header: Some(update_header),
+                                            name: "test-update".to_owned(),
+                                            args: Some(Payloads {
+                                                payloads: update_payloads,
+                                            }),
+                                        }),
+                                        ..Default::default()
+                                    }),
+                                    ..Default::default()
+                                },
+                            )),
+                        },
+                    ],
+                    resource_id: "workflow-id".to_owned(),
+                }
             );
 
             assert_eq!(update_handle.id(), "my-update-id");
@@ -4330,6 +4411,71 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(result, "update-result");
+        }
+
+        #[tokio::test]
+        async fn update_with_start_retries_until_update_is_accepted() {
+            let client = MockMultiOperationClient::new(
+                Vec::new(),
+                [
+                    successful_multi_operation_response(
+                        UpdateWorkflowExecutionLifecycleStage::Unspecified,
+                    ),
+                    successful_multi_operation_response(
+                        UpdateWorkflowExecutionLifecycleStage::Accepted,
+                    ),
+                ],
+            );
+            let call_count = client.call_count.clone();
+
+            let update_handle = client
+                .start_update_with_start_workflow(
+                    TestWorkflow,
+                    "workflow-input".to_owned(),
+                    TestUpdate,
+                    "update-input".to_owned(),
+                    update_with_start_options(WorkflowIdConflictPolicy::Fail),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(*call_count.lock(), 2);
+            assert_eq!(update_handle.workflow_run_id(), Some("update-run-id"));
+        }
+
+        #[tokio::test]
+        async fn update_with_start_rejects_malformed_operation_responses() {
+            let mut missing_response = successful_multi_operation_response(
+                UpdateWorkflowExecutionLifecycleStage::Accepted,
+            );
+            missing_response.responses[0] = execute_multi_operation_response::Response::default();
+            let mut extra_response = successful_multi_operation_response(
+                UpdateWorkflowExecutionLifecycleStage::Accepted,
+            );
+            extra_response
+                .responses
+                .push(execute_multi_operation_response::Response::default());
+            let mut wrong_order = successful_multi_operation_response(
+                UpdateWorkflowExecutionLifecycleStage::Accepted,
+            );
+            wrong_order.responses.swap(0, 1);
+
+            for response in [missing_response, extra_response, wrong_order] {
+                let client = MockMultiOperationClient::new(Vec::new(), [response]);
+                let result = client
+                    .start_update_with_start_workflow(
+                        TestWorkflow,
+                        "workflow-input".to_owned(),
+                        TestUpdate,
+                        "update-input".to_owned(),
+                        update_with_start_options(WorkflowIdConflictPolicy::Fail),
+                    )
+                    .await;
+                assert!(matches!(
+                    result,
+                    Err(WorkflowUpdateWithStartError::Other(_))
+                ));
+            }
         }
 
         #[tokio::test]
@@ -4363,11 +4509,8 @@ mod tests {
                 }
             }
 
-            let recorded = Arc::new(Mutex::new(None));
-            let client = MockMultiOperationClient {
-                recorded: recorded.clone(),
-                interceptors: vec![Arc::new(ReplaceArgsInterceptor)],
-            };
+            let client = MockMultiOperationClient::new(vec![Arc::new(ReplaceArgsInterceptor)], []);
+            let recorded = client.recorded.clone();
 
             client
                 .start_update_with_start_workflow(

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -508,6 +508,133 @@ impl WorkflowStartOptions {
     }
 }
 
+/// Options for starting a workflow and sending it an update in one atomic operation.
+///
+/// See [crate::Client::start_update_with_start_workflow] and
+/// [crate::Client::execute_update_with_start_workflow].
+#[derive(Debug, Clone, bon::Builder)]
+#[builder(start_fn = new, on(String, into))]
+#[non_exhaustive]
+pub struct WorkflowUpdateWithStartOptions {
+    /// The task queue to run the workflow on.
+    #[builder(start_fn)]
+    pub task_queue: String,
+
+    /// The workflow ID.
+    #[builder(start_fn)]
+    pub workflow_id: String,
+
+    /// How to resolve a conflict with an already-running workflow. This is required so callers
+    /// explicitly choose whether an update may attach to an existing workflow.
+    #[builder(start_fn)]
+    pub id_conflict_policy: WorkflowIdConflictPolicy,
+
+    /// The policy for reusing the workflow ID after a workflow closes.
+    #[builder(default)]
+    pub id_reuse_policy: WorkflowIdReusePolicy,
+
+    /// The workflow execution timeout.
+    pub execution_timeout: Option<Duration>,
+
+    /// The workflow run timeout.
+    pub run_timeout: Option<Duration>,
+
+    /// The workflow task timeout.
+    pub task_timeout: Option<Duration>,
+
+    /// Search attributes for the workflow.
+    pub search_attributes: Option<SearchAttributes>,
+
+    /// The workflow retry policy.
+    #[builder(into)]
+    pub retry_policy: Option<RetryPolicy>,
+
+    /// Links to associate with the workflow.
+    #[builder(default)]
+    pub links: Vec<common::v1::Link>,
+
+    /// Callbacks invoked when the workflow completes.
+    #[builder(default)]
+    pub completion_callbacks: Vec<common::v1::Callback>,
+
+    /// Priority for the workflow. Defaults to all-inherited (empty).
+    #[builder(default)]
+    pub priority: Priority,
+
+    /// Headers to include with the start operation.
+    pub start_header: Option<Header>,
+
+    /// Headers to include with the update operation.
+    pub update_header: Option<Header>,
+
+    /// Non-indexed values attached to the workflow, serialized with the client's data converter.
+    pub memo: Option<MemoValues>,
+
+    /// Single-line static summary for the workflow, shown in the Temporal UI.
+    pub static_summary: Option<String>,
+
+    /// Multi-line static details for the workflow, shown in the Temporal UI.
+    pub static_details: Option<String>,
+
+    /// Update ID for idempotency. If not provided, a UUID will be generated.
+    pub update_id: Option<String>,
+
+    /// Controls for the multi-operation RPC and, when executing the update, subsequent polling.
+    #[builder(default)]
+    pub rpc_options: RpcOptions,
+}
+
+impl WorkflowUpdateWithStartOptions {
+    pub(crate) fn into_parts(self) -> (WorkflowStartOptions, Option<String>, Option<Header>) {
+        let Self {
+            task_queue,
+            workflow_id,
+            id_conflict_policy,
+            id_reuse_policy,
+            execution_timeout,
+            run_timeout,
+            task_timeout,
+            search_attributes,
+            retry_policy,
+            links,
+            completion_callbacks,
+            priority,
+            start_header,
+            update_header,
+            memo,
+            static_summary,
+            static_details,
+            update_id,
+            rpc_options: _,
+        } = self;
+        (
+            WorkflowStartOptions {
+                task_queue,
+                workflow_id,
+                id_reuse_policy,
+                id_conflict_policy,
+                execution_timeout,
+                run_timeout,
+                task_timeout,
+                cron_schedule: None,
+                search_attributes,
+                enable_eager_workflow_start: false,
+                retry_policy,
+                links,
+                completion_callbacks,
+                priority,
+                header: start_header,
+                memo,
+                static_summary,
+                static_details,
+                rpc_options: RpcOptions::default(),
+            },
+            update_id,
+            update_header,
+        )
+    }
+}
+
 pub use temporalio_common::Priority;
 
 /// Options for fetching workflow results
@@ -709,6 +836,17 @@ pub struct WorkflowStartUpdateOptions {
     /// Controls for the start-update RPC.
     #[builder(default)]
     pub rpc_options: RpcOptions,
+}
+
+impl From<WorkflowExecuteUpdateOptions> for WorkflowStartUpdateOptions {
+    /// Execute-update is start-update followed by waiting for the update result.
+    fn from(options: WorkflowExecuteUpdateOptions) -> Self {
+        Self::builder()
+            .maybe_update_id(options.update_id)
+            .maybe_header(options.header)
+            .rpc_options(options.rpc_options)
+            .build()
+    }
 }
 
 /// Options for listing workflows.

--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -28,7 +28,7 @@ use temporalio_common::{
         coresdk::FromPayloadsExt,
         proto_ts_to_system_time,
         temporal::api::{
-            common::v1::{Payload, Payloads, WorkflowExecution as ProtoWorkflowExecution},
+            common::v1::{Header, Payload, Payloads, WorkflowExecution as ProtoWorkflowExecution},
             enums::v1::{HistoryEventFilterType, UpdateWorkflowExecutionLifecycleStage},
             history::{
                 self,
@@ -525,6 +525,45 @@ impl<W: WorkflowDefinition> UpdateDefinition for UntypedUpdate<W> {
     }
 }
 
+/// Shared by [WorkflowHandle::start_update] and the client's update-with-start, which sends the
+/// same update request as one of its operations. Update starts always wait for the update to be
+/// accepted; results are waited on separately via the update handle.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_update_workflow_request(
+    namespace: String,
+    identity: String,
+    workflow_id: String,
+    run_id: String,
+    update_id: String,
+    update_name: String,
+    header: Option<Header>,
+    payloads: Vec<Payload>,
+) -> UpdateWorkflowExecutionRequest {
+    UpdateWorkflowExecutionRequest {
+        namespace,
+        workflow_execution: Some(ProtoWorkflowExecution {
+            workflow_id,
+            run_id,
+        }),
+        wait_policy: Some(WaitPolicy {
+            lifecycle_stage: UpdateWorkflowExecutionLifecycleStage::Accepted.into(),
+        }),
+        request: Some(update::v1::Request {
+            meta: Some(update::v1::Meta {
+                update_id,
+                identity,
+            }),
+            input: Some(update::v1::Input {
+                header,
+                name: update_name,
+                args: Some(Payloads { payloads }),
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
 impl<CT, W> WorkflowHandle<CT, W>
 where
     CT: WorkflowService + Clone,
@@ -854,17 +893,7 @@ where
         U::Output: 'static,
     {
         let rpc_options = options.rpc_options.clone();
-        let handle = self
-            .start_update(
-                update,
-                input,
-                WorkflowStartUpdateOptions::builder()
-                    .maybe_update_id(options.update_id)
-                    .maybe_header(options.header)
-                    .rpc_options(rpc_options.clone())
-                    .build(),
-            )
-            .await?;
+        let handle = self.start_update(update, input, options.into()).await?;
         handle.get_result(rpc_options).await
     }
 
@@ -916,30 +945,16 @@ where
                             let update_id = options
                                 .update_id
                                 .unwrap_or_else(|| Uuid::new_v4().to_string());
-                            let mut request = UpdateWorkflowExecutionRequest {
-                                namespace: client.namespace(),
-                                workflow_execution: Some(ProtoWorkflowExecution {
-                                    workflow_id: workflow_id.clone(),
-                                    run_id,
-                                }),
-                                wait_policy: Some(WaitPolicy {
-                                    lifecycle_stage:
-                                        UpdateWorkflowExecutionLifecycleStage::Accepted.into(),
-                                }),
-                                request: Some(update::v1::Request {
-                                    meta: Some(update::v1::Meta {
-                                        update_id: update_id.clone(),
-                                        identity: client.identity(),
-                                    }),
-                                    input: Some(update::v1::Input {
-                                        header: options.header,
-                                        name: update_name,
-                                        args: Some(Payloads { payloads }),
-                                    }),
-                                    ..Default::default()
-                                }),
-                                ..Default::default()
-                            }
+                            let mut request = build_update_workflow_request(
+                                client.namespace(),
+                                client.identity(),
+                                workflow_id.clone(),
+                                run_id,
+                                update_id.clone(),
+                                update_name,
+                                options.header,
+                                payloads,
+                            )
                             .into_request();
                             options.rpc_options.apply_to(&mut request);
                             let response =
@@ -965,14 +980,13 @@ where
         )
         .await?;
 
-        Ok(WorkflowUpdateHandle {
-            client: self.client.clone(),
-            update_id: output.update_id,
-            workflow_id: output.workflow_id,
-            run_id: output.run_id.or_else(|| self.info().run_id.clone()),
-            known_outcome: output.known_outcome,
-            _output: PhantomData,
-        })
+        Ok(WorkflowUpdateHandle::new(
+            self.client.clone(),
+            output.update_id,
+            output.workflow_id,
+            output.run_id.or_else(|| self.info().run_id.clone()),
+            output.known_outcome,
+        ))
     }
 
     /// Request cancellation of this workflow.
@@ -1228,6 +1242,23 @@ pub struct WorkflowUpdateHandle<CT, T> {
 }
 
 impl<CT, T> WorkflowUpdateHandle<CT, T> {
+    pub(crate) fn new(
+        client: CT,
+        update_id: String,
+        workflow_id: String,
+        run_id: Option<String>,
+        known_outcome: Option<update::v1::Outcome>,
+    ) -> Self {
+        Self {
+            client,
+            update_id,
+            workflow_id,
+            run_id,
+            known_outcome,
+            _output: PhantomData,
+        }
+    }
+
     /// Get the update ID.
     pub fn id(&self) -> &str {
         &self.update_id

--- a/crates/protos/src/protos/utilities.rs
+++ b/crates/protos/src/protos/utilities.rs
@@ -37,6 +37,12 @@ pub fn decode_status_detail<T: Message + Default>(details: &[u8]) -> Option<T> {
     T::decode(first_detail.value.as_slice()).ok()
 }
 
+/// Encode a `google.rpc.Status` into the serialized bytes format carried by
+/// `grpc-status-details-bin` (as expected by `tonic::Status::with_details`).
+pub fn encode_status_details(status: &super::google::rpc::Status) -> Vec<u8> {
+    status.encode_to_vec()
+}
+
 /// Given a header map, lowercase all the keys and return it as a new map.
 /// Any keys that are duplicated after lowercasing will clobber each other in undefined ordering.
 pub fn normalize_http_headers(headers: HashMap<String, String>) -> HashMap<String, String> {

--- a/crates/sdk-core/CHANGELOG.md
+++ b/crates/sdk-core/CHANGELOG.md
@@ -73,6 +73,9 @@ relevant information.
 ### Fixed
 * The Prometheus exporter now appends `_total` to counter metric names when an SDK enables the
   counter suffix option.
+* Update-with-start `ExecuteMultiOperation` calls now use Core's long-poll timeout instead of the
+  normal RPC timeout, avoiding premature failures while waiting for an update to reach its
+  requested stage.
 * An activity failure caused by oversized final heartbeat details is now counted in the
   `temporal_activity_execution_failed` metric as `failure_reason="PayloadsTooLarge"`. Previously it
   was counted under the reason for the failure the activity itself reported, and was not counted at

--- a/crates/sdk-core/tests/integ_tests/update_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/update_tests.rs
@@ -1526,10 +1526,53 @@ async fn update_lost_on_activity_mismatch() {
     handle.fetch_history_and_replay(&mut worker).await.unwrap();
 }
 
+#[workflow]
+#[derive(Default)]
+struct UpdateWithStartWf {
+    done: bool,
+}
+
+#[workflow_methods]
+impl UpdateWithStartWf {
+    #[run]
+    async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+        ctx.wait_condition(|s| s.done).await?;
+        Ok(())
+    }
+
+    #[update]
+    async fn do_update(
+        _ctx: &mut WorkflowContext<Self>,
+        arg: String,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        if arg == "reject" {
+            return Err(anyhow!("update rejected").into());
+        }
+        Ok(format!("hello {arg}"))
+    }
+
+    #[signal]
+    fn done_signal(&mut self, _ctx: &mut SyncWorkflowContext<Self>, _: ()) {
+        self.done = true;
+    }
+}
+
+#[derive(Clone, Copy)]
+enum UpdateWithStartScenario {
+    StartAndGetHandle,
+    ExecuteOnExisting,
+    UpdateFailure,
+    StartConflict,
+}
+
+#[rstest::rstest]
+#[case::start_and_get_handle(UpdateWithStartScenario::StartAndGetHandle)]
+#[case::execute_on_existing(UpdateWithStartScenario::ExecuteOnExisting)]
+#[case::update_failure(UpdateWithStartScenario::UpdateFailure)]
+#[case::start_conflict(UpdateWithStartScenario::StartConflict)]
 #[tokio::test]
-async fn update_with_start() {
-    let wf_name = "update_with_start";
-    let mut starter = CoreWfStarter::new(wf_name);
+async fn update_with_start(#[case] scenario: UpdateWithStartScenario) {
+    let mut starter = CoreWfStarter::new("update_with_start");
     starter
         .sdk_config
         .register_workflow::<UpdateWithStartWf>()
@@ -1537,79 +1580,100 @@ async fn update_with_start() {
     starter.set_core_task_types(WorkerTaskTypes::workflow_only());
     let mut worker = starter.worker().await;
     let client = starter.get_core_client().await;
-
-    #[workflow]
-    #[derive(Default)]
-    struct UpdateWithStartWf {
-        done: bool,
-    }
-
-    #[workflow_methods]
-    impl UpdateWithStartWf {
-        #[run]
-        async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.wait_condition(|s| s.done).await?;
-            Ok(())
-        }
-
-        #[update]
-        async fn do_update(
-            _ctx: &mut WorkflowContext<Self>,
-            arg: String,
-        ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-            Ok(format!("hello {arg}"))
-        }
-
-        #[signal]
-        fn done_signal(&mut self, _ctx: &mut SyncWorkflowContext<Self>, _: ()) {
-            self.done = true;
-        }
-    }
-
     let task_queue = starter.get_task_queue().to_owned();
     let wf_id = starter.get_wf_id().to_owned();
+
+    let existing_run_id = if matches!(scenario, UpdateWithStartScenario::StartAndGetHandle) {
+        None
+    } else {
+        let handle = worker
+            .submit_workflow(
+                UpdateWithStartWf::run,
+                (),
+                WorkflowStartOptions::new(task_queue.clone(), wf_id.clone()).build(),
+            )
+            .await
+            .unwrap();
+        Some(handle.run_id().unwrap().to_owned())
+    };
+
     let core_worker = worker.core_worker();
-
     let interactions = async {
-        let update_handle = client
-            .start_update_with_start_workflow(
-                UpdateWithStartWf::run,
-                (),
-                UpdateWithStartWf::do_update,
-                "world".to_string(),
-                WorkflowUpdateWithStartOptions::new(
-                    task_queue.clone(),
-                    wf_id.clone(),
-                    WorkflowIdConflictPolicy::Fail,
-                )
+        let options = |conflict_policy| {
+            WorkflowUpdateWithStartOptions::new(task_queue.clone(), wf_id.clone(), conflict_policy)
                 .execution_timeout(Duration::from_secs(60 * 5))
-                .build(),
-            )
-            .await
-            .unwrap();
-        assert!(update_handle.workflow_run_id().is_some());
-        let result = update_handle.get_result(Default::default()).await.unwrap();
-        assert_eq!(result, "hello world");
+                .build()
+        };
+        match scenario {
+            UpdateWithStartScenario::StartAndGetHandle => {
+                let update_handle = client
+                    .start_update_with_start_workflow(
+                        UpdateWithStartWf::run,
+                        (),
+                        UpdateWithStartWf::do_update,
+                        "world".to_owned(),
+                        options(WorkflowIdConflictPolicy::Fail),
+                    )
+                    .await
+                    .unwrap();
+                assert!(update_handle.workflow_run_id().is_some());
+                assert_eq!(
+                    update_handle.get_result(Default::default()).await.unwrap(),
+                    "hello world"
+                );
+            }
+            UpdateWithStartScenario::ExecuteOnExisting => {
+                let result = client
+                    .execute_update_with_start_workflow(
+                        UpdateWithStartWf::run,
+                        (),
+                        UpdateWithStartWf::do_update,
+                        "again".to_owned(),
+                        options(WorkflowIdConflictPolicy::UseExisting),
+                    )
+                    .await
+                    .unwrap();
+                assert_eq!(result, "hello again");
+            }
+            UpdateWithStartScenario::UpdateFailure => {
+                let error = client
+                    .execute_update_with_start_workflow(
+                        UpdateWithStartWf::run,
+                        (),
+                        UpdateWithStartWf::do_update,
+                        "reject".to_owned(),
+                        options(WorkflowIdConflictPolicy::UseExisting),
+                    )
+                    .await
+                    .expect_err("rejected update must be returned as an update failure");
+                assert_matches!(
+                    error,
+                    WorkflowUpdateWithStartError::Update(WorkflowUpdateError::Failed(failure))
+                        if failure.message.contains("update rejected")
+                );
+            }
+            UpdateWithStartScenario::StartConflict => {
+                let error = client
+                    .execute_update_with_start_workflow(
+                        UpdateWithStartWf::run,
+                        (),
+                        UpdateWithStartWf::do_update,
+                        "unused".to_owned(),
+                        options(WorkflowIdConflictPolicy::Fail),
+                    )
+                    .await
+                    .expect_err("update-with-start must fail against a running workflow");
+                assert_matches!(
+                    error,
+                    WorkflowUpdateWithStartError::Start(WorkflowStartError::AlreadyStarted {
+                        run_id: Some(run_id),
+                        ..
+                    }) if existing_run_id.as_deref() == Some(run_id.as_str())
+                );
+            }
+        }
 
-        let second_result = client
-            .execute_update_with_start_workflow(
-                UpdateWithStartWf::run,
-                (),
-                UpdateWithStartWf::do_update,
-                "again".to_string(),
-                WorkflowUpdateWithStartOptions::new(
-                    task_queue.clone(),
-                    wf_id.clone(),
-                    WorkflowIdConflictPolicy::UseExisting,
-                )
-                .execution_timeout(Duration::from_secs(60 * 5))
-                .build(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(second_result, "hello again");
-
-        let wf_handle = client.get_workflow_handle::<update_with_start_wf::Run>(wf_id.clone());
+        let wf_handle = client.get_workflow_handle::<update_with_start_wf::Run>(wf_id);
         wf_handle
             .signal(
                 UpdateWithStartWf::done_signal,
@@ -1623,81 +1687,6 @@ async fn update_with_start() {
     };
     let run = async {
         worker.inner_mut().run().await.unwrap();
-    };
-    join!(interactions, run);
-}
-
-#[tokio::test]
-async fn update_with_start_fail_conflict_policy() {
-    let wf_name = "update_with_start_fail_conflict_policy";
-    let mut starter = CoreWfStarter::new(wf_name);
-    starter
-        .sdk_config
-        .register_workflow::<UwsConflictWf>()
-        .unwrap();
-    starter.set_core_task_types(WorkerTaskTypes::workflow_only());
-    let mut worker = starter.worker().await;
-    let client = starter.get_core_client().await;
-
-    #[workflow]
-    #[derive(Default)]
-    struct UwsConflictWf;
-
-    #[workflow_methods]
-    impl UwsConflictWf {
-        #[run]
-        async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.timer(Duration::from_secs(1)).await;
-            Ok(())
-        }
-
-        #[update]
-        async fn do_update(
-            _ctx: &mut WorkflowContext<Self>,
-            _: (),
-        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-            Ok(())
-        }
-    }
-
-    let task_queue = starter.get_task_queue().to_owned();
-    let wf_id = starter.get_wf_id().to_owned();
-    let handle = worker
-        .submit_workflow(
-            UwsConflictWf::run,
-            (),
-            WorkflowStartOptions::new(task_queue.clone(), wf_id.clone()).build(),
-        )
-        .await
-        .unwrap();
-    let existing_run_id = handle.run_id().unwrap().to_owned();
-
-    let interactions = async {
-        let error = client
-            .execute_update_with_start_workflow(
-                UwsConflictWf::run,
-                (),
-                UwsConflictWf::do_update,
-                (),
-                WorkflowUpdateWithStartOptions::new(
-                    task_queue.clone(),
-                    wf_id.clone(),
-                    WorkflowIdConflictPolicy::Fail,
-                )
-                .build(),
-            )
-            .await
-            .expect_err("update-with-start must fail against a running workflow");
-        assert_matches!(
-            error,
-            WorkflowUpdateWithStartError::Start(WorkflowStartError::AlreadyStarted {
-                run_id: Some(run_id),
-                ..
-            }) if run_id == existing_run_id
-        );
-    };
-    let run = async {
-        worker.run_until_done().await.unwrap();
     };
     join!(interactions, run);
 }

--- a/crates/sdk-core/tests/integ_tests/update_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/update_tests.rs
@@ -15,7 +15,9 @@ use std::{
 use temporalio_client::{
     Client, NamespacedClient, UntypedSignal, UntypedUpdate, UntypedWorkflow,
     WorkflowExecuteUpdateOptions, WorkflowExecutionInfo, WorkflowSignalOptions,
-    WorkflowStartOptions, errors::WorkflowUpdateError, grpc::WorkflowService,
+    WorkflowStartOptions, WorkflowUpdateWithStartOptions,
+    errors::{WorkflowStartError, WorkflowUpdateError, WorkflowUpdateWithStartError},
+    grpc::WorkflowService,
 };
 use temporalio_common::{
     data_converters::RawValue,
@@ -33,10 +35,11 @@ use temporalio_common::{
         },
         temporal::api::{
             common::v1::WorkflowExecution,
-            enums::v1::{EventType, ResetReapplyType},
+            enums::v1::{EventType, ResetReapplyType, WorkflowIdConflictPolicy},
             workflowservice::v1::{ResetStickyTaskQueueRequest, ResetWorkflowExecutionRequest},
         },
     },
+    worker::WorkerTaskTypes,
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
@@ -1521,4 +1524,180 @@ async fn update_lost_on_activity_mismatch() {
     };
     join!(update, runner);
     handle.fetch_history_and_replay(&mut worker).await.unwrap();
+}
+
+#[tokio::test]
+async fn update_with_start() {
+    let wf_name = "update_with_start";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter
+        .sdk_config
+        .register_workflow::<UpdateWithStartWf>()
+        .unwrap();
+    starter.set_core_task_types(WorkerTaskTypes::workflow_only());
+    let mut worker = starter.worker().await;
+    let client = starter.get_core_client().await;
+
+    #[workflow]
+    #[derive(Default)]
+    struct UpdateWithStartWf {
+        done: bool,
+    }
+
+    #[workflow_methods]
+    impl UpdateWithStartWf {
+        #[run]
+        async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+            ctx.wait_condition(|s| s.done).await?;
+            Ok(())
+        }
+
+        #[update]
+        async fn do_update(
+            _ctx: &mut WorkflowContext<Self>,
+            arg: String,
+        ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(format!("hello {arg}"))
+        }
+
+        #[signal]
+        fn done_signal(&mut self, _ctx: &mut SyncWorkflowContext<Self>, _: ()) {
+            self.done = true;
+        }
+    }
+
+    let task_queue = starter.get_task_queue().to_owned();
+    let wf_id = starter.get_wf_id().to_owned();
+    let core_worker = worker.core_worker();
+
+    let interactions = async {
+        let update_handle = client
+            .start_update_with_start_workflow(
+                UpdateWithStartWf::run,
+                (),
+                UpdateWithStartWf::do_update,
+                "world".to_string(),
+                WorkflowUpdateWithStartOptions::new(
+                    task_queue.clone(),
+                    wf_id.clone(),
+                    WorkflowIdConflictPolicy::Fail,
+                )
+                .execution_timeout(Duration::from_secs(60 * 5))
+                .build(),
+            )
+            .await
+            .unwrap();
+        assert!(update_handle.workflow_run_id().is_some());
+        let result = update_handle.get_result(Default::default()).await.unwrap();
+        assert_eq!(result, "hello world");
+
+        let second_result = client
+            .execute_update_with_start_workflow(
+                UpdateWithStartWf::run,
+                (),
+                UpdateWithStartWf::do_update,
+                "again".to_string(),
+                WorkflowUpdateWithStartOptions::new(
+                    task_queue.clone(),
+                    wf_id.clone(),
+                    WorkflowIdConflictPolicy::UseExisting,
+                )
+                .execution_timeout(Duration::from_secs(60 * 5))
+                .build(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second_result, "hello again");
+
+        let wf_handle = client.get_workflow_handle::<update_with_start_wf::Run>(wf_id.clone());
+        wf_handle
+            .signal(
+                UpdateWithStartWf::done_signal,
+                (),
+                WorkflowSignalOptions::default(),
+            )
+            .await
+            .unwrap();
+        wf_handle.get_result(Default::default()).await.unwrap();
+        core_worker.initiate_shutdown();
+    };
+    let run = async {
+        worker.inner_mut().run().await.unwrap();
+    };
+    join!(interactions, run);
+}
+
+#[tokio::test]
+async fn update_with_start_fail_conflict_policy() {
+    let wf_name = "update_with_start_fail_conflict_policy";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter
+        .sdk_config
+        .register_workflow::<UwsConflictWf>()
+        .unwrap();
+    starter.set_core_task_types(WorkerTaskTypes::workflow_only());
+    let mut worker = starter.worker().await;
+    let client = starter.get_core_client().await;
+
+    #[workflow]
+    #[derive(Default)]
+    struct UwsConflictWf;
+
+    #[workflow_methods]
+    impl UwsConflictWf {
+        #[run]
+        async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+            ctx.timer(Duration::from_secs(1)).await;
+            Ok(())
+        }
+
+        #[update]
+        async fn do_update(
+            _ctx: &mut WorkflowContext<Self>,
+            _: (),
+        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            Ok(())
+        }
+    }
+
+    let task_queue = starter.get_task_queue().to_owned();
+    let wf_id = starter.get_wf_id().to_owned();
+    let handle = worker
+        .submit_workflow(
+            UwsConflictWf::run,
+            (),
+            WorkflowStartOptions::new(task_queue.clone(), wf_id.clone()).build(),
+        )
+        .await
+        .unwrap();
+    let existing_run_id = handle.run_id().unwrap().to_owned();
+
+    let interactions = async {
+        let error = client
+            .execute_update_with_start_workflow(
+                UwsConflictWf::run,
+                (),
+                UwsConflictWf::do_update,
+                (),
+                WorkflowUpdateWithStartOptions::new(
+                    task_queue.clone(),
+                    wf_id.clone(),
+                    WorkflowIdConflictPolicy::Fail,
+                )
+                .build(),
+            )
+            .await
+            .expect_err("update-with-start must fail against a running workflow");
+        assert_matches!(
+            error,
+            WorkflowUpdateWithStartError::Start(WorkflowStartError::AlreadyStarted {
+                run_id: Some(run_id),
+                ..
+            }) if run_id == existing_run_id
+        );
+    };
+    let run = async {
+        worker.run_until_done().await.unwrap();
+    };
+    join!(interactions, run);
 }


### PR DESCRIPTION
Closes #1136

Adds atomic update-with-start to the client:

- `Client::start_update_with_start_workflow` and `Client::execute_update_with_start_workflow`, backed by the `ExecuteMultiOperation` RPC, with `WithStartWorkflowOperation` describing the start request.
- Multi-operation failures are decoded and attributed to the failing operation (`WorkflowUpdateWithStartError::Start`/`Update`).
- Interceptor support via `ClientInterceptor::update_with_start_workflow`.

Tested against local dev server.