### PR TITLE
Add forward declarations to C bridge header to fix -Wvisibility warnings

### DIFF
--- a/crates/sdk-core-c-bridge/build.rs
+++ b/crates/sdk-core-c-bridge/build.rs
@@ -8,6 +8,15 @@ fn main() {
     // Prefix every enum's variants with the enum's type name to avoid collisions.
     let mut config = cbindgen::Config::default();
     config.enumeration.prefix_with_name = true;
+    config.after_includes = Some(
+        concat!(
+            "\n",
+            "/* Forward declarations for structs referenced in callback typedefs */\n",
+            "struct TemporalCoreCustomMetricMeter;\n",
+            "struct TemporalCoreCustomSlotSupplierCallbacks;\n",
+        )
+        .to_string(),
+    );
 
     let changed = cbindgen::Builder::new()
         .with_config(config)

--- a/crates/sdk-core-c-bridge/include/temporal-sdk-core-c-bridge.h
+++ b/crates/sdk-core-c-bridge/include/temporal-sdk-core-c-bridge.h
@@ -5,6 +5,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+/* Forward declarations for structs referenced in callback typedefs */
+struct TemporalCoreCustomMetricMeter;
+struct TemporalCoreCustomSlotSupplierCallbacks;
+
+
 typedef enum TemporalCoreClientGrpcCompression {
   TemporalCoreClientGrpcCompression_Gzip = 0,
   TemporalCoreClientGrpcCompression_None = 1,


### PR DESCRIPTION
## Summary

- Add explicit forward declarations for `TemporalCoreCustomMetricMeter` and `TemporalCoreCustomSlotSupplierCallbacks` at file scope in the generated C bridge header
- Uses cbindgen's `after_includes` config to inject the declarations before any typedef references them
- Fixes Clang `-Wvisibility` warnings that occur because callback typedefs reference these structs before they are defined

## Root cause

The callback typedefs `TemporalCoreCustomMetricMeterMeterFreeCallback` and `TemporalCoreCustomSlotSupplierFreeCallback` use `struct TemporalCoreCustomMetricMeter *` and `struct TemporalCoreCustomSlotSupplierCallbacks *` in their parameter lists before the structs are defined. In C, this creates an implicit declaration scoped to the function prototype (not file scope), triggering:

```
temporal-sdk-core-c-bridge.h:428:77: warning: declaration of 'struct TemporalCoreCustomMetricMeter' will not be visible outside of this function [-Wvisibility]
temporal-sdk-core-c-bridge.h:741:73: warning: declaration of 'struct TemporalCoreCustomSlotSupplierCallbacks' will not be visible outside of this function [-Wvisibility]
```

## Verification

```bash
# Before: 2 warnings
clang -fsyntax-only -Wvisibility temporal-sdk-core-c-bridge.h

# After: clean
clang -fsyntax-only -Werror -Wvisibility temporal-sdk-core-c-bridge.h
```

## Context

This unblocks [apple/swift-temporal-sdk#167](https://github.com/apple/swift-temporal-sdk/pull/167), which enables `-warnings-as-errors` in CI. The Swift compiler's Clang importer propagates these C warnings, causing build failures when warnings are promoted to errors.

## Test plan

- [x] `clang -fsyntax-only -Werror -Wvisibility` passes on the generated header
- [x] `cargo build -p temporalio-sdk-core-c-bridge` succeeds and regenerates the header correctly