### PR TITLE
Use typed worker run errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ to docs, or any other relevant information.
 
 ### Breaking Changes :boom:
 * `Worker::run` now returns `WorkerRunError` instead of `anyhow::Error`.
+  Non-validation failures are reported as `WorkerRunError::Fatal` with a message and source.
 * `CancellableFuture` and `CancellableFutureWithReason` now use the inherited `Future::Output`
   associated type instead of a generic output parameter.
 * `TimerOptions` is now tagged with `#[non_exhaustive]`. Use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ to docs, or any other relevant information.
 * `DnsLoadBalancingOptions::builder()` for configuring DNS re-resolution intervals.
 
 ### Breaking Changes :boom:
+* `Worker::run` now returns `WorkerRunError` instead of `anyhow::Error`.
 * `CancellableFuture` and `CancellableFutureWithReason` now use the inherited `Future::Output`
   associated type instead of a generic output parameter.
 * `TimerOptions` is now tagged with `#[non_exhaustive]`. Use

--- a/crates/sdk-core/tests/common/mod.rs
+++ b/crates/sdk-core/tests/common/mod.rs
@@ -793,7 +793,10 @@ impl TestWorker {
             interceptor_router.clear();
         }
         let get_results_waiter = completion_waiter.wait_all_wfs();
-        tokio::try_join!(self.inner.run(), get_results_waiter)?;
+        tokio::try_join!(
+            async { self.inner.run().await.map_err(anyhow::Error::from) },
+            get_results_waiter
+        )?;
         Ok(())
     }
 

--- a/crates/sdk/src/error.rs
+++ b/crates/sdk/src/error.rs
@@ -2,6 +2,9 @@
 
 pub use crate::workflow_registry::WorkflowRegistrationError;
 use temporalio_client::PluginApplyError;
+use temporalio_sdk_core::{
+    CompleteActivityError, CompleteWfError, PollError, WorkerValidationError,
+};
 
 /// Errors that can occur while creating a worker.
 ///
@@ -15,6 +18,39 @@ pub enum WorkerCreateError {
     /// Worker initialization failed after plugin configuration completed.
     #[error("worker initialization failed: {0}")]
     Initialization(#[source] anyhow::Error),
+}
+
+/// Errors that can occur while running a worker.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum WorkerRunError {
+    /// Worker validation failed before polling began.
+    #[error("worker validation failed")]
+    Validation(#[source] WorkerValidationError),
+    /// Polling for a workflow activation failed.
+    #[error("workflow polling failed")]
+    WorkflowPoll(#[source] PollError),
+    /// A worker interceptor failed while processing a workflow activation.
+    #[error("workflow activation interceptor failed")]
+    WorkflowActivationInterceptor(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    /// The SDK failed while processing a workflow activation.
+    #[error("workflow activation processing failed")]
+    WorkflowActivation(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    /// A workflow future failed.
+    #[error("workflow futures encountered an error")]
+    WorkflowFutures(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    /// The workflow completion processor failed.
+    #[error("workflow completions processor encountered an error")]
+    WorkflowCompletions(#[source] CompleteWfError),
+    /// Polling for an activity task failed.
+    #[error("activity polling failed")]
+    ActivityPoll(#[source] PollError),
+    /// Completing an activity task failed.
+    #[error("activity completion failed")]
+    ActivityCompletion(#[source] Box<CompleteActivityError>),
+    /// The SDK failed while handling an activity task.
+    #[error("activity task handling failed")]
+    ActivityTask(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 pub use temporalio_common::error::{
     ActivityExecutionError, ApplicationErrorCategory, ApplicationFailure,

--- a/crates/sdk/src/error.rs
+++ b/crates/sdk/src/error.rs
@@ -2,9 +2,7 @@
 
 pub use crate::workflow_registry::WorkflowRegistrationError;
 use temporalio_client::PluginApplyError;
-use temporalio_sdk_core::{
-    CompleteActivityError, CompleteWfError, PollError, WorkerValidationError,
-};
+use temporalio_sdk_core::WorkerValidationError;
 
 /// Errors that can occur while creating a worker.
 ///
@@ -25,33 +23,19 @@ pub enum WorkerCreateError {
 #[non_exhaustive]
 pub enum WorkerRunError {
     /// Worker validation failed before polling began.
-    #[error("worker validation failed")]
+    #[error("worker validation failed: {0}")]
     Validation(#[source] WorkerValidationError),
-    /// Polling for a workflow activation failed.
-    #[error("workflow polling failed")]
-    WorkflowPoll(#[source] PollError),
-    /// A worker interceptor failed while processing a workflow activation.
-    #[error("workflow activation interceptor failed")]
-    WorkflowActivationInterceptor(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
-    /// The SDK failed while processing a workflow activation.
-    #[error("workflow activation processing failed")]
-    WorkflowActivation(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
-    /// A workflow future failed.
-    #[error("workflow futures encountered an error")]
-    WorkflowFutures(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
-    /// The workflow completion processor failed.
-    #[error("workflow completions processor encountered an error")]
-    WorkflowCompletions(#[source] CompleteWfError),
-    /// Polling for an activity task failed.
-    #[error("activity polling failed")]
-    ActivityPoll(#[source] PollError),
-    /// Completing an activity task failed.
-    #[error("activity completion failed")]
-    ActivityCompletion(#[source] Box<CompleteActivityError>),
-    /// The SDK failed while handling an activity task.
-    #[error("activity task handling failed")]
-    ActivityTask(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    /// An unrecoverable error occurred while running the worker.
+    #[error("{message}: {source}")]
+    Fatal {
+        /// Worker operation that could not continue.
+        message: String,
+        /// Underlying cause.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
 }
+
 pub use temporalio_common::error::{
     ActivityExecutionError, ApplicationErrorCategory, ApplicationFailure,
     ChildWorkflowExecutionError, ChildWorkflowStartError, OutgoingActivityError, OutgoingError,

--- a/crates/sdk/src/error.rs
+++ b/crates/sdk/src/error.rs
@@ -2,7 +2,7 @@
 
 pub use crate::workflow_registry::WorkflowRegistrationError;
 use temporalio_client::PluginApplyError;
-use temporalio_sdk_core::WorkerValidationError;
+pub use temporalio_sdk_core::WorkerValidationError;
 
 /// Errors that can occur while creating a worker.
 ///
@@ -26,7 +26,7 @@ pub enum WorkerRunError {
     #[error("worker validation failed: {0}")]
     Validation(#[source] WorkerValidationError),
     /// An unrecoverable error occurred while running the worker.
-    #[error("{message}: {source}")]
+    #[error("{message}")]
     Fatal {
         /// Worker operation that could not continue.
         message: String,

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -113,7 +113,7 @@ use crate::{
         activity_error_to_core_result,
     },
     interceptors::{ActivityInboundInterceptor, WorkerInterceptor},
-    workflow_executor::{TaskDroppedError, TaskHandle, WorkflowExecutor},
+    workflow_executor::{TaskHandle, WorkflowExecutor},
     workflow_future::start_workflow,
     workflow_interceptors::WorkflowInterceptorConstructor,
 };

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -965,7 +965,10 @@ impl Worker {
                     },
                 )
                 .await
-                .map_err(|source| WorkerRunError::WorkflowFutures(Box::new(source)))
+                .map_err(|source| WorkerRunError::Fatal {
+                    message: "workflow futures encountered an error".to_owned(),
+                    source: Box::new(source),
+                })
         };
         let wf_completion_processor = async {
             UnboundedReceiverStream::new(completions_rx)
@@ -978,7 +981,10 @@ impl Worker {
                     common.worker.complete_workflow_activation(completion).await
                 })
                 .await
-                .map_err(WorkerRunError::WorkflowCompletions)
+                .map_err(|source| WorkerRunError::Fatal {
+                    message: "workflow completions processor encountered an error".to_owned(),
+                    source: Box::new(source),
+                })
         };
         tokio::try_join!(
             // Workflow-related tasks run inside LocalSet (allows !Send futures)
@@ -993,7 +999,10 @@ impl Worker {
                                     Err(PollError::ShutDown) => {
                                         break;
                                     }
-                                    o => o.map_err(WorkerRunError::WorkflowPoll)?,
+                                    o => o.map_err(|source| WorkerRunError::Fatal {
+                                        message: "workflow polling failed".to_owned(),
+                                        source: Box::new(source),
+                                    })?,
                                 };
                             if let Err(err) = decode_payloads(
                                 &mut activation,
@@ -1020,9 +1029,10 @@ impl Worker {
                             }
                             for i in &common.worker_interceptors {
                                 i.on_workflow_activation(&activation).await.map_err(|source| {
-                                    WorkerRunError::WorkflowActivationInterceptor(
-                                        source.into_boxed_dyn_error(),
-                                    )
+                                    WorkerRunError::Fatal {
+                                        message: "workflow activation interceptor failed".to_owned(),
+                                        source: source.into_boxed_dyn_error(),
+                                    }
                                 })?;
                             }
                             if let Some(wf_fut) = wf_half
@@ -1035,9 +1045,10 @@ impl Worker {
                                 )
                                 .await
                                 .map_err(|source| {
-                                    WorkerRunError::WorkflowActivation(
-                                        source.into_boxed_dyn_error(),
-                                    )
+                                    WorkerRunError::Fatal {
+                                        message: "workflow activation processing failed".to_owned(),
+                                        source: source.into_boxed_dyn_error(),
+                                    }
                                 })?
                                 && wf_future_tx.send(wf_fut).is_err()
                             {
@@ -1075,7 +1086,10 @@ impl Worker {
                         if matches!(activity, Err(PollError::ShutDown)) {
                             break;
                         }
-                        let mut activity = activity.map_err(WorkerRunError::ActivityPoll)?;
+                        let mut activity = activity.map_err(|source| WorkerRunError::Fatal {
+                            message: "activity polling failed".to_owned(),
+                            source: Box::new(source),
+                        })?;
                         if let Err(err) = decode_payloads(
                             &mut activity,
                             common.data_converter.codec(),
@@ -1099,8 +1113,9 @@ impl Worker {
                                 .worker
                                 .complete_activity_task(completion)
                                 .await
-                                .map_err(|source| {
-                                    WorkerRunError::ActivityCompletion(Box::new(source))
+                                .map_err(|source| WorkerRunError::Fatal {
+                                    message: "activity completion failed".to_owned(),
+                                    source: Box::new(source),
                                 })?;
                             continue;
                         }
@@ -1136,14 +1151,16 @@ impl Worker {
                                     .worker
                                     .complete_activity_task(completion)
                                     .await
-                                    .map_err(|source| {
-                                        WorkerRunError::ActivityCompletion(Box::new(source))
+                                    .map_err(|source| WorkerRunError::Fatal {
+                                        message: "activity completion failed".to_owned(),
+                                        source: Box::new(source),
                                     })?;
                             }
                             Err(ActivityTaskHandlerError::Fatal(source)) => {
-                                return Err(WorkerRunError::ActivityTask(
-                                    source.into_boxed_dyn_error(),
-                                ));
+                                return Err(WorkerRunError::Fatal {
+                                    message: "activity task handling failed".to_owned(),
+                                    source: source.into_boxed_dyn_error(),
+                                });
                             }
                         };
                     }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -636,14 +636,6 @@ struct WorkflowFutureHandle<F: Future> {
     run_id: String,
 }
 
-#[derive(Debug, thiserror::Error)]
-enum WorkflowFutureError {
-    #[error("workflow task was dropped")]
-    TaskDropped(#[from] TaskDroppedError),
-    #[error("workflow execution failed")]
-    WorkflowFailed(#[source] WorkflowTermination),
-}
-
 #[derive(Debug, Default)]
 struct ActivityHalf {
     /// Maps activity type to the function for executing activities of that type
@@ -940,7 +932,7 @@ impl Worker {
 
         let wf_future_joiner = async {
             UnboundedReceiverStream::new(wf_future_rx)
-                .map(Result::<_, WorkflowFutureError>::Ok)
+                .map(Result::<_, WorkerRunError>::Ok)
                 .try_for_each_concurrent(
                     None,
                     |WorkflowFutureHandle {
@@ -949,13 +941,19 @@ impl Worker {
                      }| {
                         let wf_half = &*wf_half;
                         async move {
-                            let result = join_handle.await?;
+                            let result = join_handle.await.map_err(|e| WorkerRunError::Fatal {
+                                message: "workflow task dropped".into(),
+                                source: e.into(),
+                            })?;
                             // Eviction is normal workflow lifecycle - workflows loop waiting for
                             // eviction after completion to manage cache cleanup
                             if let Err(e) = result
                                 && !matches!(e, WorkflowTermination::Evicted)
                             {
-                                return Err(WorkflowFutureError::WorkflowFailed(e));
+                                return Err(WorkerRunError::Fatal {
+                                    message: "workflow execution failed".into(),
+                                    source: e.into(),
+                                });
                             }
                             debug!(run_id=%run_id, "Removing workflow from cache");
                             wf_half.workflows.borrow_mut().remove(&run_id);

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -82,7 +82,8 @@ pub use crate::{
     error::{
         ActivityExecutionError, ApplicationFailure, ChildWorkflowExecutionError,
         ChildWorkflowStartError, OutgoingActivityError, OutgoingError, OutgoingWorkflowError,
-        RetryState, TimeoutType, WorkerCreateError, WorkflowRegistrationError, WorkflowSignalError,
+        RetryState, TimeoutType, WorkerCreateError, WorkerRunError, WorkflowRegistrationError,
+        WorkflowSignalError,
     },
     plugins::{
         ClientAndWorkerPlugin, SimplePlugin, SimplePluginBuilder, SimplePluginOption, WorkerPlugin,
@@ -112,12 +113,12 @@ use crate::{
         activity_error_to_core_result,
     },
     interceptors::{ActivityInboundInterceptor, WorkerInterceptor},
-    workflow_executor::{TaskHandle, WorkflowExecutor},
+    workflow_executor::{TaskDroppedError, TaskHandle, WorkflowExecutor},
     workflow_future::start_workflow,
     workflow_interceptors::WorkflowInterceptorConstructor,
 };
-use anyhow::{Context, anyhow, bail};
-use futures_util::{FutureExt, StreamExt, TryFutureExt, TryStreamExt};
+use anyhow::{anyhow, bail};
+use futures_util::{FutureExt, StreamExt, TryStreamExt};
 use std::{
     any::{Any, TypeId},
     cell::RefCell,
@@ -635,6 +636,14 @@ struct WorkflowFutureHandle<F: Future> {
     run_id: String,
 }
 
+#[derive(Debug, thiserror::Error)]
+enum WorkflowFutureError {
+    #[error("workflow task was dropped")]
+    TaskDropped(#[from] TaskDroppedError),
+    #[error("workflow execution failed")]
+    WorkflowFailed(#[source] WorkflowTermination),
+}
+
 #[derive(Debug, Default)]
 struct ActivityHalf {
     /// Maps activity type to the function for executing activities of that type
@@ -908,10 +917,14 @@ impl Worker {
 
     /// Runs the worker. Eventually resolves after the worker has been explicitly shut down,
     /// or may return early with an error in the event of some unresolvable problem.
-    pub async fn run(&mut self) -> Result<(), anyhow::Error> {
+    pub async fn run(&mut self) -> Result<(), WorkerRunError> {
         // Perform the namespace check-in so poller behavior (e.g. autoscaling auto-enroll) is
         // resolved before any polling begins.
-        self.common.worker.validate().await?;
+        self.common
+            .worker
+            .validate()
+            .await
+            .map_err(WorkerRunError::Validation)?;
         let shutdown_token = CancellationToken::new();
         let (common, wf_half, act_half) = self.split_apart();
         let (wf_future_tx, wf_future_rx) =
@@ -927,7 +940,7 @@ impl Worker {
 
         let wf_future_joiner = async {
             UnboundedReceiverStream::new(wf_future_rx)
-                .map(Result::<_, anyhow::Error>::Ok)
+                .map(Result::<_, WorkflowFutureError>::Ok)
                 .try_for_each_concurrent(
                     None,
                     |WorkflowFutureHandle {
@@ -936,13 +949,13 @@ impl Worker {
                      }| {
                         let wf_half = &*wf_half;
                         async move {
-                            let result = join_handle.await.map_err(anyhow::Error::new)?;
+                            let result = join_handle.await?;
                             // Eviction is normal workflow lifecycle - workflows loop waiting for
                             // eviction after completion to manage cache cleanup
                             if let Err(e) = result
                                 && !matches!(e, WorkflowTermination::Evicted)
                             {
-                                return Err(anyhow::Error::new(e));
+                                return Err(WorkflowFutureError::WorkflowFailed(e));
                             }
                             debug!(run_id=%run_id, "Removing workflow from cache");
                             wf_half.workflows.borrow_mut().remove(&run_id);
@@ -952,7 +965,7 @@ impl Worker {
                     },
                 )
                 .await
-                .context("Workflow futures encountered an error")
+                .map_err(|source| WorkerRunError::WorkflowFutures(Box::new(source)))
         };
         let wf_completion_processor = async {
             UnboundedReceiverStream::new(completions_rx)
@@ -964,9 +977,8 @@ impl Worker {
                     }
                     common.worker.complete_workflow_activation(completion).await
                 })
-                .map_err(anyhow::Error::from)
                 .await
-                .context("Workflow completions processor encountered an error")
+                .map_err(WorkerRunError::WorkflowCompletions)
         };
         tokio::try_join!(
             // Workflow-related tasks run inside LocalSet (allows !Send futures)
@@ -981,7 +993,7 @@ impl Worker {
                                     Err(PollError::ShutDown) => {
                                         break;
                                     }
-                                    o => o?,
+                                    o => o.map_err(WorkerRunError::WorkflowPoll)?,
                                 };
                             if let Err(err) = decode_payloads(
                                 &mut activation,
@@ -1007,7 +1019,11 @@ impl Worker {
                                 continue;
                             }
                             for i in &common.worker_interceptors {
-                                i.on_workflow_activation(&activation).await?;
+                                i.on_workflow_activation(&activation).await.map_err(|source| {
+                                    WorkerRunError::WorkflowActivationInterceptor(
+                                        source.into_boxed_dyn_error(),
+                                    )
+                                })?;
                             }
                             if let Some(wf_fut) = wf_half
                                 .workflow_activation_handler(
@@ -1017,7 +1033,12 @@ impl Worker {
                                     &completions_tx,
                                     &executor,
                                 )
-                                .await?
+                                .await
+                                .map_err(|source| {
+                                    WorkerRunError::WorkflowActivation(
+                                        source.into_boxed_dyn_error(),
+                                    )
+                                })?
                                 && wf_future_tx.send(wf_fut).is_err()
                             {
                                 panic!(
@@ -1031,7 +1052,7 @@ impl Worker {
                         // terminate.
                         drop(wf_future_tx);
                         drop(completions_tx);
-                        Result::<_, anyhow::Error>::Ok(())
+                        Result::<_, WorkerRunError>::Ok(())
                     },
                     wf_future_joiner,
                     async {
@@ -1040,7 +1061,7 @@ impl Worker {
                             _ = shutdown_token.cancelled() => {}
                         }
                         executor.shutdown().await;
-                        Result::<_, anyhow::Error>::Ok(())
+                        Result::<_, WorkerRunError>::Ok(())
                     },
                 )
                 }).await
@@ -1054,7 +1075,7 @@ impl Worker {
                         if matches!(activity, Err(PollError::ShutDown)) {
                             break;
                         }
-                        let mut activity = activity?;
+                        let mut activity = activity.map_err(WorkerRunError::ActivityPoll)?;
                         if let Err(err) = decode_payloads(
                             &mut activity,
                             common.data_converter.codec(),
@@ -1074,7 +1095,13 @@ impl Worker {
                             };
                             encode_activity_completion(&mut completion, &common.data_converter)
                                 .await;
-                            common.worker.complete_activity_task(completion).await?;
+                            common
+                                .worker
+                                .complete_activity_task(completion)
+                                .await
+                                .map_err(|source| {
+                                    WorkerRunError::ActivityCompletion(Box::new(source))
+                                })?;
                             continue;
                         }
                         match act_half.activity_task_handler(
@@ -1105,13 +1132,23 @@ impl Worker {
                                 };
                                 encode_activity_completion(&mut completion, &common.data_converter)
                                     .await;
-                                common.worker.complete_activity_task(completion).await?;
+                                common
+                                    .worker
+                                    .complete_activity_task(completion)
+                                    .await
+                                    .map_err(|source| {
+                                        WorkerRunError::ActivityCompletion(Box::new(source))
+                                    })?;
                             }
-                            Err(ActivityTaskHandlerError::Fatal(err)) => return Err(err),
+                            Err(ActivityTaskHandlerError::Fatal(source)) => {
+                                return Err(WorkerRunError::ActivityTask(
+                                    source.into_boxed_dyn_error(),
+                                ));
+                            }
                         };
                     }
                 };
-                Result::<_, anyhow::Error>::Ok(())
+                Result::<_, WorkerRunError>::Ok(())
             },
             wf_completion_processor,
         )?;

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -82,8 +82,8 @@ pub use crate::{
     error::{
         ActivityExecutionError, ApplicationFailure, ChildWorkflowExecutionError,
         ChildWorkflowStartError, OutgoingActivityError, OutgoingError, OutgoingWorkflowError,
-        RetryState, TimeoutType, WorkerCreateError, WorkerRunError, WorkflowRegistrationError,
-        WorkflowSignalError,
+        RetryState, TimeoutType, WorkerCreateError, WorkerRunError, WorkerValidationError,
+        WorkflowRegistrationError, WorkflowSignalError,
     },
     plugins::{
         ClientAndWorkerPlugin, SimplePlugin, SimplePluginBuilder, SimplePluginOption, WorkerPlugin,
@@ -963,10 +963,6 @@ impl Worker {
                     },
                 )
                 .await
-                .map_err(|source| WorkerRunError::Fatal {
-                    message: "workflow futures encountered an error".to_owned(),
-                    source: Box::new(source),
-                })
         };
         let wf_completion_processor = async {
             UnboundedReceiverStream::new(completions_rx)


### PR DESCRIPTION
## What
Remove `anyhow` in favor of our own typed error for `Worker::run`.

## Why
Remove `anyhow` from public API.

I kept it to a very small number of variants vs each possible failure point. Other than verification, none of these are really meaningfully recoverable by the user.