### PR TITLE
feat(sdk): add worker lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ relevant information.
   instead of failed.
 * `WorkflowReplayer` for workflow history replay, including JSON history helpers
   and worker-plugin configuration.
+* Experimental worker lifecycle interception through `WorkerInterceptor::run_worker` and
+  `WorkerInterceptor::with_workflow_replay_worker`.
 
 ### Breaking Changes :boom:
 * `CancellableFuture` and `CancellableFutureWithReason` now use the inherited `Future::Output`

--- a/crates/sdk-core/tests/integ_tests/workflow_replayer_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_replayer_tests.rs
@@ -1,4 +1,5 @@
 use crate::common::{CoreWfStarter, TestWorker, eventually};
+use futures_util::future::LocalBoxFuture;
 use std::{
     sync::{
         Arc,
@@ -13,9 +14,10 @@ use temporalio_client::{
 use temporalio_common::protos::temporal::api::enums::v1::EventType;
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityOptions, SimplePlugin, WorkerPlugin, WorkflowContext, WorkflowContextView,
-    WorkflowDefinitions, WorkflowResult,
+    ActivityOptions, SimplePlugin, WorkerPlugin, WorkerRunError, WorkflowContext,
+    WorkflowContextView, WorkflowDefinitions, WorkflowResult,
     activities::{ActivityContext, ActivityError},
+    interceptors::{Next, RunWorkerInput, WithWorkflowReplayWorkerInput, WorkerInterceptor},
     workflow_replayer::{
         WorkflowReplayError, WorkflowReplayFailure, WorkflowReplayer, WorkflowReplayerOptions,
     },
@@ -373,6 +375,36 @@ struct ReplayConfigPlugin {
     configure_calls: Arc<AtomicUsize>,
 }
 
+struct ReplayLifecycleInterceptor {
+    run_calls: Arc<AtomicUsize>,
+    replay_calls: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait(?Send)]
+impl WorkerInterceptor for ReplayLifecycleInterceptor {
+    fn run_worker<'a>(
+        &'a self,
+        input: RunWorkerInput<'a>,
+        next: Next<'a, RunWorkerInput<'a>, LocalBoxFuture<'a, Result<(), WorkerRunError>>>,
+    ) -> LocalBoxFuture<'a, Result<(), WorkerRunError>> {
+        self.run_calls.fetch_add(1, Ordering::Relaxed);
+        next.run(input)
+    }
+
+    fn with_workflow_replay_worker<'a>(
+        &'a self,
+        input: WithWorkflowReplayWorkerInput<'a>,
+        next: Next<
+            'a,
+            WithWorkflowReplayWorkerInput<'a>,
+            LocalBoxFuture<'a, Result<(), WorkerRunError>>,
+        >,
+    ) -> LocalBoxFuture<'a, Result<(), WorkerRunError>> {
+        self.replay_calls.fetch_add(1, Ordering::Relaxed);
+        next.run(input)
+    }
+}
+
 impl WorkerPlugin for ReplayConfigPlugin {
     fn name(&self) -> &str {
         "replay-config"
@@ -427,6 +459,26 @@ async fn workflow_replayer_applies_plugins() {
     );
     replayer.replay_workflow(history.clone()).await.unwrap();
     assert_eq!(configure_calls.load(Ordering::Relaxed), 1);
+
+    let run_calls = Arc::new(AtomicUsize::new(0));
+    let replay_calls = Arc::new(AtomicUsize::new(0));
+    let replayer = WorkflowReplayer::new(
+        WorkflowReplayerOptions::new()
+            .register_workflow::<SayHelloWorkflow>()
+            .unwrap()
+            .worker_interceptor(ReplayLifecycleInterceptor {
+                run_calls: run_calls.clone(),
+                replay_calls: replay_calls.clone(),
+            })
+            .build(),
+    )
+    .unwrap();
+    replayer
+        .replay_workflows([history.clone(), history.clone()])
+        .await
+        .unwrap();
+    assert_eq!(run_calls.load(Ordering::Relaxed), 0);
+    assert_eq!(replay_calls.load(Ordering::Relaxed), 1);
 
     let mut workflows = WorkflowDefinitions::new();
     workflows.register_workflow::<SayHelloWorkflow>().unwrap();

--- a/crates/sdk/src/interceptors.rs
+++ b/crates/sdk/src/interceptors.rs
@@ -1,11 +1,11 @@
 //! User-definable interceptors are defined in this module
 
 use crate::{
-    Worker,
+    Worker, WorkerRunError,
     activities::{ActivityContext, ActivityError, ActivityInfo},
 };
 use anyhow::bail;
-use futures_util::future::BoxFuture;
+use futures_util::future::{BoxFuture, LocalBoxFuture};
 use std::{
     any::Any,
     collections::HashMap,
@@ -53,6 +53,28 @@ mod activity_execution_value {
 /// **Experimental:** This API may change or be removed.
 #[async_trait::async_trait(?Send)]
 pub trait WorkerInterceptor: Send + Sync {
+    /// Intercept the running of a worker.
+    fn run_worker<'a>(
+        &'a self,
+        input: RunWorkerInput<'a>,
+        next: Next<'a, RunWorkerInput<'a>, LocalBoxFuture<'a, Result<(), WorkerRunError>>>,
+    ) -> LocalBoxFuture<'a, Result<(), WorkerRunError>> {
+        next.run(input)
+    }
+
+    /// Intercept the running of a worker created for workflow replay.
+    fn with_workflow_replay_worker<'a>(
+        &'a self,
+        input: WithWorkflowReplayWorkerInput<'a>,
+        next: Next<
+            'a,
+            WithWorkflowReplayWorkerInput<'a>,
+            LocalBoxFuture<'a, Result<(), WorkerRunError>>,
+        >,
+    ) -> LocalBoxFuture<'a, Result<(), WorkerRunError>> {
+        next.run(input)
+    }
+
     /// Called every time a workflow activation completes (just before sending the completion to
     /// core).
     async fn on_workflow_activation_completion(&self, _completion: &WorkflowActivationCompletion) {}
@@ -73,6 +95,65 @@ pub trait WorkerInterceptor: Send + Sync {
 /// Interceptor implementations call [`Next::run`] to invoke the next step of the chain.
 pub struct Next<'a, I, O> {
     inner: Box<dyn FnOnce(I) -> O + Send + 'a>,
+}
+
+/// Input to [`WorkerInterceptor::run_worker`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct RunWorkerInput<'a> {
+    /// The worker being run.
+    pub worker: &'a mut Worker,
+}
+
+impl<'a> RunWorkerInput<'a> {
+    pub(crate) fn new(worker: &'a mut Worker) -> Self {
+        Self { worker }
+    }
+}
+
+/// Input to [`WorkerInterceptor::with_workflow_replay_worker`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct WithWorkflowReplayWorkerInput<'a> {
+    /// The worker created for this replay operation.
+    pub worker: &'a mut Worker,
+}
+
+impl<'a> WithWorkflowReplayWorkerInput<'a> {
+    pub(crate) fn new(worker: &'a mut Worker) -> Self {
+        Self { worker }
+    }
+}
+
+pub(crate) fn call_run_worker<'a>(
+    interceptors: &'a [Arc<dyn WorkerInterceptor>],
+    input: RunWorkerInput<'a>,
+    terminal: Next<'a, RunWorkerInput<'a>, LocalBoxFuture<'a, Result<(), WorkerRunError>>>,
+) -> LocalBoxFuture<'a, Result<(), WorkerRunError>> {
+    if let Some((interceptor, remaining)) = interceptors.split_first() {
+        let next = Next::new(move |input| call_run_worker(remaining, input, terminal));
+        interceptor.run_worker(input, next)
+    } else {
+        terminal.run(input)
+    }
+}
+
+pub(crate) fn call_with_workflow_replay_worker<'a>(
+    interceptors: &'a [Arc<dyn WorkerInterceptor>],
+    input: WithWorkflowReplayWorkerInput<'a>,
+    terminal: Next<
+        'a,
+        WithWorkflowReplayWorkerInput<'a>,
+        LocalBoxFuture<'a, Result<(), WorkerRunError>>,
+    >,
+) -> LocalBoxFuture<'a, Result<(), WorkerRunError>> {
+    if let Some((interceptor, remaining)) = interceptors.split_first() {
+        let next =
+            Next::new(move |input| call_with_workflow_replay_worker(remaining, input, terminal));
+        interceptor.with_workflow_replay_worker(input, next)
+    } else {
+        terminal.run(input)
+    }
 }
 
 impl<'a, I, O> Next<'a, I, O> {
@@ -180,6 +261,7 @@ pub trait ActivityInboundInterceptor: Send + Sync + 'static {
 }
 
 /// Supports the composition of interceptors
+// TODO: remove this, we already support vec based registration on the worker directly
 pub struct InterceptorWithNext {
     inner: Box<dyn WorkerInterceptor>,
     next: Option<Box<InterceptorWithNext>>,
@@ -200,6 +282,44 @@ impl InterceptorWithNext {
 
 #[async_trait::async_trait(?Send)]
 impl WorkerInterceptor for InterceptorWithNext {
+    fn run_worker<'a>(
+        &'a self,
+        input: RunWorkerInput<'a>,
+        next: Next<'a, RunWorkerInput<'a>, LocalBoxFuture<'a, Result<(), WorkerRunError>>>,
+    ) -> LocalBoxFuture<'a, Result<(), WorkerRunError>> {
+        self.inner.run_worker(
+            input,
+            Next::new(move |input| {
+                if let Some(interceptor) = &self.next {
+                    interceptor.run_worker(input, next)
+                } else {
+                    next.run(input)
+                }
+            }),
+        )
+    }
+
+    fn with_workflow_replay_worker<'a>(
+        &'a self,
+        input: WithWorkflowReplayWorkerInput<'a>,
+        next: Next<
+            'a,
+            WithWorkflowReplayWorkerInput<'a>,
+            LocalBoxFuture<'a, Result<(), WorkerRunError>>,
+        >,
+    ) -> LocalBoxFuture<'a, Result<(), WorkerRunError>> {
+        self.inner.with_workflow_replay_worker(
+            input,
+            Next::new(move |input| {
+                if let Some(interceptor) = &self.next {
+                    interceptor.with_workflow_replay_worker(input, next)
+                } else {
+                    next.run(input)
+                }
+            }),
+        )
+    }
+
     async fn on_workflow_activation_completion(&self, c: &WorkflowActivationCompletion) {
         self.inner.on_workflow_activation_completion(c).await;
         if let Some(next) = &self.next {

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -114,13 +114,13 @@ use crate::{
         ActivityContext, ActivityDefinitions, ActivityImplementer, ExecutableActivity,
         activity_error_to_core_result,
     },
-    interceptors::{ActivityInboundInterceptor, WorkerInterceptor},
+    interceptors::{ActivityInboundInterceptor, Next, RunWorkerInput, WorkerInterceptor},
     workflow_executor::{TaskHandle, WorkflowExecutor},
     workflow_future::start_workflow,
     workflow_interceptors::WorkflowInterceptorConstructor,
 };
 use anyhow::{anyhow, bail};
-use futures_util::{FutureExt, StreamExt, TryStreamExt};
+use futures_util::{FutureExt, StreamExt, TryStreamExt, future::LocalBoxFuture};
 use std::{
     any::{Any, TypeId},
     cell::RefCell,
@@ -950,6 +950,20 @@ impl Worker {
     /// Runs the worker. Eventually resolves after the worker has been explicitly shut down,
     /// or may return early with an error in the event of some unresolvable problem.
     pub async fn run(&mut self) -> Result<(), WorkerRunError> {
+        let interceptors = self.common.worker_interceptors.clone();
+        interceptors::call_run_worker(
+            &interceptors,
+            RunWorkerInput::new(self),
+            Next::new(
+                |input: RunWorkerInput<'_>| -> LocalBoxFuture<'_, Result<(), _>> {
+                    Box::pin(async move { input.worker.run_inner().await })
+                },
+            ),
+        )
+        .await
+    }
+
+    pub(crate) async fn run_inner(&mut self) -> Result<(), WorkerRunError> {
         // Perform the namespace check-in so poller behavior (e.g. autoscaling auto-enroll) is
         // resolved before any polling begins.
         self.common
@@ -1209,6 +1223,10 @@ impl Worker {
         }
         self.common.worker.shutdown().await;
         Ok(())
+    }
+
+    pub(crate) fn worker_interceptors(&self) -> Vec<Arc<dyn WorkerInterceptor>> {
+        self.common.worker_interceptors.clone()
     }
 
     /// Turns this rust worker into a new worker with all the same workflows and activities

--- a/crates/sdk/src/workflow_replayer.rs
+++ b/crates/sdk/src/workflow_replayer.rs
@@ -1,12 +1,12 @@
 use crate::{
     Worker, WorkerOptions, WorkerRunError,
-    interceptors::WorkerInterceptor,
+    interceptors::{self, Next, WithWorkflowReplayWorkerInput, WorkerInterceptor},
     plugins::WorkerPlugin,
     runtime::WorkflowErrorType,
     workflow_interceptors::WorkflowInterceptorConstructor,
     workflow_registry::{WorkflowDefinitions, WorkflowRegistrationError},
 };
-use futures_util::stream;
+use futures_util::{future::LocalBoxFuture, stream};
 use parking_lot::Mutex;
 use std::{
     collections::{HashMap, HashSet},
@@ -412,7 +412,18 @@ impl WorkflowReplayer {
             message: error.to_string(),
         })?;
 
-        if let Err(source) = worker.run().await {
+        let worker_interceptors = worker.worker_interceptors();
+        if let Err(source) = interceptors::call_with_workflow_replay_worker(
+            &worker_interceptors,
+            WithWorkflowReplayWorkerInput::new(&mut worker),
+            Next::new(
+                |input: WithWorkflowReplayWorkerInput<'_>| -> LocalBoxFuture<'_, Result<(), _>> {
+                    Box::pin(async move { input.worker.run_inner().await })
+                },
+            ),
+        )
+        .await
+        {
             let core_worker = worker.core_worker();
             core_worker.initiate_shutdown();
             core_worker.shutdown().await;


### PR DESCRIPTION
## What

Add methods for intercepting `Worker#run` and workflow replayer's run on `WorkerInterceptor` trait.

## Why

These methods bring parity to the Rust SDKs Plugins via `WorkerInterceptor`. Having these method live there instead of on `WorkerPlugin` as other SDKs do, feels more sensible.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>