### PR TITLE
fix(sdk): reject updates when validators panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ to docs, or any other relevant information.
 * Cancellation errors propagated after workflow cancellation now complete the workflow as cancelled
   instead of failed.
 
+### Fixed
+* Panics from update validators now reject the update instead of repeatedly failing workflow
+  tasks.
+
 ## [0.6.0] - 2026-08-04
 
 ### Added

--- a/crates/sdk-core/tests/integ_tests/update_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/update_tests.rs
@@ -33,8 +33,7 @@ use temporalio_common::{
         },
         temporal::api::{
             common::v1::WorkflowExecution,
-            enums::v1::{EventType, ResetReapplyType, WorkflowTaskFailedCause},
-            history::v1::history_event::Attributes::WorkflowTaskFailedEventAttributes,
+            enums::v1::{EventType, ResetReapplyType},
             workflowservice::v1::{ResetStickyTaskQueueRequest, ResetWorkflowExecutionRequest},
         },
     },

--- a/crates/sdk-core/tests/integ_tests/update_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/update_tests.rs
@@ -15,7 +15,7 @@ use std::{
 use temporalio_client::{
     Client, NamespacedClient, UntypedSignal, UntypedUpdate, UntypedWorkflow,
     WorkflowExecuteUpdateOptions, WorkflowExecutionInfo, WorkflowSignalOptions,
-    WorkflowStartOptions, grpc::WorkflowService,
+    WorkflowStartOptions, errors::WorkflowUpdateError, grpc::WorkflowService,
 };
 use temporalio_common::{
     data_converters::RawValue,
@@ -33,7 +33,8 @@ use temporalio_common::{
         },
         temporal::api::{
             common::v1::WorkflowExecution,
-            enums::v1::{EventType, ResetReapplyType},
+            enums::v1::{EventType, ResetReapplyType, WorkflowTaskFailedCause},
+            history::v1::history_event::Attributes::WorkflowTaskFailedEventAttributes,
             workflowservice::v1::{ResetStickyTaskQueueRequest, ResetWorkflowExecutionRequest},
         },
     },
@@ -994,14 +995,21 @@ async fn task_failure_during_validation() {
     let mut worker = starter.worker().await;
     #[workflow]
     #[derive(Default)]
-    struct TaskFailureDuringValidationWf;
+    struct TaskFailureDuringValidationWf {
+        done: bool,
+    }
 
     #[workflow_methods]
     impl TaskFailureDuringValidationWf {
         #[run]
         async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-            ctx.timer(Duration::from_secs(1)).await;
+            ctx.wait_condition(|state| state.done).await?;
             Ok(())
+        }
+
+        #[signal]
+        fn done(&mut self, _ctx: &mut SyncWorkflowContext<Self>, _: ()) {
+            self.done = true;
         }
 
         #[update_validator(do_update)]
@@ -1010,11 +1018,7 @@ async fn task_failure_during_validation() {
             _ctx: &WorkflowContextView,
             _: &(),
         ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-            static FAILCT: AtomicUsize = AtomicUsize::new(0);
-            if FAILCT.fetch_add(1, Ordering::Relaxed) < 2 {
-                panic!("ahhhhhh");
-            }
-            Ok(())
+            panic!("intentional validator panic")
         }
 
         #[update]
@@ -1038,7 +1042,7 @@ async fn task_failure_during_validation() {
         )
         .await
         .unwrap();
-    let update = async {
+    let update_result = async {
         let res = handle
             .execute_update(
                 TaskFailureDuringValidationWf::do_update,
@@ -1046,7 +1050,96 @@ async fn task_failure_during_validation() {
                 WorkflowExecuteUpdateOptions::default(),
             )
             .await;
+
+        handle
+            .signal(
+                TaskFailureDuringValidationWf::done,
+                (),
+                WorkflowSignalOptions::default(),
+            )
+            .await
+            .unwrap();
+        res
+    };
+    let run = async {
+        worker.run_until_done().await.unwrap();
+    };
+    let (update_result, _) = join!(update_result, run);
+    assert_matches!(
+        update_result,
+        Err(WorkflowUpdateError::Failed(failure))
+            if failure.message.contains("intentional validator panic")
+    );
+}
+
+#[tokio::test]
+async fn task_failure_during_update_handler() {
+    let wf_name = "task_failure_during_update_handler";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter.workflow_options.task_timeout = Some(Duration::from_secs(1));
+    let mut worker = starter.worker().await;
+    #[workflow]
+    #[derive(Default)]
+    struct TaskFailureDuringUpdateHandlerWf {
+        done: bool,
+    }
+
+    #[workflow_methods]
+    impl TaskFailureDuringUpdateHandlerWf {
+        #[run]
+        async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+            ctx.wait_condition(|state| state.done).await?;
+            Ok(())
+        }
+
+        #[signal]
+        fn done(&mut self, _ctx: &mut SyncWorkflowContext<Self>, _: ()) {
+            self.done = true;
+        }
+
+        #[update]
+        async fn do_update(
+            _ctx: &mut WorkflowContext<Self>,
+            _: (),
+        ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+            static FAILCT: AtomicUsize = AtomicUsize::new(0);
+            if FAILCT.fetch_add(1, Ordering::Relaxed) == 0 {
+                panic!("intentional update handler panic");
+            }
+            Ok("done".to_string())
+        }
+    }
+
+    worker
+        .register_workflow::<TaskFailureDuringUpdateHandlerWf>()
+        .unwrap();
+    let task_queue = starter.get_task_queue().to_owned();
+    let handle = worker
+        .submit_workflow(
+            TaskFailureDuringUpdateHandlerWf::run,
+            (),
+            WorkflowStartOptions::new(task_queue, starter.get_wf_id().to_owned()).build(),
+        )
+        .await
+        .unwrap();
+    let update = async {
+        let res = handle
+            .execute_update(
+                TaskFailureDuringUpdateHandlerWf::do_update,
+                (),
+                WorkflowExecuteUpdateOptions::default(),
+            )
+            .await;
         assert!(res.unwrap() == "done");
+        handle
+            .signal(
+                TaskFailureDuringUpdateHandlerWf::done,
+                (),
+                WorkflowSignalOptions::default(),
+            )
+            .await
+            .unwrap();
     };
     let run = async {
         worker.run_until_done().await.unwrap();

--- a/crates/workflow/src/runtime/instance.rs
+++ b/crates/workflow/src/runtime/instance.rs
@@ -28,10 +28,12 @@ use futures_util::{
     future::{Fuse, LocalBoxFuture},
 };
 use std::{
-    any::Any,
+    any::{Any, TypeId},
     cell::RefCell,
     collections::HashMap,
+    fmt::{Display, Formatter},
     future::{Future, ready},
+    panic::AssertUnwindSafe,
     pin::Pin,
     rc::Rc,
     sync::Arc,
@@ -603,12 +605,19 @@ where
                 let view = workflow_ctx.view();
                 workflow_ctx.state(|wf| wf.validate_update(view, &name, input))
             });
-            let validation = call_validate_update(
-                &self.interceptors,
-                validation_ctx,
-                validation_input,
-                validation_next,
-            );
+            let validation = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                call_validate_update(
+                    &self.interceptors,
+                    validation_ctx,
+                    validation_input,
+                    validation_next,
+                )
+            }))
+            .unwrap_or_else(|panic| {
+                Err(WorkflowError::Execution(
+                    anyhow::anyhow!("Update validator panicked: {}", panic_formatter(panic)).into(),
+                ))
+            });
             match validation {
                 Ok(()) => {}
                 Err(e) => {
@@ -1086,6 +1095,43 @@ where
     <W::Run as WorkflowDefinition>::Input: Send,
 {
     GuestWorkflowInstance::<W>::instantiate(payloads, converter, base_ctx)
+}
+
+/// Attempts to turn caught panics into something printable
+fn panic_formatter(panic: Box<dyn Any>) -> Box<dyn Display> {
+    _panic_formatter::<&str>(panic)
+}
+fn _panic_formatter<T: 'static + PrintablePanicType>(panic: Box<dyn Any>) -> Box<dyn Display> {
+    match panic.downcast::<T>() {
+        Ok(d) => d,
+        Err(orig) => {
+            if TypeId::of::<<T as PrintablePanicType>::NextType>()
+                == TypeId::of::<EndPrintingAttempts>()
+            {
+                return Box::new("Couldn't turn panic into a string");
+            }
+            _panic_formatter::<T::NextType>(orig)
+        }
+    }
+}
+trait PrintablePanicType: Display {
+    type NextType: PrintablePanicType;
+}
+
+impl PrintablePanicType for &str {
+    type NextType = String;
+}
+impl PrintablePanicType for String {
+    type NextType = EndPrintingAttempts;
+}
+struct EndPrintingAttempts {}
+impl Display for EndPrintingAttempts {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Will never be printed")
+    }
+}
+impl PrintablePanicType for EndPrintingAttempts {
+    type NextType = EndPrintingAttempts;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Catch panics in update validators and treat them as rejections instead of retrying them.

## Why?
Match other SDK behavior described from features

> Panics/Exceptions out of validation handlers are equivalent to rejections from a durability perspective while panics/exceptions from the main execution function are the equivalent of panicking/throwing in a workflow task.

source: https://github.com/temporalio/features/tree/main/features/update/task_failure

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Updated existing unit test to verify update fails instead of being retried.
Added new unit test verifying panic during actual handler is retried. (We previously just had assertion around panic after an update)

3. Any docs updates needed?
N/A
