### PR TITLE
:boom: Use heartbeat details field on activity failure instead of force-flush

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ document as your quick reference when submitting pull requests.
 - It is EXTREMELY IMPORTANT that any added comments should explain why something needs to be done,
   rather than what it is. Comments that simply state a fact easily understood from type signatures
   or other context should NEVER be added. Always prefer to avoid a comment unless it truly is 
-  clarifying something nonobvious.
+  clarifying something nonobvious. This does _NOT_ mean you should _remove_ any existing comments
+  unless they are no longer accurate.
 - Always make every attempt to avoid explicit sleeps in test code. Instead rely on synchronization
   techniques like channels, Notify, etc.
 - Rust compilation can take some time. Do not interrupt builds or tests unless they are taking more

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,9 @@ to docs, or any other relevant information.
 ### Fixed
 * Try-cancel child workflows no longer cause nondeterminism when they complete or fail after their
   cancellation was requested.
+* Activity failures now include the latest heartbeat details atomically instead of force-flushing a
+  throttled heartbeat first. Temporal Server 1.16.0 or newer is required to guarantee those details
+  are preserved on failure; workers warn when the server does not advertise support.
 * `RuntimeOptions::default()` now uses the same 60-second worker heartbeat interval as the
   builder default.
 * Local activity resolutions are now delivered to workflows as each activity completes instead of

--- a/crates/client/src/grpc.rs
+++ b/crates/client/src/grpc.rs
@@ -430,6 +430,11 @@ impl<C> PayloadLimitsClient<C> {
     pub fn set_error_limits(&self, limits: Option<PayloadErrorLimits>) {
         *self.error_limits.write() = limits;
     }
+
+    /// Return the error limits currently injected into requests.
+    pub fn error_limits(&self) -> Option<PayloadErrorLimits> {
+        *self.error_limits.read()
+    }
 }
 
 impl<C: RawClientProducer> RawClientProducer for PayloadLimitsClient<C> {

--- a/crates/sdk-core/src/core_tests/activity_tasks.rs
+++ b/crates/sdk-core/src/core_tests/activity_tasks.rs
@@ -8,20 +8,28 @@ use crate::{
         poll_and_reply, single_hist_mock_sg, start_timer_cmd, test_worker_cfg,
     },
     worker::{
-        PollerBehavior,
-        client::mocks::{mock_manual_worker_client, mock_worker_client},
+        PollerBehavior, WorkerVersioningStrategy,
+        client::{
+            WorkerClient, WorkerClientBag,
+            mocks::{mock_manual_worker_client, mock_worker_client},
+        },
     },
 };
 use futures_util::FutureExt;
 use itertools::Itertools;
+use prost::Message;
 use std::{
     collections::{HashMap, HashSet, VecDeque, hash_map::Entry},
     future,
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::{Duration, Instant},
+};
+use temporalio_client::{
+    Connection, ConnectionOptions, PayloadErrorLimits, SharedReplaceableClient,
+    callback_based::{CallbackBasedGrpcService, GrpcSuccessResponse},
 };
 use temporalio_common::{
     payload_limits::{LimitClass, LimitSeverity, PayloadLimitViolation},
@@ -47,16 +55,19 @@ use temporalio_common::{
             enums::v1::EventType,
             failure::v1::failure::FailureInfo,
             workflowservice::v1::{
-                PollActivityTaskQueueResponse, RecordActivityTaskHeartbeatResponse,
+                GetSystemInfoResponse, PollActivityTaskQueueResponse,
+                RecordActivityTaskHeartbeatRequest, RecordActivityTaskHeartbeatResponse,
                 RespondActivityTaskCanceledResponse, RespondActivityTaskCompletedResponse,
-                RespondActivityTaskFailedResponse, RespondWorkflowTaskCompletedResponse,
+                RespondActivityTaskFailedRequest, RespondActivityTaskFailedResponse,
+                RespondWorkflowTaskCompletedResponse, ShutdownWorkerResponse,
             },
         },
     },
     worker::WorkerTaskTypes,
 };
-use tokio::{join, time::sleep};
+use tokio::{join, sync::oneshot, time::sleep};
 use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
 
 fn three_tasks() -> VecDeque<PollActivityTaskQueueResponse> {
     VecDeque::from(vec![
@@ -700,6 +711,124 @@ async fn complete_act_with_fail_includes_latest_heartbeat() {
     .await
     .unwrap();
     core.drain_activity_poller_and_shutdown().await;
+}
+
+#[tokio::test]
+async fn oversized_throttled_heartbeat_failure_is_reported() {
+    let heartbeat_requests = Arc::new(Mutex::new(Vec::new()));
+    let failure_requests = Arc::new(Mutex::new(Vec::new()));
+    let (first_heartbeat_tx, first_heartbeat_rx) = oneshot::channel();
+    let first_heartbeat_tx = Arc::new(Mutex::new(Some(first_heartbeat_tx)));
+    let heartbeat_requests_clone = heartbeat_requests.clone();
+    let failure_requests_clone = failure_requests.clone();
+    let first_heartbeat_tx_clone = first_heartbeat_tx.clone();
+
+    let service_override = CallbackBasedGrpcService {
+        callback: Arc::new(move |request| {
+            let heartbeat_requests = heartbeat_requests_clone.clone();
+            let failure_requests = failure_requests_clone.clone();
+            let first_heartbeat_tx = first_heartbeat_tx_clone.clone();
+            Box::pin(async move {
+                let proto = match request.rpc.as_str() {
+                    "GetSystemInfo" => GetSystemInfoResponse::default().encode_to_vec(),
+                    "RecordActivityTaskHeartbeat" => {
+                        heartbeat_requests.lock().unwrap().push(
+                            RecordActivityTaskHeartbeatRequest::decode(request.proto)
+                                .expect("heartbeat request is valid"),
+                        );
+                        if let Some(tx) = first_heartbeat_tx.lock().unwrap().take() {
+                            let _ = tx.send(());
+                        }
+                        RecordActivityTaskHeartbeatResponse::default().encode_to_vec()
+                    }
+                    "RespondActivityTaskFailed" => {
+                        failure_requests.lock().unwrap().push(
+                            RespondActivityTaskFailedRequest::decode(request.proto)
+                                .expect("failure request is valid"),
+                        );
+                        RespondActivityTaskFailedResponse::default().encode_to_vec()
+                    }
+                    "ShutdownWorker" => ShutdownWorkerResponse::default().encode_to_vec(),
+                    rpc => panic!("unexpected RPC: {rpc}"),
+                };
+                Ok(GrpcSuccessResponse {
+                    headers: Default::default(),
+                    proto,
+                })
+            })
+        }),
+    };
+    let connection = Connection::connect(
+        ConnectionOptions::new(url::Url::parse("http://localhost:7233").unwrap())
+            .service_override(service_override)
+            .dns_load_balancing(None)
+            .build(),
+    )
+    .await
+    .unwrap();
+    let client = WorkerClientBag::new(
+        SharedReplaceableClient::new(connection),
+        "namespace".to_string(),
+        WorkerVersioningStrategy::None {
+            build_id: String::new(),
+        },
+        Uuid::new_v4(),
+    );
+    client.set_payload_error_limits(Some(PayloadErrorLimits { blob: 100, memo: 0 }));
+    let core = mock_worker(MocksHolder::from_client_with_activities(
+        client,
+        [PollActivityTaskQueueResponse {
+            task_token: vec![1],
+            activity_id: "act1".to_string(),
+            heartbeat_timeout: Some(prost_dur!(from_secs(10))),
+            ..Default::default()
+        }
+        .into()],
+    ));
+
+    let act = core.poll_activity_task().await.unwrap();
+    core.record_activity_heartbeat(ActivityHeartbeat {
+        task_token: act.task_token.clone(),
+        details: vec![vec![1].into()],
+    });
+    // Ensure the first heartbeat has opened the throttle window before recording the pending one.
+    tokio::time::timeout(Duration::from_secs(5), first_heartbeat_rx)
+        .await
+        .expect("first heartbeat was not sent")
+        .unwrap();
+    core.record_activity_heartbeat(ActivityHeartbeat {
+        task_token: act.task_token.clone(),
+        details: vec![vec![0; 1024].into()],
+    });
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        core.complete_activity_task(ActivityTaskCompletion {
+            task_token: act.task_token,
+            result: Some(ActivityExecutionResult::fail(
+                "original activity failure".into(),
+            )),
+        }),
+    )
+    .await
+    .expect("activity completion did not finish")
+    .unwrap();
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        core.drain_activity_poller_and_shutdown(),
+    )
+    .await
+    .expect("activity worker did not shut down");
+
+    let heartbeat_requests = heartbeat_requests.lock().unwrap();
+    assert_eq!(heartbeat_requests.len(), 1);
+    assert_eq!(
+        heartbeat_requests[0].details.as_ref().unwrap().payloads[0].data,
+        [1]
+    );
+    let failure_requests = failure_requests.lock().unwrap();
+    assert_eq!(failure_requests.len(), 1);
+    assert!(failure_requests[0].last_heartbeat_details.is_none());
+    assert_payloads_too_large_retryable(&failure_requests[0].failure);
 }
 
 #[tokio::test]

--- a/crates/sdk-core/src/core_tests/activity_tasks.rs
+++ b/crates/sdk-core/src/core_tests/activity_tasks.rs
@@ -15,10 +15,8 @@ use crate::{
 use futures_util::FutureExt;
 use itertools::Itertools;
 use std::{
-    cell::RefCell,
     collections::{HashMap, HashSet, VecDeque, hash_map::Entry},
     future,
-    rc::Rc,
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -652,30 +650,29 @@ async fn can_heartbeat_acts_during_shutdown() {
     core.drain_activity_poller_and_shutdown().await;
 }
 
-/// Verifies that if a user has tried to record a heartbeat and then immediately after failed the
-/// activity, that we flush those details before reporting the failure completion.
+/// Rapid heartbeats are not force-flushed before failure. The failure request carries the latest
+/// details atomically instead.
 #[tokio::test]
-async fn complete_act_with_fail_flushes_heartbeat() {
+async fn complete_act_with_fail_includes_latest_heartbeat() {
     let last_hb = 50;
     let mut mock_client = mock_worker_client();
-    let last_seen_payload = Rc::new(RefCell::new(None));
-    let lsp = last_seen_payload.clone();
     mock_client
         .expect_record_activity_heartbeat()
-        // Two times b/c we always record the first heartbeat, and we'll flush the last
-        .times(2)
-        .returning_st(move |_, payload| {
-            *lsp.borrow_mut() = payload;
+        .times(1)
+        .returning(move |_, payload| {
+            assert_eq!(payload.unwrap().payloads[0].data, [1]);
             Ok(RecordActivityTaskHeartbeatResponse {
                 cancel_requested: false,
                 activity_paused: false,
                 activity_reset: false,
             })
         });
-    mock_client
-        .expect_fail_activity_task()
-        .times(1)
-        .returning(|_, _| Ok(RespondActivityTaskFailedResponse::default()));
+    mock_client.expect_fail_activity_task().times(1).returning(
+        move |_, _, last_heartbeat_details| {
+            assert_eq!(last_heartbeat_details.unwrap().payloads[0].data, [last_hb]);
+            Ok(RespondActivityTaskFailedResponse::default())
+        },
+    );
 
     let core = mock_worker(MocksHolder::from_client_with_activities(
         mock_client,
@@ -703,10 +700,95 @@ async fn complete_act_with_fail_flushes_heartbeat() {
     .await
     .unwrap();
     core.drain_activity_poller_and_shutdown().await;
+}
 
-    // Verify the last seen call to record a heartbeat had the last detail payload
-    let last_seen_payload = &last_seen_payload.take().unwrap().payloads[0];
-    assert_eq!(last_seen_payload.data, &[last_hb]);
+#[tokio::test]
+async fn activity_failure_distinguishes_no_heartbeat_from_empty_heartbeat() {
+    for explicit_empty_heartbeat in [false, true] {
+        let mut mock_client = mock_worker_client();
+        mock_client
+            .expect_record_activity_heartbeat()
+            .times(usize::from(explicit_empty_heartbeat))
+            .returning(|_, details| {
+                assert!(details.is_none());
+                Ok(RecordActivityTaskHeartbeatResponse::default())
+            });
+        mock_client.expect_fail_activity_task().times(1).returning(
+            move |_, _, last_heartbeat_details| {
+                if explicit_empty_heartbeat {
+                    assert_eq!(last_heartbeat_details.unwrap().payloads, []);
+                } else {
+                    assert!(last_heartbeat_details.is_none());
+                }
+                Ok(RespondActivityTaskFailedResponse::default())
+            },
+        );
+
+        let core = mock_worker(MocksHolder::from_client_with_activities(
+            mock_client,
+            [PollActivityTaskQueueResponse {
+                task_token: vec![1],
+                activity_id: "act1".to_string(),
+                heartbeat_timeout: Some(prost_dur!(from_secs(10))),
+                ..Default::default()
+            }
+            .into()],
+        ));
+
+        let act = core.poll_activity_task().await.unwrap();
+        if explicit_empty_heartbeat {
+            core.record_activity_heartbeat(ActivityHeartbeat {
+                task_token: act.task_token.clone(),
+                details: vec![],
+            });
+        }
+        core.complete_activity_task(ActivityTaskCompletion {
+            task_token: act.task_token,
+            result: Some(ActivityExecutionResult::fail("Ahh".into())),
+        })
+        .await
+        .unwrap();
+        core.drain_activity_poller_and_shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn activity_cancellation_still_flushes_latest_heartbeat() {
+    let mut mock_client = mock_worker_client();
+    mock_client
+        .expect_record_activity_heartbeat()
+        .times(2)
+        .returning(|_, _| Ok(RecordActivityTaskHeartbeatResponse::default()));
+    mock_client
+        .expect_cancel_activity_task()
+        .times(1)
+        .returning(|_, _| Ok(RespondActivityTaskCanceledResponse::default()));
+
+    let core = mock_worker(MocksHolder::from_client_with_activities(
+        mock_client,
+        [PollActivityTaskQueueResponse {
+            task_token: vec![1],
+            activity_id: "act1".to_string(),
+            heartbeat_timeout: Some(prost_dur!(from_secs(10))),
+            ..Default::default()
+        }
+        .into()],
+    ));
+
+    let act = core.poll_activity_task().await.unwrap();
+    for detail in [1_u8, 2] {
+        core.record_activity_heartbeat(ActivityHeartbeat {
+            task_token: act.task_token.clone(),
+            details: vec![vec![detail].into()],
+        });
+    }
+    core.complete_activity_task(ActivityTaskCompletion {
+        task_token: act.task_token,
+        result: Some(ActivityExecutionResult::cancel_from_details(None)),
+    })
+    .await
+    .unwrap();
+    core.drain_activity_poller_and_shutdown().await;
 }
 
 /// Builds a tonic `Status` carrying a `PayloadLimitViolation` source, exactly as the gRPC client
@@ -735,22 +817,71 @@ fn assert_payloads_too_large_retryable(
     );
 }
 
+#[tokio::test]
+async fn oversized_activity_result_failure_includes_latest_heartbeat() {
+    let mut mock_client = mock_worker_client();
+    mock_client
+        .expect_record_activity_heartbeat()
+        .times(1)
+        .returning(|_, _| Ok(RecordActivityTaskHeartbeatResponse::default()));
+    mock_client
+        .expect_complete_activity_task()
+        .times(1)
+        .returning(|_, _| Err(payload_too_large_status()));
+    mock_client.expect_fail_activity_task().times(1).returning(
+        |_, failure, last_heartbeat_details| {
+            assert_payloads_too_large_retryable(&failure);
+            assert_eq!(last_heartbeat_details.unwrap().payloads[0].data, [2]);
+            Ok(RespondActivityTaskFailedResponse::default())
+        },
+    );
+
+    let core = mock_worker(MocksHolder::from_client_with_activities(
+        mock_client,
+        [PollActivityTaskQueueResponse {
+            task_token: vec![1],
+            activity_id: "act1".to_string(),
+            heartbeat_timeout: Some(prost_dur!(from_secs(10))),
+            ..Default::default()
+        }
+        .into()],
+    ));
+    let act = core.poll_activity_task().await.unwrap();
+    for detail in [1_u8, 2] {
+        core.record_activity_heartbeat(ActivityHeartbeat {
+            task_token: act.task_token.clone(),
+            details: vec![vec![detail].into()],
+        });
+    }
+    core.complete_activity_task(ActivityTaskCompletion {
+        task_token: act.task_token,
+        result: Some(ActivityExecutionResult::ok(vec![0_u8; 1024].into())),
+    })
+    .await
+    .unwrap();
+    core.drain_activity_poller_and_shutdown().await;
+}
+
 /// An oversized cancel `details` payload must be reported as a (retryable) activity task failure
 /// rather than a cancellation — mirroring the success path and the server's own behavior.
 #[tokio::test]
 async fn oversized_cancel_details_fails_activity() {
     let mut mock_client = mock_worker_client();
     mock_client
+        .expect_record_activity_heartbeat()
+        .times(2)
+        .returning(|_, _| Ok(RecordActivityTaskHeartbeatResponse::default()));
+    mock_client
         .expect_cancel_activity_task()
         .times(1)
         .returning(|_, _| Err(payload_too_large_status()));
-    mock_client
-        .expect_fail_activity_task()
-        .times(1)
-        .returning(|_, failure| {
+    mock_client.expect_fail_activity_task().times(1).returning(
+        |_, failure, last_heartbeat_details| {
             assert_payloads_too_large_retryable(&failure);
+            assert_eq!(last_heartbeat_details.unwrap().payloads[0].data, [2]);
             Ok(RespondActivityTaskFailedResponse::default())
-        });
+        },
+    );
 
     let core = mock_worker(MocksHolder::from_client_with_activities(
         mock_client,
@@ -763,6 +894,12 @@ async fn oversized_cancel_details_fails_activity() {
     ));
 
     let act = core.poll_activity_task().await.unwrap();
+    for detail in [1_u8, 2] {
+        core.record_activity_heartbeat(ActivityHeartbeat {
+            task_token: act.task_token.clone(),
+            details: vec![vec![detail].into()],
+        });
+    }
     core.complete_activity_task(ActivityTaskCompletion {
         task_token: act.task_token,
         result: Some(ActivityExecutionResult::cancel_from_details(Some(
@@ -784,13 +921,13 @@ async fn oversized_heartbeat_fails_activity() {
         .expect_record_activity_heartbeat()
         .times(1)
         .returning(|_, _| Err(payload_too_large_status()));
-    mock_client
-        .expect_fail_activity_task()
-        .times(1)
-        .returning(|_, failure| {
+    mock_client.expect_fail_activity_task().times(1).returning(
+        |_, failure, last_heartbeat_details| {
             assert_payloads_too_large_retryable(&failure);
+            assert!(last_heartbeat_details.is_none());
             Ok(RespondActivityTaskFailedResponse::default())
-        });
+        },
+    );
     // The activity winds down after the stop-cancel and reports its cancellation, which races to a
     // NotFound (already failed); allow that call.
     mock_client
@@ -1183,9 +1320,22 @@ async fn graceful_shutdown(#[values(true, false)] at_max_outstanding: bool) {
     // They shall all be reported as failed
     let mut mock_client = mock_worker_client();
     mock_client
-        .expect_fail_activity_task()
-        .times(3)
-        .returning(|_, _| Ok(Default::default()));
+        .expect_record_activity_heartbeat()
+        .times(1)
+        .returning(|_, details| {
+            assert_eq!(details.unwrap().payloads[0].data, [1]);
+            Ok(RecordActivityTaskHeartbeatResponse::default())
+        });
+    mock_client.expect_fail_activity_task().times(3).returning(
+        |task_token, _, last_heartbeat_details| {
+            if task_token.0 == [1] {
+                assert_eq!(last_heartbeat_details.unwrap().payloads[0].data, [2]);
+            } else {
+                assert!(last_heartbeat_details.is_none());
+            }
+            Ok(Default::default())
+        },
+    );
 
     let max_outstanding = if at_max_outstanding { 3_usize } else { 100 };
     let mw = MockWorkerInputs {
@@ -1200,7 +1350,13 @@ async fn graceful_shutdown(#[values(true, false)] at_max_outstanding: bool) {
     };
     let worker = mock_worker(MocksHolder::from_mock_worker(mock_client, mw));
 
-    let _1 = worker.poll_activity_task().await.unwrap();
+    let first = worker.poll_activity_task().await.unwrap();
+    for detail in [1_u8, 2] {
+        worker.record_activity_heartbeat(ActivityHeartbeat {
+            task_token: first.task_token.clone(),
+            details: vec![vec![detail].into()],
+        });
+    }
 
     // Wait at least the grace period after one poll - ensuring it doesn't trigger prematurely
     tokio::time::sleep(grace_period.mul_f32(1.1)).await;

--- a/crates/sdk-core/src/worker/activities.rs
+++ b/crates/sdk-core/src/worker/activities.rs
@@ -46,6 +46,7 @@ use temporalio_common::{
             activity_task::{ActivityCancelReason, ActivityCancellationDetails, ActivityTask},
         },
         temporal::api::{
+            common::v1::{Payload, Payloads},
             failure::v1::{
                 ApplicationFailureInfo, CanceledFailureInfo, Failure, failure::FailureInfo,
             },
@@ -117,6 +118,8 @@ struct RemoteInFlightActInfo {
     local_timeouts_task: Option<JoinHandle<()>>,
     /// Used to reset the local heartbeat timeout every time we record a heartbeat
     timeout_resetter: Option<Arc<Notify>>,
+    /// The most recent heartbeat received from lang, independently of whether it has been sent.
+    last_heartbeat_details: Option<Vec<Payload>>,
     /// The permit from the max concurrent semaphore
     _permit: UsedMeteredSemPermit<ActivitySlotKind>,
 }
@@ -140,6 +143,7 @@ impl RemoteInFlightActInfo {
             known_not_found: false,
             local_timeouts_task: None,
             timeout_resetter: None,
+            last_heartbeat_details: None,
             _permit: permit,
         }
     }
@@ -347,14 +351,21 @@ impl WorkerActivityTasks {
             if let Some(jh) = act_info.local_timeouts_task {
                 jh.abort()
             };
+            // Cancellation responses cannot carry heartbeat details, so normal cancellations must
+            // flush them separately. Worker-shutdown cancellations are reported as failures below.
             let should_flush = !known_not_found
+                && matches!(&status, aer::Status::Cancelled(_))
                 && !matches!(
-                    &status,
-                    aer::Status::Completed(_) | aer::Status::WillCompleteAsync(_)
+                    act_info.issued_cancel_to_lang,
+                    Some(ActivityCancelReason::WorkerShutdown)
                 );
             self.heartbeat_manager
                 .evict(task_token.clone(), should_flush)
                 .await;
+
+            let last_heartbeat_details = act_info
+                .last_heartbeat_details
+                .map(|payloads| Payloads { payloads });
 
             // No need to report activities which we already know the server doesn't care about
             if !known_not_found {
@@ -384,6 +395,7 @@ impl WorkerActivityTasks {
                                         .fail_activity_task(
                                             task_token.clone(),
                                             Some(make_payloads_too_large_failure(violation)),
+                                            last_heartbeat_details.clone(),
                                         )
                                         .await
                                         .err()
@@ -398,7 +410,7 @@ impl WorkerActivityTasks {
                             act_metrics.act_execution_failed();
                         }
                         client
-                            .fail_activity_task(task_token.clone(), failure)
+                            .fail_activity_task(task_token.clone(), failure, last_heartbeat_details)
                             .await
                             .err()
                     }
@@ -414,6 +426,7 @@ impl WorkerActivityTasks {
                                 .fail_activity_task(
                                     task_token.clone(),
                                     Some(worker_shutdown_failure()),
+                                    last_heartbeat_details,
                                 )
                                 .await
                                 .err()
@@ -445,6 +458,7 @@ impl WorkerActivityTasks {
                                             .fail_activity_task(
                                                 task_token.clone(),
                                                 Some(make_payloads_too_large_failure(violation)),
+                                                last_heartbeat_details,
                                             )
                                             .await
                                             .err()
@@ -484,10 +498,11 @@ impl WorkerActivityTasks {
     ) -> Result<(), ActivityHeartbeatError> {
         // TODO: Propagate these back as cancels. Silent fails is too nonobvious
         let (heartbeat_timeout, timeout_resetter) = {
-            let outstanding_activity_tasks = self.outstanding_activity_tasks.lock();
+            let mut outstanding_activity_tasks = self.outstanding_activity_tasks.lock();
             let at_info = outstanding_activity_tasks
-                .get(&TaskToken(details.task_token.clone()))
+                .get_mut(&TaskToken(details.task_token.clone()))
                 .ok_or(ActivityHeartbeatError::UnknownActivity)?;
+            at_info.last_heartbeat_details = Some(details.details.clone());
             (at_info.heartbeat_timeout, at_info.timeout_resetter.clone())
         };
         let heartbeat_timeout: Duration = heartbeat_timeout

--- a/crates/sdk-core/src/worker/activities/activity_heartbeat_manager.rs
+++ b/crates/sdk-core/src/worker/activities/activity_heartbeat_manager.rs
@@ -202,6 +202,7 @@ impl ActivityHeartbeatManager {
                                                 .fail_activity_task(
                                                     tt.clone(),
                                                     Some(make_payloads_too_large_failure(violation)),
+                                                    None,
                                                 )
                                                 .await
                                             {

--- a/crates/sdk-core/src/worker/client.rs
+++ b/crates/sdk-core/src/worker/client.rs
@@ -212,6 +212,7 @@ pub trait WorkerClient: Sync + Send {
         &self,
         task_token: TaskToken,
         failure: Option<Failure>,
+        last_heartbeat_details: Option<Payloads>,
     ) -> Result<RespondActivityTaskFailedResponse>;
     /// Fail a workflow task
     async fn fail_workflow_task(
@@ -613,6 +614,7 @@ impl WorkerClient for WorkerClientBag {
         &self,
         task_token: TaskToken,
         failure: Option<Failure>,
+        last_heartbeat_details: Option<Payloads>,
     ) -> Result<RespondActivityTaskFailedResponse> {
         Ok(self
             .client
@@ -624,8 +626,7 @@ impl WorkerClient for WorkerClientBag {
                     failure,
                     identity: self.identity(),
                     namespace: self.namespace.clone(),
-                    // TODO: Implement - https://github.com/temporalio/sdk-core/issues/293
-                    last_heartbeat_details: None,
+                    last_heartbeat_details,
                     worker_version: self.worker_version_stamp(),
                     // Will never be set, deprecated.
                     deployment: None,
@@ -988,6 +989,72 @@ mod tests {
         callback_based::{CallbackBasedGrpcService, GrpcSuccessResponse},
     };
     use temporalio_common::worker::{WorkerDeploymentOptions, WorkerDeploymentVersion};
+
+    #[tokio::test]
+    async fn activity_failure_request_includes_last_heartbeat_details() {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let requests_clone = requests.clone();
+        let service_override = CallbackBasedGrpcService {
+            callback: Arc::new(move |request| {
+                let requests = requests_clone.clone();
+                Box::pin(async move {
+                    let proto = match request.rpc.as_str() {
+                        "GetSystemInfo" => GetSystemInfoResponse::default().encode_to_vec(),
+                        "RespondActivityTaskFailed" => {
+                            requests.lock().unwrap().push(
+                                RespondActivityTaskFailedRequest::decode(request.proto)
+                                    .expect("failure request is valid"),
+                            );
+                            RespondActivityTaskFailedResponse::default().encode_to_vec()
+                        }
+                        rpc => panic!("unexpected RPC: {rpc}"),
+                    };
+                    Ok(GrpcSuccessResponse {
+                        headers: Default::default(),
+                        proto,
+                    })
+                })
+            }),
+        };
+        let connection = Connection::connect(
+            ConnectionOptions::new(url::Url::parse("http://localhost:7233").unwrap())
+                .service_override(service_override)
+                .dns_load_balancing(None)
+                .build(),
+        )
+        .await
+        .unwrap();
+        let client = WorkerClientBag::new(
+            SharedReplaceableClient::new(connection),
+            "namespace".to_string(),
+            WorkerVersioningStrategy::None {
+                build_id: String::new(),
+            },
+            Uuid::new_v4(),
+        );
+        let last_heartbeat_details = Payloads {
+            payloads: vec![
+                temporalio_common::protos::temporal::api::common::v1::Payload {
+                    data: vec![1, 2, 3],
+                    ..Default::default()
+                },
+            ],
+        };
+
+        client
+            .fail_activity_task(
+                TaskToken(vec![1]),
+                None,
+                Some(last_heartbeat_details.clone()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            requests.lock().unwrap()[0].last_heartbeat_details,
+            Some(last_heartbeat_details)
+        );
+    }
 
     #[allow(deprecated)]
     #[tokio::test]

--- a/crates/sdk-core/src/worker/client.rs
+++ b/crates/sdk-core/src/worker/client.rs
@@ -613,9 +613,34 @@ impl WorkerClient for WorkerClientBag {
     async fn fail_activity_task(
         &self,
         task_token: TaskToken,
-        failure: Option<Failure>,
-        last_heartbeat_details: Option<Payloads>,
+        mut failure: Option<Failure>,
+        mut last_heartbeat_details: Option<Payloads>,
     ) -> Result<RespondActivityTaskFailedResponse> {
+        let payload_error_limits = self.client.error_limits();
+        if let (Some(details), Some(limits)) =
+            (last_heartbeat_details.as_ref(), payload_error_limits)
+        {
+            let heartbeat_request = RecordActivityTaskHeartbeatRequest {
+                details: Some(details.clone()),
+                ..Default::default()
+            };
+            let payload_limits = temporalio_common::payload_limits::PayloadLimits {
+                blob_error: limits.blob,
+                memo_error: limits.memo,
+                ..Default::default()
+            };
+            if let Some(violation) =
+                temporalio_common::payload_limits::validate_known_payload_limits(
+                    &heartbeat_request,
+                    &payload_limits,
+                )
+            {
+                failure = Some(crate::worker::activities::make_payloads_too_large_failure(
+                    &violation,
+                ));
+                last_heartbeat_details = None;
+            }
+        }
         Ok(self
             .client
             .clone()

--- a/crates/sdk-core/src/worker/client/mocks.rs
+++ b/crates/sdk-core/src/worker/client/mocks.rs
@@ -114,6 +114,7 @@ mockall::mock! {
             &self,
             task_token: TaskToken,
             failure: Option<Failure>,
+            last_heartbeat_details: Option<Payloads>,
         ) -> impl Future<Output = Result<RespondActivityTaskFailedResponse>> + Send + 'b
             where 'a: 'b, Self: 'b;
 

--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -882,8 +882,8 @@ impl Worker {
         // Build the poller-dependent subsystems lazily. This closure runs once, after namespace
         // capabilities have been fetched (see `Worker::validate`), so the effective poller behavior
         // can be resolved with knowledge of those capabilities.
-        let task_subsystems_builder: Box<dyn FnOnce() -> TaskSubsystems + Send> =
-            Box::new(move || {
+        let task_subsystems_builder: Box<dyn FnOnce() -> TaskSubsystems + Send> = Box::new(
+            move || {
                 let (wft_stream, act_poller, nexus_poller) = match task_pollers {
                     TaskPollers::Real => {
                         let wft_stream = if config.task_types.enable_workflows {
@@ -1011,6 +1011,15 @@ impl Worker {
                     }
                 };
 
+                if act_poller.is_some()
+                    && !client
+                        .capabilities()
+                        .is_some_and(|caps| caps.activity_failure_include_heartbeat)
+                {
+                    warn!(
+                        "Temporal Server 1.16.0 or newer is required to guarantee that the latest heartbeat details are preserved when an activity fails; the server did not advertise the activity_failure_include_heartbeat capability, so heartbeat details may be lost on failure"
+                    );
+                }
                 let at_task_mgr = act_poller.map(|ap| {
                     WorkerActivityTasks::new(
                         act_slots.clone(),
@@ -1085,7 +1094,8 @@ impl Worker {
                     at_task_mgr,
                     nexus_mgr,
                 }
-            });
+            },
+        );
 
         Ok(Self {
             worker_instance_key,

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -1,8 +1,7 @@
 use crate::{
     common::{
         ActivationAssertionsInterceptor, CoreWfStarter, INTEG_CLIENT_IDENTITY,
-        activity_functions::StdActivities, build_fake_sdk_intercepted, eventually,
-        init_core_and_create_wf, mock_sdk, mock_sdk_cfg,
+        activity_functions::StdActivities, build_fake_sdk_intercepted, init_core_and_create_wf, mock_sdk, mock_sdk_cfg,
     },
     shared_tests,
 };
@@ -17,8 +16,7 @@ use std::{
     time::Duration,
 };
 use temporalio_client::{
-    ActivityIdentifier, UntypedWorkflow, WorkflowDescribeOptions, WorkflowStartOptions,
-    WorkflowTerminateOptions,
+    ActivityIdentifier, UntypedWorkflow, WorkflowStartOptions, WorkflowTerminateOptions,
 };
 
 use temporalio_common::{
@@ -28,7 +26,6 @@ use temporalio_common::{
     protos::{
         coresdk::{
             ActivityHeartbeat, ActivityTaskCompletion, AsJsonPayloadExt, IntoCompletion,
-            IntoPayloadsExt,
             activity_result::{
                 self, ActivityExecutionResult, ActivityResolution, activity_resolution as act_res,
             },
@@ -1622,26 +1619,25 @@ async fn activity_cancelled_after_heartbeat_times_out() {
         .unwrap();
 }
 
-#[ignore] // Currently skipped because of https://github.com/temporalio/temporal/issues/8376
 #[tokio::test]
-async fn activity_heartbeat_not_flushed_on_success() {
-    let mut starter = init_core_and_create_wf("activity_heartbeat_not_flushed_on_success").await;
+async fn activity_failure_includes_latest_heartbeat_on_retry() {
+    let mut starter =
+        init_core_and_create_wf("activity_failure_includes_latest_heartbeat_on_retry").await;
     let core = starter.get_worker().await;
     let task_q = starter.get_task_queue().to_string();
-    let activity_id = "act-1";
     let task = core.poll_workflow_activation().await.unwrap();
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
         task.run_id,
         ScheduleActivity {
             seq: 0,
-            activity_id: activity_id.to_string(),
+            activity_id: "act-1".to_string(),
             activity_type: "dontcare".to_string(),
             task_queue: task_q.clone(),
             schedule_to_close_timeout: Some(prost_dur!(from_secs(60))),
             heartbeat_timeout: Some(prost_dur!(from_secs(10))),
             retry_policy: Some(RetryPolicy {
                 maximum_attempts: 2,
-                initial_interval: Some(prost_dur!(from_secs(5))),
+                initial_interval: Some(prost_dur!(from_millis(10))),
                 ..Default::default()
             }),
             ..Default::default()
@@ -1663,45 +1659,45 @@ async fn activity_heartbeat_not_flushed_on_success() {
         task_token: task.task_token.clone(),
         details: vec!["two".into()],
     });
-    // Complete activity with fail
-    let failure = Failure::application_failure("activity failed".to_string(), false);
     core.complete_activity_task(ActivityTaskCompletion {
         task_token: task.task_token,
-        result: Some(ActivityExecutionResult::fail(failure)),
+        result: Some(ActivityExecutionResult::fail(Failure::application_failure(
+            "activity failed".to_string(),
+            false,
+        ))),
     })
     .await
     .unwrap();
-    // The activity is still in the pending state since it has retries left
-    let client = starter.get_client().await;
-    eventually(
-        || async {
-            // Verify pending details has the flushed heartbeat
-            let details = client
-                .get_workflow_handle::<UntypedWorkflow>(starter.get_wf_id().to_string())
-                .describe(WorkflowDescribeOptions::default())
-                .await
-                .unwrap();
-            let last_deets = details
-                .raw_description
-                .pending_activities
-                .into_iter()
-                .find(|i| i.activity_id == activity_id)
-                .and_then(|i| i.heartbeat_details);
-            if last_deets == ["two".into()].into_payloads() {
-                Ok(())
-            } else {
-                Err("details don't yet match")
-            }
-        },
-        Duration::from_secs(5),
-    )
+
+    let retry = core.poll_activity_task().await.unwrap();
+    let retry_task_token = retry.task_token;
+    let retry_start =
+        assert_matches!(retry.variant, Some(act_task::Variant::Start(start)) => start);
+    assert_eq!(retry_start.heartbeat_details, ["two".into()]);
+    core.complete_activity_task(ActivityTaskCompletion {
+        task_token: retry_task_token,
+        result: Some(ActivityExecutionResult::ok("done".into())),
+    })
     .await
     .unwrap();
-    client
-        .get_workflow_handle::<UntypedWorkflow>(task_q)
-        .terminate(WorkflowTerminateOptions::default())
-        .await
-        .unwrap();
+
+    let task = core.poll_workflow_activation().await.unwrap();
+    assert_matches!(
+        task.jobs.as_slice(),
+        [WorkflowActivationJob {
+            variant: Some(workflow_activation_job::Variant::ResolveActivity(
+                ResolveActivity {
+                    result: Some(ActivityResolution {
+                        status: Some(act_res::Status::Completed(_)),
+                        ..
+                    }),
+                    ..
+                }
+            )),
+        }]
+    );
+    core.complete_execution(&task.run_id).await;
+    core.handle_eviction().await;
     drain_pollers_and_shutdown(&core).await;
 }
 

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -1,7 +1,8 @@
 use crate::{
     common::{
         ActivationAssertionsInterceptor, CoreWfStarter, INTEG_CLIENT_IDENTITY,
-        activity_functions::StdActivities, build_fake_sdk_intercepted, init_core_and_create_wf, mock_sdk, mock_sdk_cfg,
+        activity_functions::StdActivities, build_fake_sdk_intercepted, init_core_and_create_wf,
+        mock_sdk, mock_sdk_cfg,
     },
     shared_tests,
 };


### PR DESCRIPTION
… flush

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Title

I chose to no longer use the old path since this field has existed for a _long_ time now. A warning is issued if pointed at a too-old server.

## Why?
Avoids unnecessary heartbeat RPC and makes final details atomic with failure.

We still force a flush when the activity is completing as cancelled, because no such field exists on the cancel response (probably it should, but, fairly niche situation).

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-rust/issues/293
2. How was this tested:
Existing & new tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
