### PR TITLE
feat(sdk): add WorkflowReplayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ relevant information.
 ### Changed
 * Cancellation errors propagated after workflow cancellation now complete the workflow as cancelled
   instead of failed.
+* `WorkflowReplayer` for workflow history replay, including JSON history helpers
+  and worker-plugin configuration.
 
 ### Breaking Changes :boom:
 * `CancellableFuture` and `CancellableFutureWithReason` now use the inherited `Future::Output`

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -53,11 +53,13 @@ tracing = "0.1"
 url = "2.5"
 uuid = { version = "1.18", default-features = false, features = ["v4"] }
 rand = "0.10"
+serde_json = { workspace = true }
 
 [dependencies.temporalio-common]
 path = "../common"
 version = "0.6"
 default-features = false
+features = ["serde_serialize"]
 
 [dev-dependencies]
 assert_matches = "1"

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -99,7 +99,7 @@ pub use tonic;
 pub use workflow_handle::{
     UntypedQuery, UntypedSignal, UntypedUpdate, UntypedWorkflow, UntypedWorkflowHandle,
     WorkflowExecutionDescription, WorkflowExecutionInfo, WorkflowExecutionResult, WorkflowHandle,
-    WorkflowHistory, WorkflowResultDetails, WorkflowUpdateHandle,
+    WorkflowHistory, WorkflowHistoryJsonError, WorkflowResultDetails, WorkflowUpdateHandle,
 };
 pub use workflow_status::WorkflowExecutionStatus;
 

--- a/crates/client/src/plugins.rs
+++ b/crates/client/src/plugins.rs
@@ -28,6 +28,9 @@ pub enum PluginTarget {
     /// Worker options.
     #[display("worker options")]
     Worker,
+    /// Workflow replayer options.
+    #[display("workflow replayer options")]
+    WorkflowReplayer,
 }
 
 /// An error applying a named plugin to a configuration target.

--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -336,6 +336,7 @@ impl WorkflowExecutionDescription {
 #[derive(Debug, Clone)]
 pub struct WorkflowHistory {
     events: Vec<HistoryEvent>,
+    workflow_id: Option<String>,
 }
 impl From<WorkflowHistory> for history::v1::History {
     fn from(h: WorkflowHistory) -> Self {
@@ -349,8 +350,24 @@ impl From<WorkflowHistory> for history::v1::History {
 pub struct WorkflowHistoryJsonError(#[from] serde_json::Error);
 
 impl WorkflowHistory {
-    fn new(events: Vec<HistoryEvent>) -> Self {
-        Self { events }
+    fn new(events: Vec<HistoryEvent>, workflow_id: Option<String>) -> Self {
+        Self {
+            events,
+            workflow_id,
+        }
+    }
+
+    /// Decode a workflow history from JSON bytes.
+    ///
+    /// This currently uses the JSON representation provided by the generated protobuf serde
+    /// implementations. It will use canonical protobuf JSON once that encoding is supported
+    /// natively.
+    pub fn from_json(bytes: &[u8]) -> Result<Self, WorkflowHistoryJsonError> {
+        let history: History = serde_json::from_slice(bytes)?;
+        let workflow_id = workflow_execution_started_attributes(&history.events)
+            .map(|attributes| attributes.workflow_id.clone())
+            .filter(|workflow_id| !workflow_id.is_empty());
+        Ok(Self::new(history.events, workflow_id))
     }
 
     /// Encode this workflow history as JSON bytes.
@@ -364,6 +381,24 @@ impl WorkflowHistory {
         })?)
     }
 
+    /// Return the workflow ID when it is known.
+    pub fn workflow_id(&self) -> Option<&str> {
+        self.workflow_id.as_deref()
+    }
+
+    /// Return the original run ID recorded by the workflow start event, when present.
+    pub fn run_id(&self) -> Option<&str> {
+        workflow_execution_started_attributes(&self.events)
+            .map(|attributes| attributes.original_execution_run_id.as_str())
+            .filter(|run_id| !run_id.is_empty())
+    }
+
+    /// Override the workflow ID used when replaying this history.
+    pub fn with_workflow_id(mut self, workflow_id: impl Into<String>) -> Self {
+        self.workflow_id = Some(workflow_id.into());
+        self
+    }
+
     /// The history events.
     pub fn events(&self) -> &[HistoryEvent] {
         &self.events
@@ -372,6 +407,17 @@ impl WorkflowHistory {
     /// Consume the history and return the events.
     pub fn into_events(self) -> Vec<HistoryEvent> {
         self.events
+    }
+}
+
+fn workflow_execution_started_attributes(
+    events: &[HistoryEvent],
+) -> Option<
+    &temporalio_common::protos::temporal::api::history::v1::WorkflowExecutionStartedEventAttributes,
+> {
+    match events.first()?.attributes.as_ref()? {
+        Attributes::WorkflowExecutionStartedEventAttributes(attributes) => Some(attributes),
+        _ => None,
     }
 }
 
@@ -1204,7 +1250,10 @@ where
             next_page_token = output.next_page_token;
         }
 
-        Ok(WorkflowHistory::new(all_events))
+        Ok(WorkflowHistory::new(
+            all_events,
+            Some(self.info.workflow_id.clone()),
+        ))
     }
 }
 
@@ -1351,11 +1400,41 @@ mod tests {
             )),
             ..Default::default()
         };
-        let history = WorkflowHistory::new(vec![event.clone()]);
+        let history = WorkflowHistory::new(vec![event.clone()], Some("external-id".to_owned()));
 
         let bytes = history.to_json().unwrap();
         let proto: History = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(proto.events, [event]);
+
+        let decoded = WorkflowHistory::from_json(&bytes).unwrap();
+        assert_eq!(decoded.events(), proto.events);
+        assert_eq!(decoded.workflow_id(), Some("workflow-id"));
+        assert_eq!(decoded.run_id(), Some("run-id"));
+    }
+
+    #[test]
+    fn workflow_history_identity_is_optional_and_overridable() {
+        let event = HistoryEvent {
+            event_id: 1,
+            attributes: Some(Attributes::WorkflowExecutionStartedEventAttributes(
+                WorkflowExecutionStartedEventAttributes {
+                    original_execution_run_id: "run-id".to_owned(),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        let bytes = serde_json::to_vec(&History {
+            events: vec![event],
+        })
+        .unwrap();
+
+        let history = WorkflowHistory::from_json(&bytes).unwrap();
+        assert_eq!(history.workflow_id(), None);
+        assert_eq!(history.run_id(), Some("run-id"));
+
+        let history = history.with_workflow_id("override-id");
+        assert_eq!(history.workflow_id(), Some("override-id"));
     }
 
     #[tokio::test]

--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -32,7 +32,7 @@ use temporalio_common::{
             enums::v1::{HistoryEventFilterType, UpdateWorkflowExecutionLifecycleStage},
             history::{
                 self,
-                v1::{HistoryEvent, history_event::Attributes},
+                v1::{History, HistoryEvent, history_event::Attributes},
             },
             query::v1::WorkflowQuery,
             sdk::v1::UserMetadata,
@@ -343,9 +343,25 @@ impl From<WorkflowHistory> for history::v1::History {
     }
 }
 
+/// Error converting a workflow history to or from JSON.
+#[derive(Debug, thiserror::Error)]
+#[error("failed to convert workflow history JSON: {0}")]
+pub struct WorkflowHistoryJsonError(#[from] serde_json::Error);
+
 impl WorkflowHistory {
     fn new(events: Vec<HistoryEvent>) -> Self {
         Self { events }
+    }
+
+    /// Encode this workflow history as JSON bytes.
+    ///
+    /// This currently uses the JSON representation provided by the generated protobuf serde
+    /// implementations. It will use canonical protobuf JSON once that encoding is supported
+    /// natively.
+    pub fn to_json(&self) -> Result<Vec<u8>, WorkflowHistoryJsonError> {
+        Ok(serde_json::to_vec(&History {
+            events: self.events.clone(),
+        })?)
     }
 
     /// The history events.
@@ -1316,10 +1332,31 @@ mod tests {
         protos::temporal::api::{
             common::v1::{Memo, SearchAttributes},
             enums::v1::WorkflowExecutionStatus as ProtoWorkflowExecutionStatus,
+            history::v1::WorkflowExecutionStartedEventAttributes,
             sdk::v1::UserMetadata,
             workflow::v1::WorkflowExecutionConfig,
         },
     };
+
+    #[test]
+    fn workflow_history_to_json_serializes_events() {
+        let event = HistoryEvent {
+            event_id: 1,
+            attributes: Some(Attributes::WorkflowExecutionStartedEventAttributes(
+                WorkflowExecutionStartedEventAttributes {
+                    workflow_id: "workflow-id".to_owned(),
+                    original_execution_run_id: "run-id".to_owned(),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        let history = WorkflowHistory::new(vec![event.clone()]);
+
+        let bytes = history.to_json().unwrap();
+        let proto: History = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(proto.events, [event]);
+    }
 
     #[tokio::test]
     async fn workflow_result_details_support_typed_decoding() {

--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -358,23 +358,23 @@ impl WorkflowHistory {
     }
 
     /// Decode a workflow history from JSON bytes.
-    ///
-    /// This currently uses the JSON representation provided by the generated protobuf serde
-    /// implementations. It will use canonical protobuf JSON once that encoding is supported
-    /// natively.
     pub fn from_json(bytes: &[u8]) -> Result<Self, WorkflowHistoryJsonError> {
         let history: History = serde_json::from_slice(bytes)?;
-        let workflow_id = workflow_execution_started_attributes(&history.events)
+        let workflow_id = history
+            .events
+            .first()
+            .and_then(|event| match event.attributes.as_ref() {
+                Some(Attributes::WorkflowExecutionStartedEventAttributes(attributes)) => {
+                    Some(attributes)
+                }
+                _ => None,
+            })
             .map(|attributes| attributes.workflow_id.clone())
-            .filter(|workflow_id| !workflow_id.is_empty());
+            .filter(|wfid| !wfid.is_empty());
         Ok(Self::new(history.events, workflow_id))
     }
 
     /// Encode this workflow history as JSON bytes.
-    ///
-    /// This currently uses the JSON representation provided by the generated protobuf serde
-    /// implementations. It will use canonical protobuf JSON once that encoding is supported
-    /// natively.
     pub fn to_json(&self) -> Result<Vec<u8>, WorkflowHistoryJsonError> {
         Ok(serde_json::to_vec(&History {
             events: self.events.clone(),
@@ -386,19 +386,6 @@ impl WorkflowHistory {
         self.workflow_id.as_deref()
     }
 
-    /// Return the original run ID recorded by the workflow start event, when present.
-    pub fn run_id(&self) -> Option<&str> {
-        workflow_execution_started_attributes(&self.events)
-            .map(|attributes| attributes.original_execution_run_id.as_str())
-            .filter(|run_id| !run_id.is_empty())
-    }
-
-    /// Override the workflow ID used when replaying this history.
-    pub fn with_workflow_id(mut self, workflow_id: impl Into<String>) -> Self {
-        self.workflow_id = Some(workflow_id.into());
-        self
-    }
-
     /// The history events.
     pub fn events(&self) -> &[HistoryEvent] {
         &self.events
@@ -407,17 +394,6 @@ impl WorkflowHistory {
     /// Consume the history and return the events.
     pub fn into_events(self) -> Vec<HistoryEvent> {
         self.events
-    }
-}
-
-fn workflow_execution_started_attributes(
-    events: &[HistoryEvent],
-) -> Option<
-    &temporalio_common::protos::temporal::api::history::v1::WorkflowExecutionStartedEventAttributes,
-> {
-    match events.first()?.attributes.as_ref()? {
-        Attributes::WorkflowExecutionStartedEventAttributes(attributes) => Some(attributes),
-        _ => None,
     }
 }
 
@@ -1388,7 +1364,7 @@ mod tests {
     };
 
     #[test]
-    fn workflow_history_to_json_serializes_events() {
+    fn workflow_history_workflow_id_roundtrips() {
         let event = HistoryEvent {
             event_id: 1,
             attributes: Some(Attributes::WorkflowExecutionStartedEventAttributes(
@@ -1400,41 +1376,12 @@ mod tests {
             )),
             ..Default::default()
         };
-        let history = WorkflowHistory::new(vec![event.clone()], Some("external-id".to_owned()));
+        let history = WorkflowHistory::new(vec![event], None);
 
         let bytes = history.to_json().unwrap();
-        let proto: History = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(proto.events, [event]);
 
         let decoded = WorkflowHistory::from_json(&bytes).unwrap();
-        assert_eq!(decoded.events(), proto.events);
         assert_eq!(decoded.workflow_id(), Some("workflow-id"));
-        assert_eq!(decoded.run_id(), Some("run-id"));
-    }
-
-    #[test]
-    fn workflow_history_identity_is_optional_and_overridable() {
-        let event = HistoryEvent {
-            event_id: 1,
-            attributes: Some(Attributes::WorkflowExecutionStartedEventAttributes(
-                WorkflowExecutionStartedEventAttributes {
-                    original_execution_run_id: "run-id".to_owned(),
-                    ..Default::default()
-                },
-            )),
-            ..Default::default()
-        };
-        let bytes = serde_json::to_vec(&History {
-            events: vec![event],
-        })
-        .unwrap();
-
-        let history = WorkflowHistory::from_json(&bytes).unwrap();
-        assert_eq!(history.workflow_id(), None);
-        assert_eq!(history.run_id(), Some("run-id"));
-
-        let history = history.with_workflow_id("override-id");
-        assert_eq!(history.workflow_id(), Some("override-id"));
     }
 
     #[tokio::test]

--- a/crates/sdk-core/tests/integ_tests/workflow_replayer_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_replayer_tests.rs
@@ -147,7 +147,6 @@ async fn workflow_replayer_replays_completed_workflow() {
         .unwrap();
     assert_eq!(results.len(), 2);
     assert!(results.iter().all(|result| result.replay_failure.is_none()));
-    assert_eq!(results[0].history.run_id(), results[1].history.run_id());
 }
 
 #[tokio::test]

--- a/crates/sdk-core/tests/integ_tests/workflow_replayer_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_replayer_tests.rs
@@ -1,4 +1,4 @@
-use crate::common::{CoreWfStarter, TestWorker};
+use crate::common::{CoreWfStarter, TestWorker, eventually};
 use std::{
     sync::{
         Arc,
@@ -171,15 +171,23 @@ async fn workflow_replayer_replays_incomplete_workflow() {
         .unwrap();
 
     let fetch_open_history = async {
-        while !handle
-            .query(
-                SayHelloWorkflow::waiting,
-                (),
-                WorkflowQueryOptions::default(),
-            )
-            .await
-            .unwrap()
-        {}
+        eventually(
+            || async {
+                handle
+                    .query(
+                        SayHelloWorkflow::waiting,
+                        (),
+                        WorkflowQueryOptions::default(),
+                    )
+                    .await
+                    .unwrap()
+                    .then_some(())
+                    .ok_or("workflow is not waiting")
+            },
+            Duration::from_secs(10),
+        )
+        .await
+        .unwrap();
         let history = handle.fetch_history(Default::default()).await.unwrap();
         handle
             .terminate(WorkflowTerminateOptions::default())
@@ -281,20 +289,25 @@ async fn workflow_replayer_replays_history_with_workflow_task_failure() {
         .unwrap();
 
     let fetch_failed_history = async {
-        loop {
-            let history = handle.fetch_history(Default::default()).await.unwrap();
-            if history
-                .events()
-                .iter()
-                .any(|event| event.event_type() == EventType::WorkflowTaskFailed)
-            {
-                handle
-                    .terminate(WorkflowTerminateOptions::default())
-                    .await
-                    .unwrap();
-                break history;
-            }
-        }
+        let history = eventually(
+            || async {
+                let history = handle.fetch_history(Default::default()).await.unwrap();
+                history
+                    .events()
+                    .iter()
+                    .any(|event| event.event_type() == EventType::WorkflowTaskFailed)
+                    .then_some(history)
+                    .ok_or("workflow task failure not yet recorded")
+            },
+            Duration::from_secs(10),
+        )
+        .await
+        .unwrap();
+        handle
+            .terminate(WorkflowTerminateOptions::default())
+            .await
+            .unwrap();
+        history
     };
     let (history, worker_result) = tokio::join!(fetch_failed_history, worker.run_until_done());
     worker_result.unwrap();

--- a/crates/sdk-core/tests/integ_tests/workflow_replayer_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_replayer_tests.rs
@@ -1,0 +1,432 @@
+use crate::common::{CoreWfStarter, TestWorker};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+use temporalio_client::{
+    PluginError, WorkflowHistory, WorkflowQueryOptions, WorkflowStartOptions,
+    WorkflowTerminateOptions, errors::WorkflowGetResultError,
+};
+use temporalio_common::protos::temporal::api::enums::v1::EventType;
+use temporalio_macros::{activities, workflow, workflow_methods};
+use temporalio_sdk::{
+    ActivityOptions, SimplePlugin, WorkerPlugin, WorkflowContext, WorkflowContextView,
+    WorkflowDefinitions, WorkflowResult,
+    activities::{ActivityContext, ActivityError},
+    workflow_replayer::{
+        WorkflowReplayError, WorkflowReplayFailure, WorkflowReplayer, WorkflowReplayerOptions,
+    },
+};
+
+struct SayHelloActivities;
+
+#[activities]
+impl SayHelloActivities {
+    #[activity]
+    async fn say_hello(_ctx: ActivityContext, name: String) -> Result<String, ActivityError> {
+        Ok(format!("Hello, {name}!"))
+    }
+}
+
+#[derive(Default, serde::Deserialize, serde::Serialize, bon::Builder)]
+struct SayHelloInput {
+    #[builder(into)]
+    name: String,
+    #[builder(default)]
+    should_hang: bool,
+    #[builder(default)]
+    should_error: bool,
+    #[builder(default)]
+    should_fail_task: bool,
+    #[builder(default)]
+    should_cause_nondeterminism: bool,
+}
+
+impl SayHelloInput {
+    fn new(name: impl Into<String>) -> Self {
+        Self::builder().name(name).build()
+    }
+}
+
+#[workflow]
+#[derive(Default)]
+struct SayHelloWorkflow {
+    waiting: bool,
+}
+
+#[workflow_methods]
+impl SayHelloWorkflow {
+    #[run]
+    async fn run(ctx: &mut WorkflowContext<Self>, input: SayHelloInput) -> WorkflowResult<String> {
+        let greeting = ctx
+            .execute_activity(
+                SayHelloActivities::say_hello,
+                input.name,
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
+            )
+            .await?;
+
+        if input.should_hang {
+            ctx.state_mut(|workflow| workflow.waiting = true);
+            ctx.wait_condition(|_| false).await?;
+        }
+        if input.should_error {
+            return Err(anyhow::anyhow!("Intentional workflow failure").into());
+        }
+        if input.should_fail_task {
+            panic!("Intentional workflow task failure");
+        }
+        if input.should_cause_nondeterminism && ctx.is_replaying() {
+            ctx.timer(Duration::from_secs(1)).await;
+        }
+
+        Ok(greeting)
+    }
+
+    #[query]
+    fn waiting(&self, _ctx: &WorkflowContextView) -> bool {
+        self.waiting
+    }
+}
+
+async fn replay_test_worker(test_name: &str) -> (CoreWfStarter, TestWorker) {
+    let mut starter = CoreWfStarter::new(test_name);
+    starter.sdk_config.register_activities(SayHelloActivities);
+    let mut worker = starter.worker().await;
+    worker.register_workflow::<SayHelloWorkflow>().unwrap();
+    (starter, worker)
+}
+
+fn replayer() -> WorkflowReplayer {
+    WorkflowReplayer::new(
+        WorkflowReplayerOptions::new()
+            .register_workflow::<SayHelloWorkflow>()
+            .unwrap()
+            .build(),
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn workflow_replayer_replays_completed_workflow() {
+    let (starter, mut worker) =
+        replay_test_worker("workflow_replayer_replays_completed_workflow").await;
+    let handle = worker
+        .submit_workflow(
+            SayHelloWorkflow::run,
+            SayHelloInput::new("Temporal"),
+            WorkflowStartOptions::new(
+                starter.get_task_queue().to_owned(),
+                starter.get_wf_id().to_owned(),
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    worker.run_until_done().await.unwrap();
+    assert_eq!(
+        handle.get_result(Default::default()).await.unwrap(),
+        "Hello, Temporal!"
+    );
+    let history = handle.fetch_history(Default::default()).await.unwrap();
+    let history_from_json = WorkflowHistory::from_json(&history.to_json().unwrap()).unwrap();
+    assert_eq!(history_from_json.workflow_id(), history.workflow_id());
+
+    let replayer = replayer();
+    replayer
+        .replay_workflow(history_from_json.clone())
+        .await
+        .unwrap();
+    let results = replayer
+        .replay_workflows([history_from_json.clone(), history_from_json])
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 2);
+    assert!(results.iter().all(|result| result.replay_failure.is_none()));
+    assert_eq!(results[0].history.run_id(), results[1].history.run_id());
+}
+
+#[tokio::test]
+async fn workflow_replayer_replays_incomplete_workflow() {
+    let (starter, mut worker) =
+        replay_test_worker("workflow_replayer_replays_incomplete_workflow").await;
+    let handle = worker
+        .submit_workflow(
+            SayHelloWorkflow::run,
+            SayHelloInput::builder()
+                .name("Temporal")
+                .should_hang(true)
+                .build(),
+            WorkflowStartOptions::new(
+                starter.get_task_queue().to_owned(),
+                starter.get_wf_id().to_owned(),
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    let fetch_open_history = async {
+        while !handle
+            .query(
+                SayHelloWorkflow::waiting,
+                (),
+                WorkflowQueryOptions::default(),
+            )
+            .await
+            .unwrap()
+        {}
+        let history = handle.fetch_history(Default::default()).await.unwrap();
+        handle
+            .terminate(WorkflowTerminateOptions::default())
+            .await
+            .unwrap();
+        history
+    };
+    let (history, worker_result) = tokio::join!(fetch_open_history, worker.run_until_done());
+    worker_result.unwrap();
+
+    replayer().replay_workflow(history).await.unwrap();
+}
+
+#[tokio::test]
+async fn workflow_replayer_replays_failed_workflow() {
+    let (starter, mut worker) =
+        replay_test_worker("workflow_replayer_replays_failed_workflow").await;
+    let handle = worker
+        .submit_workflow(
+            SayHelloWorkflow::run,
+            SayHelloInput::builder()
+                .name("Temporal")
+                .should_error(true)
+                .build(),
+            WorkflowStartOptions::new(
+                starter.get_task_queue().to_owned(),
+                starter.get_wf_id().to_owned(),
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    worker.run_until_done().await.unwrap();
+    assert!(matches!(
+        handle.get_result(Default::default()).await,
+        Err(WorkflowGetResultError::Failed(_))
+    ));
+    let history = handle.fetch_history(Default::default()).await.unwrap();
+
+    replayer().replay_workflow(history).await.unwrap();
+}
+
+#[tokio::test]
+async fn workflow_replayer_reports_nondeterminism() {
+    let (starter, mut worker) =
+        replay_test_worker("workflow_replayer_reports_nondeterminism").await;
+    let handle = worker
+        .submit_workflow(
+            SayHelloWorkflow::run,
+            SayHelloInput::builder()
+                .name("Temporal")
+                .should_cause_nondeterminism(true)
+                .build(),
+            WorkflowStartOptions::new(
+                starter.get_task_queue().to_owned(),
+                starter.get_wf_id().to_owned(),
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    worker.run_until_done().await.unwrap();
+    let history = handle.fetch_history(Default::default()).await.unwrap();
+    let replayer = replayer();
+
+    assert!(matches!(
+        replayer.replay_workflow(history.clone()).await,
+        Err(WorkflowReplayError::Replay(
+            WorkflowReplayFailure::Nondeterminism { .. }
+        ))
+    ));
+    let results = replayer.replay_workflows([history]).await.unwrap();
+    assert!(matches!(
+        results[0].replay_failure,
+        Some(WorkflowReplayFailure::Nondeterminism { .. })
+    ));
+}
+
+#[tokio::test]
+async fn workflow_replayer_replays_history_with_workflow_task_failure() {
+    let (starter, mut worker) =
+        replay_test_worker("workflow_replayer_replays_history_with_workflow_task_failure").await;
+    let handle = worker
+        .submit_workflow(
+            SayHelloWorkflow::run,
+            SayHelloInput::builder()
+                .name("Temporal")
+                .should_fail_task(true)
+                .build(),
+            WorkflowStartOptions::new(
+                starter.get_task_queue().to_owned(),
+                starter.get_wf_id().to_owned(),
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    let fetch_failed_history = async {
+        loop {
+            let history = handle.fetch_history(Default::default()).await.unwrap();
+            if history
+                .events()
+                .iter()
+                .any(|event| event.event_type() == EventType::WorkflowTaskFailed)
+            {
+                handle
+                    .terminate(WorkflowTerminateOptions::default())
+                    .await
+                    .unwrap();
+                break history;
+            }
+        }
+    };
+    let (history, worker_result) = tokio::join!(fetch_failed_history, worker.run_until_done());
+    worker_result.unwrap();
+
+    replayer().replay_workflow(history).await.unwrap();
+}
+
+#[tokio::test]
+async fn workflow_replayer_returns_ordered_results_for_multiple_histories() {
+    let (starter, mut worker) =
+        replay_test_worker("workflow_replayer_returns_ordered_results_for_multiple_histories")
+            .await;
+    let successful_handle = worker
+        .submit_workflow(
+            SayHelloWorkflow::run,
+            SayHelloInput::new("Temporal"),
+            WorkflowStartOptions::new(
+                starter.get_task_queue().to_owned(),
+                format!("{}-success", starter.get_wf_id()),
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+    let nondeterministic_handle = worker
+        .submit_workflow(
+            SayHelloWorkflow::run,
+            SayHelloInput::builder()
+                .name("Temporal")
+                .should_cause_nondeterminism(true)
+                .build(),
+            WorkflowStartOptions::new(
+                starter.get_task_queue().to_owned(),
+                format!("{}-nondeterministic", starter.get_wf_id()),
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    worker.run_until_done().await.unwrap();
+    let successful_history = successful_handle
+        .fetch_history(Default::default())
+        .await
+        .unwrap();
+    let nondeterministic_history = nondeterministic_handle
+        .fetch_history(Default::default())
+        .await
+        .unwrap();
+
+    let results = replayer()
+        .replay_workflows([successful_history, nondeterministic_history])
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 2);
+    assert!(results[0].replay_failure.is_none());
+    assert!(matches!(
+        results[1].replay_failure,
+        Some(WorkflowReplayFailure::Nondeterminism { .. })
+    ));
+}
+
+struct ReplayConfigPlugin {
+    configure_calls: Arc<AtomicUsize>,
+}
+
+impl WorkerPlugin for ReplayConfigPlugin {
+    fn name(&self) -> &str {
+        "replay-config"
+    }
+
+    fn configure_workflow_replayer_options(
+        &self,
+        options: &mut WorkflowReplayerOptions,
+    ) -> Result<(), PluginError> {
+        self.configure_calls.fetch_add(1, Ordering::Relaxed);
+        options
+            .register_workflow::<SayHelloWorkflow>()
+            .map_err(PluginError::new)?;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn workflow_replayer_applies_plugins() {
+    let (starter, mut worker) = replay_test_worker("workflow_replayer_applies_plugins").await;
+    let handle = worker
+        .submit_workflow(
+            SayHelloWorkflow::run,
+            SayHelloInput::new("Temporal"),
+            WorkflowStartOptions::new(
+                starter.get_task_queue().to_owned(),
+                starter.get_wf_id().to_owned(),
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+    let history = handle.fetch_history(Default::default()).await.unwrap();
+
+    let configure_calls = Arc::new(AtomicUsize::new(0));
+    let replayer = WorkflowReplayer::new(
+        WorkflowReplayerOptions::new()
+            .worker_plugin(ReplayConfigPlugin {
+                configure_calls: configure_calls.clone(),
+            })
+            .build(),
+    )
+    .unwrap();
+    assert_eq!(
+        replayer
+            .options()
+            .workflows()
+            .workflow_definitions()
+            .count(),
+        1
+    );
+    replayer.replay_workflow(history.clone()).await.unwrap();
+    assert_eq!(configure_calls.load(Ordering::Relaxed), 1);
+
+    let mut workflows = WorkflowDefinitions::new();
+    workflows.register_workflow::<SayHelloWorkflow>().unwrap();
+    let replayer = WorkflowReplayer::new(
+        WorkflowReplayerOptions::new()
+            .worker_plugin(
+                SimplePlugin::builder("simple-replay")
+                    .workflows(workflows)
+                    .build(),
+            )
+            .build(),
+    )
+    .unwrap();
+    replayer.replay_workflow(history).await.unwrap();
+}

--- a/crates/sdk-core/tests/main.rs
+++ b/crates/sdk-core/tests/main.rs
@@ -30,6 +30,7 @@ mod integ_tests {
     mod worker_tests;
     mod worker_versioning_tests;
     mod workflow_client_tests;
+    mod workflow_replayer_tests;
     mod workflow_tests;
 
     use crate::common::{

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -348,6 +348,27 @@ let worker_options = WorkerOptions::new("task-queue")
     .build();
 ```
 
+## Workflow Replay
+
+`WorkflowReplayer` checks whether workflow code remains compatible with recorded workflow
+histories. Histories can come from directly from a workflow handle or from JSON:
+
+```rust
+use temporalio_client::WorkflowHistory;
+use temporalio_sdk::workflow_replayer::{WorkflowReplayer, WorkflowReplayerOptions};
+
+let replayer = WorkflowReplayer::new(
+    WorkflowReplayerOptions::new()
+        .register_workflow::<MyWorkflow>()?
+        .build(),
+)?;
+let saved_history = std::fs::read("workflow-history.json")?;
+let history = WorkflowHistory::from_json(&saved_history)?;
+
+replayer.replay_workflow(history).await?;
+```
+
+
 ## Using the Client
 
 The `temporalio_client` crate provides a client for interacting with the Temporal service. You can

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -113,7 +113,7 @@ use crate::{
         activity_error_to_core_result,
     },
     interceptors::{ActivityInboundInterceptor, WorkerInterceptor},
-    workflow_executor::{TaskDroppedError, TaskHandle, WorkflowExecutor},
+    workflow_executor::{TaskHandle, WorkflowExecutor},
     workflow_future::start_workflow,
     workflow_interceptors::WorkflowInterceptorConstructor,
 };

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -316,6 +316,44 @@ pub struct WorkerOptions {
 }
 
 impl<S: worker_options_builder::State> WorkerOptionsBuilder<S> {
+    pub(crate) fn with_workflows(mut self, workflows: WorkflowDefinitions) -> Self {
+        self.workflows = workflows;
+        self
+    }
+
+    pub(crate) fn with_worker_interceptors(
+        mut self,
+        worker_interceptors: Vec<Arc<dyn WorkerInterceptor>>,
+    ) -> Self {
+        self.worker_interceptors = worker_interceptors;
+        self
+    }
+
+    pub(crate) fn with_workflow_interceptor_constructors(
+        mut self,
+        workflow_interceptor_constructors: Vec<WorkflowInterceptorConstructor>,
+    ) -> Self {
+        self.workflow_interceptor_constructors = workflow_interceptor_constructors;
+        self
+    }
+
+    pub(crate) fn with_worker_plugins(
+        mut self,
+        worker_plugins: Vec<Arc<dyn WorkerPlugin>>,
+    ) -> Self {
+        self.worker_plugins = worker_plugins;
+        self
+    }
+
+    #[cfg(feature = "wasm-workflows")]
+    pub(crate) fn with_wasm_workflow_components(
+        mut self,
+        wasm_workflow_components: Vec<WasmWorkflowComponent>,
+    ) -> Self {
+        self.wasm_workflow_components = wasm_workflow_components;
+        self
+    }
+
     /// Register a worker plugin.
     ///
     /// **Experimental:** This API may change or be removed.

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -113,7 +113,7 @@ use crate::{
         activity_error_to_core_result,
     },
     interceptors::{ActivityInboundInterceptor, WorkerInterceptor},
-    workflow_executor::{TaskHandle, WorkflowExecutor},
+    workflow_executor::{TaskDroppedError, TaskHandle, WorkflowExecutor},
     workflow_future::start_workflow,
     workflow_interceptors::WorkflowInterceptorConstructor,
 };

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -74,6 +74,8 @@ mod workflow_executor;
 mod workflow_future;
 pub mod workflow_interceptors;
 mod workflow_registry;
+/// Workflow history replay APIs.
+pub mod workflow_replayer;
 #[cfg(feature = "wasm-workflows")]
 mod workflow_wasm;
 pub mod workflows;

--- a/crates/sdk/src/plugins.rs
+++ b/crates/sdk/src/plugins.rs
@@ -8,6 +8,7 @@ use crate::{
     activities::ActivityDefinitions,
     interceptors::{ActivityInboundInterceptor, WorkerInterceptor},
     workflow_interceptors::WorkflowInterceptorConstructor,
+    workflow_replayer::WorkflowReplayerOptions,
 };
 use std::{any::Any, sync::Arc};
 use temporalio_client::{
@@ -30,6 +31,17 @@ pub trait WorkerPlugin: Send + Sync + 'static {
     /// Worker plugin registrations are captured before this method is called. Altering plugins in
     /// this method does not change which plugins are applied.
     fn configure_worker_options(&self, _options: &mut WorkerOptions) -> Result<(), PluginError> {
+        Ok(())
+    }
+
+    /// Configure workflow replayer options.
+    ///
+    /// Replay plugin registrations are captured before this method is called. Altering plugins in
+    /// this method does not change which plugins are applied.
+    fn configure_workflow_replayer_options(
+        &self,
+        _options: &mut WorkflowReplayerOptions,
+    ) -> Result<(), PluginError> {
         Ok(())
     }
 }
@@ -99,6 +111,13 @@ impl WorkerPlugin for ClientAndWorkerPlugin {
 
     fn configure_worker_options(&self, options: &mut WorkerOptions) -> Result<(), PluginError> {
         self.worker.configure_worker_options(options)
+    }
+
+    fn configure_workflow_replayer_options(
+        &self,
+        options: &mut WorkflowReplayerOptions,
+    ) -> Result<(), PluginError> {
+        self.worker.configure_workflow_replayer_options(options)
     }
 }
 
@@ -282,6 +301,40 @@ impl WorkerPlugin for SimplePlugin {
         );
         Ok(())
     }
+
+    fn configure_workflow_replayer_options(
+        &self,
+        options: &mut WorkflowReplayerOptions,
+    ) -> Result<(), PluginError> {
+        apply_replacing(&mut options.data_converter, self.data_converter.as_ref());
+        if let Some(workflows) = &self.workflows {
+            match workflows {
+                SimplePluginOption::Value(value) => options.workflows.extend(value),
+                SimplePluginOption::Function(function) => {
+                    let workflows = function(Some(options.workflows.clone()));
+                    options.workflows.extend(&workflows)
+                }
+            }
+            .map_err(PluginError::new)?;
+        }
+        apply_appending(
+            &mut options.worker_interceptors,
+            self.worker_interceptors.as_ref(),
+            |existing, value| existing.extend(value.iter().cloned()),
+        );
+        apply_appending(
+            &mut options.workflow_interceptor_constructors,
+            self.workflow_interceptors.as_ref(),
+            |existing, value| existing.extend(value.iter().cloned()),
+        );
+        #[cfg(feature = "wasm-workflows")]
+        apply_appending(
+            &mut options.wasm_workflow_components,
+            self.wasm_workflow_components.as_ref(),
+            |existing, value| existing.extend(value.iter().cloned()),
+        );
+        Ok(())
+    }
 }
 
 struct SharedClientPlugin<P>(Arc<P>);
@@ -318,6 +371,13 @@ where
 
     fn configure_worker_options(&self, options: &mut WorkerOptions) -> Result<(), PluginError> {
         self.0.configure_worker_options(options)
+    }
+
+    fn configure_workflow_replayer_options(
+        &self,
+        options: &mut WorkflowReplayerOptions,
+    ) -> Result<(), PluginError> {
+        self.0.configure_workflow_replayer_options(options)
     }
 }
 
@@ -368,6 +428,26 @@ pub(crate) fn apply_worker_plugins(
             .configure_worker_options(options)
             .map_err(|source| {
                 PluginApplyError::new(registration.name(), PluginTarget::Worker, source)
+            })?;
+    }
+    options.worker_plugins = plugins;
+    Ok(())
+}
+
+pub(crate) fn apply_workflow_replayer_plugins(
+    options: &mut WorkflowReplayerOptions,
+) -> Result<(), PluginApplyError> {
+    let plugins = std::mem::take(&mut options.worker_plugins);
+
+    for warning in worker_plugin_warnings(&plugins) {
+        warn!(plugin = warning.plugin_name, "{}", warning.message);
+    }
+
+    for registration in &plugins {
+        registration
+            .configure_workflow_replayer_options(options)
+            .map_err(|source| {
+                PluginApplyError::new(registration.name(), PluginTarget::WorkflowReplayer, source)
             })?;
     }
     options.worker_plugins = plugins;
@@ -429,6 +509,14 @@ mod tests {
             self.order.lock().unwrap().push(self.value);
             Ok(())
         }
+
+        fn configure_workflow_replayer_options(
+            &self,
+            _options: &mut WorkflowReplayerOptions,
+        ) -> Result<(), PluginError> {
+            self.order.lock().unwrap().push(self.value);
+            Ok(())
+        }
     }
 
     #[test]
@@ -449,6 +537,28 @@ mod tests {
         apply_worker_plugins(&client_options, &mut worker_options).unwrap();
 
         assert_eq!(*order.lock().unwrap(), ["propagated", "local"]);
+    }
+
+    #[test]
+    fn replay_plugins_configure_in_registration_order() {
+        let order = Arc::new(Mutex::new(Vec::new()));
+        let mut options = WorkflowReplayerOptions::new()
+            .worker_plugin(RecordingWorkerPlugin {
+                name: "first",
+                value: "first",
+                order: order.clone(),
+            })
+            .worker_plugin(RecordingWorkerPlugin {
+                name: "second",
+                value: "second",
+                order: order.clone(),
+            })
+            .build();
+
+        apply_workflow_replayer_plugins(&mut options).unwrap();
+
+        assert_eq!(*order.lock().unwrap(), ["first", "second"]);
+        assert_eq!(options.worker_plugins.len(), 2);
     }
 
     #[test]

--- a/crates/sdk/src/workflow_replayer.rs
+++ b/crates/sdk/src/workflow_replayer.rs
@@ -1,0 +1,503 @@
+use crate::{
+    Worker, WorkerOptions,
+    interceptors::WorkerInterceptor,
+    plugins::WorkerPlugin,
+    runtime::WorkflowErrorType,
+    workflow_interceptors::WorkflowInterceptorConstructor,
+    workflow_registry::{WorkflowDefinitions, WorkflowRegistrationError},
+};
+use anyhow::anyhow;
+use futures_util::stream;
+use parking_lot::Mutex;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+use temporalio_client::{ClientOptions, PluginApplyError, WorkflowHistory};
+use temporalio_common::{
+    WorkflowDefinition,
+    data_converters::DataConverter,
+    protos::{
+        coresdk::workflow_activation::{
+            WorkflowActivation, remove_from_cache::EvictionReason,
+            workflow_activation_job::Variant as ActivationVariant,
+        },
+        temporal::api::history::v1::{History, history_event::Attributes},
+    },
+};
+use temporalio_sdk_core::{
+    init_replay_worker,
+    replay::{HistoryForReplay, HistoryInfo, ReplayWorkerInput},
+};
+use temporalio_workflow::{PatchActivationCallback, runtime::entry::WorkflowImplementation};
+
+#[cfg(feature = "wasm-workflows")]
+use crate::WasmWorkflowComponent;
+
+const DEFAULT_REPLAY_NAMESPACE: &str = "ReplayNamespace";
+const DEFAULT_REPLAY_TASK_QUEUE: &str = "ReplayTaskQueue";
+const DEFAULT_REPLAY_WORKFLOW_ID: &str = "replay-workflow";
+
+/// Options for constructing a workflow replayer.
+#[derive(bon::Builder, Clone)]
+#[builder(start_fn = new, on(String, into), state_mod(vis = "pub"))]
+#[non_exhaustive]
+pub struct WorkflowReplayerOptions {
+    #[builder(field)]
+    pub(super) workflows: WorkflowDefinitions,
+
+    #[builder(field)]
+    pub(super) worker_interceptors: Vec<Arc<dyn WorkerInterceptor>>,
+
+    #[builder(field)]
+    pub(super) workflow_interceptor_constructors: Vec<WorkflowInterceptorConstructor>,
+
+    #[builder(field)]
+    pub(super) worker_plugins: Vec<Arc<dyn WorkerPlugin>>,
+
+    #[cfg(feature = "wasm-workflows")]
+    #[builder(field)]
+    pub(super) wasm_workflow_components: Vec<WasmWorkflowComponent>,
+
+    /// Namespace exposed to workflow code during replay.
+    #[builder(default = DEFAULT_REPLAY_NAMESPACE.to_owned())]
+    pub namespace: String,
+
+    /// Task queue exposed to workflow code during replay.
+    #[builder(default = DEFAULT_REPLAY_TASK_QUEUE.to_owned())]
+    pub task_queue: String,
+
+    /// Data converter used for workflow payloads.
+    #[builder(default)]
+    pub data_converter: DataConverter,
+
+    /// Worker-level workflow errors that should fail workflow executions.
+    #[builder(default)]
+    pub workflow_failure_errors: HashSet<WorkflowErrorType>,
+
+    /// Per-workflow-type errors that should fail workflow executions.
+    #[builder(default)]
+    pub workflow_types_to_failure_errors: HashMap<String, HashSet<WorkflowErrorType>>,
+
+    /// Whether to detect nondeterministic future usage in workflow code.
+    #[builder(default = true)]
+    pub detect_nondeterministic_futures: bool,
+
+    /// Callback controlling first non-replay patch decisions.
+    pub patch_activation_callback: Option<PatchActivationCallback>,
+}
+
+impl<S: workflow_replayer_options_builder::State> WorkflowReplayerOptionsBuilder<S> {
+    /// Register a worker plugin with this replayer.
+    ///
+    /// **Experimental:** This API may change or be removed.
+    pub fn worker_plugin<P: WorkerPlugin>(mut self, plugin: P) -> Self {
+        self.worker_plugins.push(Arc::new(plugin));
+        self
+    }
+
+    /// Append a worker interceptor used during replay.
+    pub fn worker_interceptor<I: WorkerInterceptor + 'static>(mut self, interceptor: I) -> Self {
+        self.worker_interceptors.push(Arc::new(interceptor));
+        self
+    }
+
+    /// Append a workflow interceptor constructor used during replay.
+    pub fn workflow_interceptor(mut self, constructor: WorkflowInterceptorConstructor) -> Self {
+        self.workflow_interceptor_constructors.push(constructor);
+        self
+    }
+
+    /// Register a workflow implementation for replay.
+    pub fn register_workflow<W>(mut self) -> Result<Self, WorkflowRegistrationError>
+    where
+        W: WorkflowImplementation,
+        <W::Run as WorkflowDefinition>::Input: Send,
+    {
+        self.workflows.register_workflow::<W>()?;
+        Ok(self)
+    }
+
+    /// Register a workflow using a custom instance factory.
+    pub fn register_workflow_with_factory<W, F>(
+        mut self,
+        factory: F,
+    ) -> Result<Self, WorkflowRegistrationError>
+    where
+        W: WorkflowImplementation,
+        <W::Run as WorkflowDefinition>::Input: Send,
+        F: Fn() -> W + Send + Sync + 'static,
+    {
+        self.workflows
+            .register_workflow_run_with_factory::<W, F>(factory)?;
+        Ok(self)
+    }
+
+    /// Set the ordered constructors used to create workflow interceptors for each workflow instance.
+    ///
+    /// This replaces any previously configured workflow interceptor constructors.
+    pub fn register_workflow_interceptors(
+        mut self,
+        constructors: Vec<WorkflowInterceptorConstructor>,
+    ) -> Self {
+        self.workflow_interceptor_constructors = constructors;
+        self
+    }
+
+    /// Get a mutable reference to the workflow interceptor constructors list.
+    pub fn workflow_interceptor_constructors_mut(
+        &mut self,
+    ) -> &mut Vec<WorkflowInterceptorConstructor> {
+        &mut self.workflow_interceptor_constructors
+    }
+
+    /// Register a prebuilt WASM workflow component for replay.
+    #[cfg(feature = "wasm-workflows")]
+    pub fn register_wasm_workflow(mut self, component: WasmWorkflowComponent) -> Self {
+        self.wasm_workflow_components.push(component);
+        self
+    }
+}
+
+impl WorkflowReplayerOptions {
+    /// Append a worker interceptor used during replay.
+    pub fn worker_interceptor<I: WorkerInterceptor + 'static>(
+        &mut self,
+        interceptor: I,
+    ) -> &mut Self {
+        self.worker_interceptors.push(Arc::new(interceptor));
+        self
+    }
+
+    /// Append a workflow interceptor constructor used during replay.
+    pub fn workflow_interceptor(
+        &mut self,
+        constructor: WorkflowInterceptorConstructor,
+    ) -> &mut Self {
+        self.workflow_interceptor_constructors.push(constructor);
+        self
+    }
+
+    /// Register a workflow implementation for replay.
+    pub fn register_workflow<W>(&mut self) -> Result<&mut Self, WorkflowRegistrationError>
+    where
+        W: WorkflowImplementation,
+        <W::Run as WorkflowDefinition>::Input: Send,
+    {
+        self.workflows.register_workflow::<W>()?;
+        Ok(self)
+    }
+
+    /// Register a workflow using a custom instance factory.
+    pub fn register_workflow_with_factory<W, F>(
+        &mut self,
+        factory: F,
+    ) -> Result<&mut Self, WorkflowRegistrationError>
+    where
+        W: WorkflowImplementation,
+        <W::Run as WorkflowDefinition>::Input: Send,
+        F: Fn() -> W + Send + Sync + 'static,
+    {
+        self.workflows
+            .register_workflow_run_with_factory::<W, F>(factory)?;
+        Ok(self)
+    }
+
+    /// Set the ordered constructors used to create workflow interceptors for each workflow instance.
+    ///
+    /// This replaces any previously configured workflow interceptor constructors.
+    pub fn register_workflow_interceptors(
+        &mut self,
+        constructors: Vec<WorkflowInterceptorConstructor>,
+    ) -> &mut Self {
+        self.workflow_interceptor_constructors = constructors;
+        self
+    }
+
+    /// Register a prebuilt WASM workflow component for replay.
+    #[cfg(feature = "wasm-workflows")]
+    pub fn register_wasm_workflow(&mut self, component: WasmWorkflowComponent) -> &mut Self {
+        self.wasm_workflow_components.push(component);
+        self
+    }
+
+    /// Returns all the registered workflows by cloning the current set.
+    pub fn workflows(&self) -> WorkflowDefinitions {
+        self.workflows.clone()
+    }
+}
+
+/// A failure attributable to one workflow history during replay.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum WorkflowReplayFailure {
+    /// The history could not be replayed because it was malformed or incomplete.
+    #[error("invalid workflow history: {message}")]
+    InvalidHistory {
+        /// Validation failure details.
+        message: String,
+    },
+    /// Workflow code was incompatible with recorded history.
+    #[error("workflow replay was nondeterministic: {message}")]
+    Nondeterminism {
+        /// Nondeterminism details reported by Core.
+        message: String,
+    },
+    /// Language workflow execution failed while processing a task.
+    #[error("workflow task failed during replay: {message}")]
+    WorkflowTaskFailure {
+        /// Workflow task failure details.
+        message: String,
+    },
+    /// Replay ended for an unexpected internal reason.
+    #[error("workflow replay failed internally ({reason}): {message}")]
+    Internal {
+        /// Core eviction reason.
+        reason: String,
+        /// Eviction details reported by Core.
+        message: String,
+    },
+}
+
+/// Outcome of replaying one workflow history.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct WorkflowReplayResult {
+    /// History supplied to the replayer.
+    pub history: WorkflowHistory,
+    /// Replay failure, or `None` when the workflow code is compatible with the history.
+    pub replay_failure: Option<WorkflowReplayFailure>,
+}
+
+/// Error creating or running a workflow replayer.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum WorkflowReplayError {
+    /// A plugin failed while configuring replay options.
+    #[error(transparent)]
+    Plugin(#[from] PluginApplyError),
+    /// No workflow definitions were registered after plugin configuration.
+    #[error("at least one workflow must be registered for replay")]
+    NoWorkflowsRegistered,
+    /// The replay worker could not be initialized.
+    #[error("workflow replay initialization failed: {0}")]
+    Initialization(#[source] anyhow::Error),
+    /// The replay worker stopped before producing trustworthy results.
+    #[error("workflow replay worker failed: {0}")]
+    Worker(#[source] anyhow::Error),
+    /// A single-history replay failed.
+    #[error(transparent)]
+    Replay(#[from] WorkflowReplayFailure),
+}
+
+/// Replays workflow histories against registered workflow implementations.
+pub struct WorkflowReplayer {
+    options: WorkflowReplayerOptions,
+}
+
+impl WorkflowReplayer {
+    /// Construct a replayer and apply its worker plugins.
+    pub fn new(mut options: WorkflowReplayerOptions) -> Result<Self, WorkflowReplayError> {
+        crate::plugins::apply_workflow_replayer_plugins(&mut options)?;
+        if options.workflows.is_empty() {
+            return Err(WorkflowReplayError::NoWorkflowsRegistered);
+        }
+        Ok(Self { options })
+    }
+
+    /// Return the configured replay options.
+    pub fn options(&self) -> &WorkflowReplayerOptions {
+        &self.options
+    }
+
+    /// Replay one history and return an error if it is incompatible with workflow code.
+    pub async fn replay_workflow(
+        &self,
+        history: WorkflowHistory,
+    ) -> Result<(), WorkflowReplayError> {
+        let mut results = self.replay_workflows([history]).await?;
+        let result = results.pop().ok_or_else(|| {
+            WorkflowReplayError::Worker(anyhow!("replay produced no result for its history"))
+        })?;
+        match result.replay_failure {
+            Some(failure) => Err(failure.into()),
+            None => Ok(()),
+        }
+    }
+
+    /// Replay histories using one replay worker and return outcomes in input order.
+    pub async fn replay_workflows(
+        &self,
+        histories: impl IntoIterator<Item = WorkflowHistory>,
+    ) -> Result<Vec<WorkflowReplayResult>, WorkflowReplayError> {
+        self.replay_workflows_internal(histories.into_iter().collect())
+            .await
+    }
+
+    async fn replay_workflows_internal(
+        &self,
+        histories: Vec<WorkflowHistory>,
+    ) -> Result<Vec<WorkflowReplayResult>, WorkflowReplayError> {
+        let mut results = histories
+            .into_iter()
+            .map(|history| WorkflowReplayResult {
+                history,
+                replay_failure: None,
+            })
+            .collect::<Vec<_>>();
+        let mut valid_indexes = Vec::new();
+        let mut core_histories = Vec::new();
+
+        for (index, result) in results.iter_mut().enumerate() {
+            match validate_history(&result.history) {
+                Ok(history) => {
+                    valid_indexes.push(index);
+                    core_histories.push(history);
+                }
+                Err(failure) => result.replay_failure = Some(failure),
+            }
+        }
+
+        if core_histories.is_empty() {
+            return Ok(results);
+        }
+
+        let recorded_outcomes = Arc::new(Mutex::new(Vec::new()));
+        let observer = ReplayOutcomeInterceptor {
+            outcomes: recorded_outcomes.clone(),
+        };
+        let mut worker_options = WorkerOptions::new(self.options.task_queue.clone()).build();
+        worker_options.workflows = self.options.workflows.clone();
+        worker_options.worker_interceptors = self.options.worker_interceptors.clone();
+        worker_options
+            .worker_interceptors
+            .insert(0, Arc::new(observer));
+        worker_options.workflow_interceptor_constructors =
+            self.options.workflow_interceptor_constructors.clone();
+        worker_options.worker_plugins = self.options.worker_plugins.clone();
+        worker_options.workflow_failure_errors = self.options.workflow_failure_errors.clone();
+        worker_options.workflow_types_to_failure_errors =
+            self.options.workflow_types_to_failure_errors.clone();
+        worker_options.detect_nondeterministic_futures =
+            self.options.detect_nondeterministic_futures;
+        worker_options.patch_activation_callback = self.options.patch_activation_callback.clone();
+        #[cfg(feature = "wasm-workflows")]
+        {
+            worker_options.wasm_workflow_components = self.options.wasm_workflow_components.clone();
+        }
+
+        let core_options = worker_options
+            .to_core_options(self.options.namespace.clone(), String::new())
+            .map_err(|error| WorkflowReplayError::Initialization(anyhow!(error)))?;
+        let core_worker = init_replay_worker(ReplayWorkerInput::new(
+            core_options,
+            stream::iter(core_histories),
+        ))
+        .map_err(WorkflowReplayError::Initialization)?;
+        let client_options = ClientOptions::new(self.options.namespace.clone())
+            .data_converter(self.options.data_converter.clone())
+            .build();
+        let mut worker = Worker::new_from_core_options_prepared(
+            Arc::new(core_worker),
+            client_options,
+            worker_options,
+        )
+        .map_err(|error| WorkflowReplayError::Initialization(anyhow!(error)))?;
+
+        if let Err(source) = worker.run().await {
+            let core_worker = worker.core_worker();
+            core_worker.initiate_shutdown();
+            core_worker.shutdown().await;
+            return Err(WorkflowReplayError::Worker(source));
+        }
+
+        let outcomes = std::mem::take(&mut *recorded_outcomes.lock());
+        if outcomes.len() != valid_indexes.len() {
+            return Err(WorkflowReplayError::Worker(anyhow!(
+                "replay produced {} outcomes for {} valid histories",
+                outcomes.len(),
+                valid_indexes.len()
+            )));
+        }
+        for (index, replay_failure) in valid_indexes.into_iter().zip(outcomes) {
+            results[index].replay_failure = replay_failure;
+        }
+        Ok(results)
+    }
+}
+
+fn validate_history(history: &WorkflowHistory) -> Result<HistoryForReplay, WorkflowReplayFailure> {
+    let proto = History {
+        events: history.events().to_vec(),
+    };
+    HistoryInfo::new_from_history(&proto, None).map_err(|error| {
+        WorkflowReplayFailure::InvalidHistory {
+            message: error.to_string(),
+        }
+    })?;
+    let attributes = match proto
+        .events
+        .first()
+        .and_then(|event| event.attributes.as_ref())
+    {
+        Some(Attributes::WorkflowExecutionStartedEventAttributes(attributes)) => attributes,
+        _ => {
+            return Err(WorkflowReplayFailure::InvalidHistory {
+                message: "first event is not WorkflowExecutionStarted".to_owned(),
+            });
+        }
+    };
+    if attributes.original_execution_run_id.is_empty() {
+        return Err(WorkflowReplayFailure::InvalidHistory {
+            message: "workflow start event has no original execution run ID".to_owned(),
+        });
+    }
+    if attributes
+        .task_queue
+        .as_ref()
+        .is_none_or(|task_queue| task_queue.name.is_empty())
+    {
+        return Err(WorkflowReplayFailure::InvalidHistory {
+            message: "workflow start event has no task queue".to_owned(),
+        });
+    }
+    Ok(HistoryForReplay::new(
+        proto,
+        history.workflow_id().unwrap_or(DEFAULT_REPLAY_WORKFLOW_ID),
+    ))
+}
+
+struct ReplayOutcomeInterceptor {
+    outcomes: Arc<Mutex<Vec<Option<WorkflowReplayFailure>>>>,
+}
+
+#[async_trait::async_trait(?Send)]
+impl WorkerInterceptor for ReplayOutcomeInterceptor {
+    async fn on_workflow_activation(
+        &self,
+        activation: &WorkflowActivation,
+    ) -> Result<(), anyhow::Error> {
+        let Some(remove) = activation.jobs.iter().find_map(|job| match &job.variant {
+            Some(ActivationVariant::RemoveFromCache(remove)) => Some(remove),
+            _ => None,
+        }) else {
+            return Ok(());
+        };
+        let reason = remove.reason();
+        let failure = match reason {
+            EvictionReason::CacheFull | EvictionReason::LangRequested => None,
+            EvictionReason::Nondeterminism => Some(WorkflowReplayFailure::Nondeterminism {
+                message: remove.message.clone(),
+            }),
+            EvictionReason::LangFail => Some(WorkflowReplayFailure::WorkflowTaskFailure {
+                message: remove.message.clone(),
+            }),
+            reason => Some(WorkflowReplayFailure::Internal {
+                reason: format!("{reason:?}"),
+                message: remove.message.clone(),
+            }),
+        };
+        self.outcomes.lock().push(failure);
+        Ok(())
+    }
+}

--- a/crates/sdk/src/workflow_replayer.rs
+++ b/crates/sdk/src/workflow_replayer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Worker, WorkerOptions,
+    Worker, WorkerOptions, WorkerRunError,
     interceptors::WorkerInterceptor,
     plugins::WorkerPlugin,
     runtime::WorkflowErrorType,
@@ -284,7 +284,13 @@ pub enum WorkflowReplayError {
     Initialization(#[source] anyhow::Error),
     /// The replay worker stopped before producing trustworthy results.
     #[error("workflow replay worker failed: {0}")]
-    Worker(#[source] anyhow::Error),
+    Worker(#[source] WorkerRunError),
+    /// Replay completed without producing the expected outcomes.
+    #[error("workflow replay failed internally: {message}")]
+    Internal {
+        /// Failure details.
+        message: String,
+    },
     /// A single-history replay failed.
     #[error(transparent)]
     Replay(#[from] WorkflowReplayFailure),
@@ -316,8 +322,8 @@ impl WorkflowReplayer {
         history: WorkflowHistory,
     ) -> Result<(), WorkflowReplayError> {
         let mut results = self.replay_workflows([history]).await?;
-        let result = results.pop().ok_or_else(|| {
-            WorkflowReplayError::Worker(anyhow!("replay produced no result for its history"))
+        let result = results.pop().ok_or_else(|| WorkflowReplayError::Internal {
+            message: "replay produced no result for its history".to_owned(),
         })?;
         match result.replay_failure {
             Some(failure) => Err(failure.into()),
@@ -413,11 +419,13 @@ impl WorkflowReplayer {
 
         let outcomes = std::mem::take(&mut *recorded_outcomes.lock());
         if outcomes.len() != valid_indexes.len() {
-            return Err(WorkflowReplayError::Worker(anyhow!(
-                "replay produced {} outcomes for {} valid histories",
-                outcomes.len(),
-                valid_indexes.len()
-            )));
+            return Err(WorkflowReplayError::Internal {
+                message: format!(
+                    "replay produced {} outcomes for {} valid histories",
+                    outcomes.len(),
+                    valid_indexes.len()
+                ),
+            });
         }
         for (index, replay_failure) in valid_indexes.into_iter().zip(outcomes) {
             results[index].replay_failure = replay_failure;

--- a/crates/sdk/src/workflow_replayer.rs
+++ b/crates/sdk/src/workflow_replayer.rs
@@ -372,25 +372,7 @@ impl WorkflowReplayer {
         let observer = ReplayOutcomeInterceptor {
             outcomes: recorded_outcomes.clone(),
         };
-        let mut worker_options = WorkerOptions::new(self.options.task_queue.clone()).build();
-        worker_options.workflows = self.options.workflows.clone();
-        worker_options.worker_interceptors = self.options.worker_interceptors.clone();
-        worker_options
-            .worker_interceptors
-            .insert(0, Arc::new(observer));
-        worker_options.workflow_interceptor_constructors =
-            self.options.workflow_interceptor_constructors.clone();
-        worker_options.worker_plugins = self.options.worker_plugins.clone();
-        worker_options.workflow_failure_errors = self.options.workflow_failure_errors.clone();
-        worker_options.workflow_types_to_failure_errors =
-            self.options.workflow_types_to_failure_errors.clone();
-        worker_options.detect_nondeterministic_futures =
-            self.options.detect_nondeterministic_futures;
-        worker_options.patch_activation_callback = self.options.patch_activation_callback.clone();
-        #[cfg(feature = "wasm-workflows")]
-        {
-            worker_options.wasm_workflow_components = self.options.wasm_workflow_components.clone();
-        }
+        let worker_options = self.replay_worker_options(observer);
 
         let core_options = worker_options
             .to_core_options(self.options.namespace.clone(), String::new())
@@ -431,6 +413,27 @@ impl WorkflowReplayer {
             results[index].replay_failure = replay_failure;
         }
         Ok(results)
+    }
+
+    fn replay_worker_options(&self, observer: ReplayOutcomeInterceptor) -> WorkerOptions {
+        let worker_interceptors = std::iter::once(Arc::new(observer) as Arc<dyn WorkerInterceptor>)
+            .chain(self.options.worker_interceptors.iter().cloned())
+            .collect();
+        let worker_options = WorkerOptions::new(self.options.task_queue.clone())
+            .with_workflows(self.options.workflows.clone())
+            .with_worker_interceptors(worker_interceptors)
+            .with_workflow_interceptor_constructors(
+                self.options.workflow_interceptor_constructors.clone(),
+            )
+            .with_worker_plugins(self.options.worker_plugins.clone())
+            .workflow_failure_errors(self.options.workflow_failure_errors.clone())
+            .workflow_types_to_failure_errors(self.options.workflow_types_to_failure_errors.clone())
+            .detect_nondeterministic_futures(self.options.detect_nondeterministic_futures)
+            .maybe_patch_activation_callback(self.options.patch_activation_callback.clone());
+        #[cfg(feature = "wasm-workflows")]
+        let worker_options = worker_options
+            .with_wasm_workflow_components(self.options.wasm_workflow_components.clone());
+        worker_options.build()
     }
 }
 

--- a/crates/sdk/src/workflow_replayer.rs
+++ b/crates/sdk/src/workflow_replayer.rs
@@ -6,7 +6,6 @@ use crate::{
     workflow_interceptors::WorkflowInterceptorConstructor,
     workflow_registry::{WorkflowDefinitions, WorkflowRegistrationError},
 };
-use anyhow::anyhow;
 use futures_util::stream;
 use parking_lot::Mutex;
 use std::{
@@ -22,12 +21,12 @@ use temporalio_common::{
             WorkflowActivation, remove_from_cache::EvictionReason,
             workflow_activation_job::Variant as ActivationVariant,
         },
-        temporal::api::history::v1::{History, history_event::Attributes},
+        temporal::api::history::v1::History,
     },
 };
 use temporalio_sdk_core::{
     init_replay_worker,
-    replay::{HistoryForReplay, HistoryInfo, ReplayWorkerInput},
+    replay::{HistoryForReplay, ReplayWorkerInput},
 };
 use temporalio_workflow::{PatchActivationCallback, runtime::entry::WorkflowImplementation};
 
@@ -269,10 +268,22 @@ pub struct WorkflowReplayResult {
     pub replay_failure: Option<WorkflowReplayFailure>,
 }
 
-/// Error creating or running a workflow replayer.
+/// Error replaying a workflow history.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum WorkflowReplayError {
+    /// The replay worker could not be created or run.
+    #[error(transparent)]
+    Worker(#[from] WorkflowReplayWorkerError),
+    /// A single-history replay failed.
+    #[error(transparent)]
+    Replay(#[from] WorkflowReplayFailure),
+}
+
+/// Error creating or running the worker used for replay.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum WorkflowReplayWorkerError {
     /// A plugin failed while configuring replay options.
     #[error(transparent)]
     Plugin(#[from] PluginApplyError),
@@ -280,20 +291,20 @@ pub enum WorkflowReplayError {
     #[error("at least one workflow must be registered for replay")]
     NoWorkflowsRegistered,
     /// The replay worker could not be initialized.
-    #[error("workflow replay initialization failed: {0}")]
-    Initialization(#[source] anyhow::Error),
+    #[error("workflow replay initialization failed: {message}")]
+    Initialization {
+        /// Initialization failure details.
+        message: String,
+    },
     /// The replay worker stopped before producing trustworthy results.
     #[error("workflow replay worker failed: {0}")]
-    Worker(#[source] WorkerRunError),
+    Run(#[source] WorkerRunError),
     /// Replay completed without producing the expected outcomes.
     #[error("workflow replay failed internally: {message}")]
     Internal {
         /// Failure details.
         message: String,
     },
-    /// A single-history replay failed.
-    #[error(transparent)]
-    Replay(#[from] WorkflowReplayFailure),
 }
 
 /// Replays workflow histories against registered workflow implementations.
@@ -304,9 +315,10 @@ pub struct WorkflowReplayer {
 impl WorkflowReplayer {
     /// Construct a replayer and apply its worker plugins.
     pub fn new(mut options: WorkflowReplayerOptions) -> Result<Self, WorkflowReplayError> {
-        crate::plugins::apply_workflow_replayer_plugins(&mut options)?;
+        crate::plugins::apply_workflow_replayer_plugins(&mut options)
+            .map_err(WorkflowReplayWorkerError::Plugin)?;
         if options.workflows.is_empty() {
-            return Err(WorkflowReplayError::NoWorkflowsRegistered);
+            return Err(WorkflowReplayWorkerError::NoWorkflowsRegistered.into());
         }
         Ok(Self { options })
     }
@@ -322,9 +334,11 @@ impl WorkflowReplayer {
         history: WorkflowHistory,
     ) -> Result<(), WorkflowReplayError> {
         let mut results = self.replay_workflows([history]).await?;
-        let result = results.pop().ok_or_else(|| WorkflowReplayError::Internal {
-            message: "replay produced no result for its history".to_owned(),
-        })?;
+        let result = results
+            .pop()
+            .ok_or_else(|| WorkflowReplayWorkerError::Internal {
+                message: "replay produced no result for its history".to_owned(),
+            })?;
         match result.replay_failure {
             Some(failure) => Err(failure.into()),
             None => Ok(()),
@@ -344,6 +358,10 @@ impl WorkflowReplayer {
         &self,
         histories: Vec<WorkflowHistory>,
     ) -> Result<Vec<WorkflowReplayResult>, WorkflowReplayError> {
+        if histories.is_empty() {
+            return Ok(Vec::new());
+        }
+
         let mut results = histories
             .into_iter()
             .map(|history| WorkflowReplayResult {
@@ -351,22 +369,20 @@ impl WorkflowReplayer {
                 replay_failure: None,
             })
             .collect::<Vec<_>>();
-        let mut valid_indexes = Vec::new();
-        let mut core_histories = Vec::new();
-
-        for (index, result) in results.iter_mut().enumerate() {
-            match validate_history(&result.history) {
-                Ok(history) => {
-                    valid_indexes.push(index);
-                    core_histories.push(history);
-                }
-                Err(failure) => result.replay_failure = Some(failure),
-            }
-        }
-
-        if core_histories.is_empty() {
-            return Ok(results);
-        }
+        let core_histories: Vec<_> = results
+            .iter()
+            .map(|result| {
+                HistoryForReplay::new(
+                    History {
+                        events: result.history.events().to_vec(),
+                    },
+                    result
+                        .history
+                        .workflow_id()
+                        .unwrap_or(DEFAULT_REPLAY_WORKFLOW_ID),
+                )
+            })
+            .collect();
 
         let recorded_outcomes = Arc::new(Mutex::new(Vec::new()));
         let observer = ReplayOutcomeInterceptor {
@@ -376,12 +392,14 @@ impl WorkflowReplayer {
 
         let core_options = worker_options
             .to_core_options(self.options.namespace.clone(), String::new())
-            .map_err(|error| WorkflowReplayError::Initialization(anyhow!(error)))?;
+            .map_err(|message| WorkflowReplayWorkerError::Initialization { message })?;
         let core_worker = init_replay_worker(ReplayWorkerInput::new(
             core_options,
             stream::iter(core_histories),
         ))
-        .map_err(WorkflowReplayError::Initialization)?;
+        .map_err(|error| WorkflowReplayWorkerError::Initialization {
+            message: error.to_string(),
+        })?;
         let client_options = ClientOptions::new(self.options.namespace.clone())
             .data_converter(self.options.data_converter.clone())
             .build();
@@ -390,26 +408,20 @@ impl WorkflowReplayer {
             client_options,
             worker_options,
         )
-        .map_err(|error| WorkflowReplayError::Initialization(anyhow!(error)))?;
+        .map_err(|error| WorkflowReplayWorkerError::Initialization {
+            message: error.to_string(),
+        })?;
 
         if let Err(source) = worker.run().await {
             let core_worker = worker.core_worker();
             core_worker.initiate_shutdown();
             core_worker.shutdown().await;
-            return Err(WorkflowReplayError::Worker(source));
+            return Err(WorkflowReplayWorkerError::Run(source).into());
         }
 
         let outcomes = std::mem::take(&mut *recorded_outcomes.lock());
-        if outcomes.len() != valid_indexes.len() {
-            return Err(WorkflowReplayError::Internal {
-                message: format!(
-                    "replay produced {} outcomes for {} valid histories",
-                    outcomes.len(),
-                    valid_indexes.len()
-                ),
-            });
-        }
-        for (index, replay_failure) in valid_indexes.into_iter().zip(outcomes) {
+
+        for (index, replay_failure) in outcomes.into_iter().enumerate() {
             results[index].replay_failure = replay_failure;
         }
         Ok(results)
@@ -435,47 +447,6 @@ impl WorkflowReplayer {
             .with_wasm_workflow_components(self.options.wasm_workflow_components.clone());
         worker_options.build()
     }
-}
-
-fn validate_history(history: &WorkflowHistory) -> Result<HistoryForReplay, WorkflowReplayFailure> {
-    let proto = History {
-        events: history.events().to_vec(),
-    };
-    HistoryInfo::new_from_history(&proto, None).map_err(|error| {
-        WorkflowReplayFailure::InvalidHistory {
-            message: error.to_string(),
-        }
-    })?;
-    let attributes = match proto
-        .events
-        .first()
-        .and_then(|event| event.attributes.as_ref())
-    {
-        Some(Attributes::WorkflowExecutionStartedEventAttributes(attributes)) => attributes,
-        _ => {
-            return Err(WorkflowReplayFailure::InvalidHistory {
-                message: "first event is not WorkflowExecutionStarted".to_owned(),
-            });
-        }
-    };
-    if attributes.original_execution_run_id.is_empty() {
-        return Err(WorkflowReplayFailure::InvalidHistory {
-            message: "workflow start event has no original execution run ID".to_owned(),
-        });
-    }
-    if attributes
-        .task_queue
-        .as_ref()
-        .is_none_or(|task_queue| task_queue.name.is_empty())
-    {
-        return Err(WorkflowReplayFailure::InvalidHistory {
-            message: "workflow start event has no task queue".to_owned(),
-        });
-    }
-    Ok(HistoryForReplay::new(
-        proto,
-        history.workflow_id().unwrap_or(DEFAULT_REPLAY_WORKFLOW_ID),
-    ))
 }
 
 struct ReplayOutcomeInterceptor {


### PR DESCRIPTION
## What
- Add `WorkflowHistory::from_json` / `to_json`
- Add `WorkflowReplayer` and corresponding options

## Why

SDK parity.

One semi-unique aspect of this compared to other SDK implementations is that it is built on top of `WorkerInterceptor`. 

Closes #1453 