### PR TITLE
feat(sdk): infer worker task types from registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ to docs, or any other relevant information.
   `NexusOperationOptions::builder()` to construct Nexus operation options.
 * `WorkflowContext::wait_condition` now returns `Result<(), WorkflowCancellationError>` instead of
   `()` so that workflow cancellation can be propagated to the caller.
+* Workflow and activity implementations must now be registered through `WorkerOptions` before
+  constructing a `Worker`; the corresponding registration methods on `Worker` have been removed.
 
 ### Added
 * `WorkflowCancellationToken` for deterministic cancellation of workflow operations.
@@ -86,6 +88,9 @@ to docs, or any other relevant information.
 ### Fixed
 * Panics from update validators now reject the update instead of repeatedly failing workflow
   tasks.
+* Rust SDK workers now derive enabled task types from registered workflows and activities. The
+  task types can no longer be configured separately, preventing mismatched poll loops from hanging
+  worker shutdown.
 
 ## [0.6.0] - 2026-08-04
 ## [0.5.0]

--- a/crates/sdk-core/src/worker/workflow/managed_run.rs
+++ b/crates/sdk-core/src/worker/workflow/managed_run.rs
@@ -1664,7 +1664,11 @@ mod tests {
         time::Duration,
     };
     use temporalio_common::protos::coresdk::common::ExternalStorageMetrics;
-    use tracing::{Event, Level, Metadata, Subscriber, field::Field, field::Visit, span};
+    use tracing::{
+        Event, Level, Metadata, Subscriber,
+        field::{Field, Visit},
+        span,
+    };
 
     use command_utils::*;
 

--- a/crates/sdk-core/tests/common/mod.rs
+++ b/crates/sdk-core/tests/common/mod.rs
@@ -36,7 +36,7 @@ use temporalio_client::{
     grpc::WorkflowService,
 };
 use temporalio_common::{
-    HasWorkflowDefinition, WorkflowDefinition,
+    HasWorkflowDefinition,
     data_converters::{DataConverter, RawValue},
     protos::{
         coresdk::{
@@ -54,13 +54,11 @@ use temporalio_common::{
     worker::{WorkerDeploymentOptions, WorkerDeploymentVersion, WorkerTaskTypes},
 };
 use temporalio_sdk::{
-    Worker, WorkerOptions, WorkflowRegistrationError,
-    activities::ActivityImplementer,
+    Worker, WorkerOptions,
     interceptors::{
         FailOnNondeterminismInterceptor, InterceptorWithNext, ReturnWorkflowExitValueInterceptor,
         WorkerInterceptor,
     },
-    workflows::WorkflowImplementation,
 };
 #[cfg(any(feature = "test-utilities", test))]
 pub(crate) use temporalio_sdk_core::test_help::NAMESPACE;
@@ -152,16 +150,20 @@ where
     init_replay_worker(ReplayWorkerInput::new(worker_cfg, histories))
         .expect("Replay worker must init properly")
 }
-pub(crate) fn replay_sdk_worker<I>(histories: I) -> Worker
+pub(crate) fn replay_sdk_worker_with_options<I>(
+    histories: I,
+    options_mutator: impl FnOnce(&mut WorkerOptions),
+) -> Worker
 where
     I: IntoIterator<Item = HistoryForReplay> + 'static,
     <I as IntoIterator>::IntoIter: Send,
 {
-    replay_sdk_worker_stream(stream::iter(histories))
+    replay_sdk_worker_stream_with_options(stream::iter(histories), options_mutator)
 }
-pub(crate) fn replay_sdk_worker_intercepted<I>(
+pub(crate) fn replay_sdk_worker_intercepted_with_options<I>(
     histories: I,
     interceptor: impl WorkerInterceptor + 'static,
+    options_mutator: impl FnOnce(&mut WorkerOptions),
 ) -> Worker
 where
     I: IntoIterator<Item = HistoryForReplay> + 'static,
@@ -171,30 +173,17 @@ where
     let client_options = ClientOptions::new(core.get_config().namespace.clone())
         .data_converter(DataConverter::default())
         .build();
-    let worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
+    let mut worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
         .worker_interceptor(interceptor)
         .build();
+    options_mutator(&mut worker_options);
     Worker::new_from_core_options(Arc::new(core), client_options, worker_options)
         .expect("replay worker options are valid")
 }
 
-pub(crate) fn replay_sdk_worker_stream<I>(histories: I) -> Worker
-where
-    I: Stream<Item = HistoryForReplay> + Send + 'static,
-{
-    let core = init_core_replay_stream("replay_worker_test", histories);
-    let client_options = ClientOptions::new(core.get_config().namespace.clone())
-        .data_converter(DataConverter::default())
-        .build();
-    let worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
-        .worker_interceptor(FailOnNondeterminismInterceptor {})
-        .build();
-    Worker::new_from_core_options(Arc::new(core), client_options, worker_options)
-        .expect("replay worker options are valid")
-}
-pub(crate) fn replay_sdk_worker_stream_intercepted<I>(
+pub(crate) fn replay_sdk_worker_stream_with_options<I>(
     histories: I,
-    interceptor: impl WorkerInterceptor + 'static,
+    options_mutator: impl FnOnce(&mut WorkerOptions),
 ) -> Worker
 where
     I: Stream<Item = HistoryForReplay> + Send + 'static,
@@ -203,9 +192,29 @@ where
     let client_options = ClientOptions::new(core.get_config().namespace.clone())
         .data_converter(DataConverter::default())
         .build();
-    let worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
+    let mut worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
+        .worker_interceptor(FailOnNondeterminismInterceptor {})
+        .build();
+    options_mutator(&mut worker_options);
+    Worker::new_from_core_options(Arc::new(core), client_options, worker_options)
+        .expect("replay worker options are valid")
+}
+pub(crate) fn replay_sdk_worker_stream_intercepted_with_options<I>(
+    histories: I,
+    interceptor: impl WorkerInterceptor + 'static,
+    options_mutator: impl FnOnce(&mut WorkerOptions),
+) -> Worker
+where
+    I: Stream<Item = HistoryForReplay> + Send + 'static,
+{
+    let core = init_core_replay_stream("replay_worker_test", histories);
+    let client_options = ClientOptions::new(core.get_config().namespace.clone())
+        .data_converter(DataConverter::default())
+        .build();
+    let mut worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
         .worker_interceptor(interceptor)
         .build();
+    options_mutator(&mut worker_options);
     Worker::new_from_core_options(Arc::new(core), client_options, worker_options)
         .expect("replay worker options are valid")
 }
@@ -311,6 +320,7 @@ pub(crate) struct CoreWfStarter {
     /// Run when initializing, allows for altering the config used to init the core worker
     #[allow(clippy::type_complexity)] // It's not tho
     core_config_mutator: Option<Arc<dyn Fn(&mut WorkerConfig)>>,
+    core_task_types: Option<WorkerTaskTypes>,
 }
 struct InitializedWorker {
     worker: Arc<CoreWorker>,
@@ -429,6 +439,7 @@ impl CoreWfStarter {
             client_override,
             min_local_server_version: None,
             core_config_mutator: None,
+            core_task_types: None,
         }
     }
 
@@ -444,6 +455,7 @@ impl CoreWfStarter {
             min_local_server_version: self.min_local_server_version.clone(),
             initted_worker: Default::default(),
             core_config_mutator: self.core_config_mutator.clone(),
+            core_task_types: self.core_task_types,
         }
     }
 
@@ -467,6 +479,10 @@ impl CoreWfStarter {
 
     pub(crate) fn set_core_cfg_mutator(&mut self, mutator: impl Fn(&mut WorkerConfig) + 'static) {
         self.core_config_mutator = Some(Arc::new(mutator))
+    }
+
+    pub(crate) fn set_core_task_types(&mut self, task_types: WorkerTaskTypes) {
+        self.core_task_types = Some(task_types);
     }
 
     pub(crate) async fn shutdown(&mut self) {
@@ -587,10 +603,25 @@ impl CoreWfStarter {
                     let client = Client::new(connection.clone(), client_opts).unwrap();
                     (connection, client)
                 };
-                let mut core_config = self
-                    .sdk_config
+                let mut sdk_config = self.sdk_config.clone();
+                let has_registrations =
+                    !sdk_config.workflows().is_empty() || !sdk_config.activities().is_empty();
+                if !has_registrations {
+                    // Core-only tests need a worker without language definitions, but converting
+                    // WorkerOptions rejects that public API configuration. The placeholder exists
+                    // only in this conversion clone and is never visible to an SDK worker.
+                    sdk_config
+                        .register_workflow::<workflows::LaProblemWorkflow>()
+                        .expect("placeholder workflow registers");
+                }
+                let mut core_config = sdk_config
                     .to_core_options(client.namespace(), client.identity())
                     .expect("sdk config converts to core config");
+                if let Some(task_types) = self.core_task_types {
+                    core_config.task_types = task_types;
+                } else if !has_registrations {
+                    core_config.task_types = WorkerTaskTypes::all();
+                }
                 if let Some(ref ccm) = self.core_config_mutator {
                     ccm(&mut core_config);
                 }
@@ -650,37 +681,6 @@ impl TestWorker {
 
     pub(crate) fn worker_instance_key(&self) -> Uuid {
         self.inner.worker_instance_key()
-    }
-
-    pub(crate) fn register_activities<AI: ActivityImplementer>(
-        &mut self,
-        instance: AI,
-    ) -> &mut Self {
-        self.inner.register_activities::<AI>(instance);
-        self
-    }
-
-    #[allow(unused)]
-    pub(crate) fn register_workflow<W>(&mut self) -> Result<&mut Self, WorkflowRegistrationError>
-    where
-        W: WorkflowImplementation,
-        <W::Run as WorkflowDefinition>::Input: Send,
-    {
-        self.inner.register_workflow::<W>()?;
-        Ok(self)
-    }
-
-    pub(crate) fn register_workflow_with_factory<W, F>(
-        &mut self,
-        factory: F,
-    ) -> Result<&mut Self, WorkflowRegistrationError>
-    where
-        W: WorkflowImplementation,
-        <W::Run as WorkflowDefinition>::Input: Send,
-        F: Fn() -> W + Send + Sync + 'static,
-    {
-        self.inner.register_workflow_with_factory::<W, F>(factory)?;
-        Ok(self)
     }
 
     /// Create a handle that can be used to submit workflows. Useful when workflows need to be
@@ -1093,26 +1093,9 @@ where
     }
 }
 
-pub(crate) fn build_fake_sdk(mock_cfg: MockPollCfg) -> temporalio_sdk::Worker {
-    let mut mock = build_mock_pollers(mock_cfg);
-    mock.worker_cfg(|c| {
-        c.max_cached_workflows = 1;
-        c.ignore_evicts_on_shutdown = false;
-    });
-    let core = mock_worker(mock);
-    let client_options = ClientOptions::new(core.get_config().namespace.clone())
-        .data_converter(DataConverter::default())
-        .build();
-    let worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
-        .worker_interceptor(FailOnNondeterminismInterceptor {})
-        .build();
-    Worker::new_from_core_options(Arc::new(core), client_options, worker_options)
-        .expect("mock worker options are valid")
-}
-
-pub(crate) fn build_fake_sdk_intercepted(
+pub(crate) fn build_fake_sdk_with_options(
     mock_cfg: MockPollCfg,
-    interceptor: impl WorkerInterceptor + 'static,
+    options_mutator: impl FnOnce(&mut WorkerOptions),
 ) -> temporalio_sdk::Worker {
     let mut mock = build_mock_pollers(mock_cfg);
     mock.worker_cfg(|c| {
@@ -1123,20 +1106,40 @@ pub(crate) fn build_fake_sdk_intercepted(
     let client_options = ClientOptions::new(core.get_config().namespace.clone())
         .data_converter(DataConverter::default())
         .build();
-    let worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
-        .worker_interceptor(interceptor)
+    let mut worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
+        .worker_interceptor(FailOnNondeterminismInterceptor {})
         .build();
+    options_mutator(&mut worker_options);
     Worker::new_from_core_options(Arc::new(core), client_options, worker_options)
         .expect("mock worker options are valid")
 }
 
-pub(crate) fn mock_sdk(poll_cfg: MockPollCfg) -> TestWorker {
-    mock_sdk_cfg(poll_cfg, |_| {})
+pub(crate) fn build_fake_sdk_intercepted_with_options(
+    mock_cfg: MockPollCfg,
+    interceptor: impl WorkerInterceptor + 'static,
+    options_mutator: impl FnOnce(&mut WorkerOptions),
+) -> temporalio_sdk::Worker {
+    let mut mock = build_mock_pollers(mock_cfg);
+    mock.worker_cfg(|c| {
+        c.max_cached_workflows = 1;
+        c.ignore_evicts_on_shutdown = false;
+    });
+    let core = mock_worker(mock);
+    let client_options = ClientOptions::new(core.get_config().namespace.clone())
+        .data_converter(DataConverter::default())
+        .build();
+    let mut worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
+        .worker_interceptor(interceptor)
+        .build();
+    options_mutator(&mut worker_options);
+    Worker::new_from_core_options(Arc::new(core), client_options, worker_options)
+        .expect("mock worker options are valid")
 }
 
-pub(crate) fn mock_sdk_cfg(
+pub(crate) fn mock_sdk_cfg_with_options(
     mut poll_cfg: MockPollCfg,
     mutator: impl FnOnce(&mut WorkerConfig),
+    options_mutator: impl FnOnce(&mut WorkerOptions),
 ) -> TestWorker {
     poll_cfg.using_rust_sdk = true;
     let mut mock = build_mock_pollers(poll_cfg);
@@ -1146,9 +1149,10 @@ pub(crate) fn mock_sdk_cfg(
     let client_options = ClientOptions::new(core.get_config().namespace.clone())
         .data_converter(DataConverter::default())
         .build();
-    let worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
+    let mut worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
         .worker_interceptor(interceptor_router.clone())
         .build();
+    options_mutator(&mut worker_options);
     let sdk = Worker::new_from_core_options(Arc::new(core), client_options, worker_options)
         .expect("mock worker options are valid");
     TestWorker::new_with_interceptor_router(sdk, interceptor_router)

--- a/crates/sdk-core/tests/common/mod.rs
+++ b/crates/sdk-core/tests/common/mod.rs
@@ -96,7 +96,7 @@ pub(crate) const INTEG_CLIENT_VERSION: &str = "0.1.0";
 /// upon. Returns the instance.
 pub(crate) async fn init_core_and_create_wf(test_name: &str) -> CoreWfStarter {
     let mut starter = CoreWfStarter::new(test_name);
-    let _ = starter.get_worker().await;
+    let _ = starter.get_core_worker().await;
     starter.start_wf().await;
     starter
 }
@@ -327,6 +327,12 @@ struct InitializedWorker {
     client: Client,
 }
 
+#[derive(Clone, Copy)]
+enum WorkerInitializationMode {
+    Sdk,
+    CoreOnly,
+}
+
 #[derive(Clone, Default)]
 struct TestWorkerInterceptorRouter {
     interceptor: Arc<RwLock<Option<Arc<dyn WorkerInterceptor>>>>,
@@ -396,7 +402,7 @@ impl CoreWfStarter {
 
         if check_mlsv && !version_req.is_empty() {
             let clustinfo = s
-                .get_client()
+                .get_core_client()
                 .await
                 .get_cluster_info(GetClusterInfoRequest::default().into_request())
                 .await;
@@ -460,12 +466,13 @@ impl CoreWfStarter {
     }
 
     pub(crate) async fn worker(&mut self) -> TestWorker {
-        let worker = self.get_worker().await;
+        let initialized = self.get_or_init(WorkerInitializationMode::Sdk).await;
+        let worker = initialized.worker.clone();
         worker
             .validate()
             .await
             .expect("Worker validation should succeed");
-        let client = self.get_client().await;
+        let client = initialized.client.clone();
         let interceptor_router = TestWorkerInterceptorRouter::default();
         let mut sdk_config = self.sdk_config.clone();
         sdk_config.worker_interceptor(interceptor_router.clone());
@@ -486,15 +493,27 @@ impl CoreWfStarter {
     }
 
     pub(crate) async fn shutdown(&mut self) {
-        self.get_worker().await.shutdown().await;
+        self.get_or_init(WorkerInitializationMode::Sdk)
+            .await
+            .worker
+            .shutdown()
+            .await;
     }
 
-    pub(crate) async fn get_worker(&mut self) -> Arc<CoreWorker> {
-        self.get_or_init().await.worker.clone()
+    /// Returns a Core worker for tests that drive Core directly rather than through the SDK.
+    pub(crate) async fn get_core_worker(&mut self) -> Arc<CoreWorker> {
+        self.get_or_init(WorkerInitializationMode::CoreOnly)
+            .await
+            .worker
+            .clone()
     }
 
-    pub(crate) async fn get_client(&mut self) -> Client {
-        self.get_or_init().await.client.clone()
+    /// Returns the client associated with a Core worker used directly by a test.
+    pub(crate) async fn get_core_client(&mut self) -> Client {
+        self.get_or_init(WorkerInitializationMode::CoreOnly)
+            .await
+            .client
+            .clone()
     }
 
     /// Start the workflow defined by the builder and return run id
@@ -523,7 +542,7 @@ impl CoreWfStarter {
     pub(crate) async fn start_wf_with_id(&self, workflow_id: String) -> String {
         let iw = self.initted_worker.get().expect(
             "Worker must be initted before starting a workflow.\
-                             Tests must call `get_worker` first.",
+                             Tests must initialize a worker first.",
         );
         let mut options = self.workflow_options.clone();
         options.workflow_id = workflow_id;
@@ -581,7 +600,7 @@ impl CoreWfStarter {
             .await
     }
 
-    async fn get_or_init(&mut self) -> &InitializedWorker {
+    async fn get_or_init(&mut self, mode: WorkerInitializationMode) -> &InitializedWorker {
         self.initted_worker
             .get_or_init(|| async {
                 let rt = if let Some(ref rto) = self.runtime_override {
@@ -604,12 +623,9 @@ impl CoreWfStarter {
                     (connection, client)
                 };
                 let mut sdk_config = self.sdk_config.clone();
-                let has_registrations =
-                    !sdk_config.workflows().is_empty() || !sdk_config.activities().is_empty();
-                if !has_registrations {
-                    // Core-only tests need a worker without language definitions, but converting
-                    // WorkerOptions rejects that public API configuration. The placeholder exists
-                    // only in this conversion clone and is never visible to an SDK worker.
+                if matches!(mode, WorkerInitializationMode::CoreOnly) {
+                    // Core tests intentionally have no SDK definitions, but SDK conversion needs
+                    // one.
                     sdk_config
                         .register_workflow::<workflows::LaProblemWorkflow>()
                         .expect("placeholder workflow registers");
@@ -619,7 +635,7 @@ impl CoreWfStarter {
                     .expect("sdk config converts to core config");
                 if let Some(task_types) = self.core_task_types {
                     core_config.task_types = task_types;
-                } else if !has_registrations {
+                } else if matches!(mode, WorkerInitializationMode::CoreOnly) {
                     core_config.task_types = WorkerTaskTypes::all();
                 }
                 if let Some(ref ccm) = self.core_config_mutator {

--- a/crates/sdk-core/tests/global_metric_tests.rs
+++ b/crates/sdk-core/tests/global_metric_tests.rs
@@ -78,7 +78,7 @@ async fn otel_errors_logged_as_errors() {
 
     let rt = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
     let mut starter = CoreWfStarter::new_with_runtime("otel_errors_logged_as_errors", rt);
-    let _worker = starter.get_worker().await;
+    let _worker = starter.get_core_worker().await;
 
     tracing::debug!("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ should be in global log");
 

--- a/crates/sdk-core/tests/heavy_tests.rs
+++ b/crates/sdk-core/tests/heavy_tests.rs
@@ -316,7 +316,7 @@ async fn evict_while_la_running_no_interference() {
     let task_queue = starter.get_task_queue().to_owned();
     let mut worker = starter.worker().await;
 
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let subfs = FuturesUnordered::new();
     for i in 1..100 {
         let wf_id = format!("{wf_name}-{i}");
@@ -396,7 +396,7 @@ async fn can_paginate_long_history() {
         .await
         .unwrap();
     let run_id = handle.run_id().unwrap().to_owned();
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     tokio::spawn(async move {
         let handle = WorkflowExecutionInfo {
             namespace: client.namespace(),
@@ -484,7 +484,7 @@ async fn poller_autoscaling_basic_loadtest() {
         .unwrap();
     let mut worker = starter.worker().await;
     let shutdown_handle = worker.inner_mut().shutdown_handle();
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let mut workflow_handles = vec![];

--- a/crates/sdk-core/tests/heavy_tests.rs
+++ b/crates/sdk-core/tests/heavy_tests.rs
@@ -31,12 +31,9 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 
-use temporalio_common::{
-    protos::{
-        coresdk::workflow_commands::ActivityCancellationType,
-        temporal::api::enums::v1::WorkflowIdReusePolicy,
-    },
-    worker::WorkerTaskTypes,
+use temporalio_common::protos::{
+    coresdk::workflow_commands::ActivityCancellationType,
+    temporal::api::enums::v1::WorkflowIdReusePolicy,
 };
 use temporalio_sdk::{
     ActivityCloseTimeouts, ActivityOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
@@ -87,11 +84,14 @@ async fn activity_load() {
     starter.sdk_config.tuner =
         Arc::new(TunerHolder::fixed_size(CONCURRENCY, CONCURRENCY, 100, 100));
     starter.sdk_config.register_activities(StdActivities);
+    starter
+        .sdk_config
+        .register_workflow::<ActivityLoadWf>()
+        .unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     let mut worker = starter.worker().await;
 
     let starting = Instant::now();
-    worker.register_workflow::<ActivityLoadWf>().unwrap();
     join_all((0..CONCURRENCY).map(|i| {
         let worker = &worker;
         let wf_id = format!("activity_load_{i}");
@@ -177,11 +177,14 @@ async fn chunky_activities_resource_based() {
     starter.sdk_config.tuner = Arc::new(tuner);
 
     starter.sdk_config.register_activities(ChunkyActivities);
+    starter
+        .sdk_config
+        .register_workflow::<ChunkyActivityWf>()
+        .unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     let mut worker = starter.worker().await;
 
     let starting = Instant::now();
-    worker.register_workflow::<ChunkyActivityWf>().unwrap();
     join_all((0..WORKFLOWS).map(|i| {
         let worker = &worker;
         let wf_id = format!("chunk_activity_{i}");
@@ -251,8 +254,11 @@ async fn workflow_load() {
     starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(5, 100, 100, 100));
     starter.sdk_config.register_activities(StdActivities);
     let task_queue = starter.get_task_queue().to_owned();
+    starter
+        .sdk_config
+        .register_workflow::<WorkflowLoadWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<WorkflowLoadWf>().unwrap();
 
     let mut workflow_handles = vec![];
     for i in 0..num_workflows {
@@ -303,10 +309,12 @@ async fn evict_while_la_running_no_interference() {
     // starter.max_wft(20);
     starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(100, 10, 20, 1));
     starter.sdk_config.register_activities(StdActivities);
+    starter
+        .sdk_config
+        .register_workflow::<LaProblemWorkflow>()
+        .unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     let mut worker = starter.worker().await;
-
-    worker.register_workflow::<LaProblemWorkflow>().unwrap();
 
     let client = starter.get_client().await;
     let subfs = FuturesUnordered::new();
@@ -371,13 +379,13 @@ impl ManyParallelTimersLonghistWf {
 async fn can_paginate_long_history() {
     let wf_name = "can_paginate_long_history";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.sdk_config.max_cached_workflows = 0;
-
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<ManyParallelTimersLonghistWf>()
         .unwrap();
+
+    let mut worker = starter.worker().await;
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
         .submit_workflow(
@@ -470,9 +478,12 @@ async fn poller_autoscaling_basic_loadtest() {
     });
 
     starter.sdk_config.register_activities(JitteryActivities);
+    starter
+        .sdk_config
+        .register_workflow::<PollerLoadWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
     let shutdown_handle = worker.inner_mut().shutdown_handle();
-    worker.register_workflow::<PollerLoadWf>().unwrap();
     let client = starter.get_client().await;
 
     let task_queue = starter.get_task_queue().to_owned();

--- a/crates/sdk-core/tests/heavy_tests/fuzzy_workflow.rs
+++ b/crates/sdk-core/tests/heavy_tests/fuzzy_workflow.rs
@@ -80,9 +80,9 @@ async fn fuzzy_workflow() {
     let mut starter = CoreWfStarter::new("fuzzy_workflow");
     starter.sdk_config.max_cached_workflows = 25;
     starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(25, 25, 100, 100));
+    starter.sdk_config.register_activities(StdActivities);
+    starter.sdk_config.register_workflow::<FuzzyWf>().unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<FuzzyWf>().unwrap();
-    worker.register_activities(StdActivities);
 
     let client = starter.get_client().await;
     let task_queue = starter.get_task_queue().to_owned();

--- a/crates/sdk-core/tests/heavy_tests/fuzzy_workflow.rs
+++ b/crates/sdk-core/tests/heavy_tests/fuzzy_workflow.rs
@@ -84,7 +84,7 @@ async fn fuzzy_workflow() {
     starter.sdk_config.register_workflow::<FuzzyWf>().unwrap();
     let mut worker = starter.worker().await;
 
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let task_queue = starter.get_task_queue().to_owned();
 
     for i in 0..num_workflows {

--- a/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
@@ -92,9 +92,6 @@ async fn async_activity_completions(
         .sdk_config
         .register_activities(AsyncActivities { info_tx });
 
-    let mut worker = starter.worker().await;
-    let client = starter.get_client().await;
-
     #[workflow]
     #[derive(Default)]
     struct AsyncCompletionWorkflow;
@@ -153,9 +150,12 @@ async fn async_activity_completions(
         }
     }
 
-    worker
+    starter
+        .sdk_config
         .register_workflow::<AsyncCompletionWorkflow>()
         .unwrap();
+    let mut worker = starter.worker().await;
+    let client = starter.get_client().await;
 
     let completion_task = tokio::spawn(async move {
         let info = info_rx.recv().await.expect("should receive activity info");

--- a/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/async_activity_client_tests.rs
@@ -155,7 +155,7 @@ async fn async_activity_completions(
         .register_workflow::<AsyncCompletionWorkflow>()
         .unwrap();
     let mut worker = starter.worker().await;
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
 
     let completion_task = tokio::spawn(async move {
         let info = info_rx.recv().await.expect("should receive activity info");

--- a/crates/sdk-core/tests/integ_tests/client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/client_tests.rs
@@ -45,7 +45,7 @@ use tracing::info;
 async fn can_use_retry_client() {
     // Not terribly interesting by itself but can be useful for manually inspecting metrics etc
     let mut core = CoreWfStarter::new("retry_client");
-    let retry_client = core.get_client().await;
+    let retry_client = core.get_core_client().await;
     for _ in 0..10 {
         WorkflowService::list_namespaces(
             &mut retry_client.clone(),

--- a/crates/sdk-core/tests/integ_tests/client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/client_tests.rs
@@ -706,7 +706,7 @@ async fn update_get_result_retries_on_empty_outcome() {
     fs.shutdown().await;
 }
 
-fn make_ok_response<T>(message: T) -> Response<Body>
+pub(super) fn make_ok_response<T>(message: T) -> Response<Body>
 where
     T: Message,
 {

--- a/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
@@ -27,7 +27,6 @@ use temporalio_common::{
             history::v1::history_event::Attributes,
         },
     },
-    worker::WorkerTaskTypes,
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
@@ -390,7 +389,6 @@ async fn custom_failure_converter_fallback_applied_to_workflow_failures() {
         .sdk_config
         .register_workflow::<WorkflowFailureFallbackWorkflow>()
         .unwrap();
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
@@ -473,7 +471,6 @@ async fn custom_failure_converter_fallback_applied_to_query_failures() {
         .sdk_config
         .register_workflow::<QueryUpdateFailureFallbackWorkflow>()
         .unwrap();
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
@@ -521,7 +518,6 @@ async fn custom_failure_converter_fallback_applied_to_update_validation_failures
         .sdk_config
         .register_workflow::<QueryUpdateFailureFallbackWorkflow>()
         .unwrap();
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
@@ -575,7 +571,6 @@ async fn custom_failure_converter_fallback_applied_to_update_handler_failures() 
         .sdk_config
         .register_workflow::<QueryUpdateFailureFallbackWorkflow>()
         .unwrap();
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
@@ -699,7 +694,6 @@ async fn multi_args_serializes_as_multiple_payloads() {
         .sdk_config
         .register_workflow::<MultiArgs2Workflow>()
         .unwrap();
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     let mut worker = starter.worker().await;
 
     let input = MultiArgs2("hello".to_string(), 42);
@@ -980,7 +974,6 @@ async fn codec_errors_fail_tasks_and_retry(#[case] failure_point: CodecFailurePo
         Some(client),
     );
     starter.sdk_config.register_activities(TestActivities);
-    starter.sdk_config.task_types = WorkerTaskTypes::all();
     starter
         .sdk_config
         .register_workflow::<DataConverterTestWorkflow>()
@@ -1026,7 +1019,6 @@ async fn codec_encodes_and_decodes_payloads() {
 
     let mut starter = CoreWfStarter::new_with_overrides(wf_name, None, Some(client));
     starter.sdk_config.register_activities(TestActivities);
-    starter.sdk_config.task_types = WorkerTaskTypes::all();
     starter
         .sdk_config
         .register_workflow::<DataConverterTestWorkflow>()
@@ -1085,7 +1077,6 @@ async fn describe_decodes_workflow_payload_fields() {
 
     let mut starter = CoreWfStarter::new_with_overrides(wf_name, None, Some(client));
     starter.sdk_config.register_activities(TestActivities);
-    starter.sdk_config.task_types = WorkerTaskTypes::all();
     starter
         .sdk_config
         .register_workflow::<DescribeDataConverterWorkflow>()
@@ -1164,7 +1155,6 @@ async fn describe_decodes_user_metadata_with_ungated_xor_codec() {
 
     let mut starter = CoreWfStarter::new_with_overrides(wf_name, None, Some(client));
     starter.sdk_config.register_activities(TestActivities);
-    starter.sdk_config.task_types = WorkerTaskTypes::all();
     starter
         .sdk_config
         .register_workflow::<DescribeDataConverterWorkflow>()
@@ -1231,7 +1221,6 @@ async fn codec_roundtrips_activity_cancellation_details() {
     starter
         .sdk_config
         .register_activities(FailurePayloadActivities);
-    starter.sdk_config.task_types = WorkerTaskTypes::all();
     starter
         .sdk_config
         .register_workflow::<CancellationDetailsWorkflow>()
@@ -1281,7 +1270,6 @@ async fn codec_roundtrips_activity_heartbeat_timeout_details() {
     starter
         .sdk_config
         .register_activities(FailurePayloadActivities);
-    starter.sdk_config.task_types = WorkerTaskTypes::all();
     starter
         .sdk_config
         .register_workflow::<HeartbeatDetailsWorkflow>()

--- a/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
@@ -713,7 +713,7 @@ async fn multi_args_serializes_as_multiple_payloads() {
     assert_eq!(output, "received: hello and 42");
 
     // Verify the workflow history contains multiple payloads in the input
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let events = client
         .get_workflow_handle::<UntypedWorkflow>(wf_name)
         .fetch_history(Default::default())

--- a/crates/sdk-core/tests/integ_tests/heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/heartbeat_tests.rs
@@ -62,7 +62,7 @@ impl ActivityDoesntHeartbeatHitsTimeoutThenCompletesWf {
 #[tokio::test]
 async fn activity_heartbeat() {
     let mut starter = init_core_and_create_wf("activity_heartbeat").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let task_q = starter.get_task_queue();
     let activity_id = "act-1";
     let task = core.poll_workflow_activation().await.unwrap();
@@ -134,7 +134,7 @@ async fn activity_heartbeat() {
 #[tokio::test]
 async fn many_act_fails_with_heartbeats() {
     let mut starter = init_core_and_create_wf("many_act_fails_with_heartbeats").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let activity_id = "act-1";
     let task = core.poll_workflow_activation().await.unwrap();
     // Complete workflow task and schedule activity

--- a/crates/sdk-core/tests/integ_tests/heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/heartbeat_tests.rs
@@ -215,11 +215,11 @@ async fn activity_doesnt_heartbeat_hits_timeout_then_completes() {
     let wf_name = "activity_doesnt_heartbeat_hits_timeout_then_completes";
     let mut starter = CoreWfStarter::new(wf_name);
     starter.sdk_config.register_activities(StdActivities);
-    let mut worker = starter.worker().await;
-
-    worker
+    starter
+        .sdk_config
         .register_workflow::<ActivityDoesntHeartbeatHitsTimeoutThenCompletesWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -589,7 +589,7 @@ async fn query_of_closed_workflow_doesnt_tick_terminal_metric(
         CoreWfStarter::new_with_runtime("query_of_closed_workflow_doesnt_tick_terminal_metric", rt);
     // Disable cache to ensure replay happens completely
     starter.sdk_config.max_cached_workflows = 0_usize;
-    let worker = starter.get_worker().await;
+    let worker = starter.get_core_worker().await;
     let run_id = starter.start_wf().await;
     let task = worker.poll_workflow_activation().await.unwrap();
     // Fail wf task
@@ -643,7 +643,7 @@ async fn query_of_closed_workflow_doesnt_tick_terminal_metric(
         .unwrap();
 
     // Query the now-closed workflow
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let queryer = async {
         WorkflowExecutionInfo {
             namespace: client.namespace(),
@@ -757,7 +757,7 @@ async fn latency_metrics(
     ));
     let rt = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
     let mut starter = CoreWfStarter::new_with_runtime("latency_metrics", rt);
-    let worker = starter.get_worker().await;
+    let worker = starter.get_core_worker().await;
     starter.start_wf().await;
     // Immediately finish workflow
     let task = worker.poll_workflow_activation().await.unwrap();
@@ -938,7 +938,7 @@ async fn docker_metrics_with_prometheus(
     let rt = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
     let test_name = "docker_metrics_with_prometheus";
     let mut starter = CoreWfStarter::new_with_runtime(test_name, rt);
-    let worker = starter.get_worker().await;
+    let worker = starter.get_core_worker().await;
     starter.start_wf().await;
 
     // Immediately finish the workflow
@@ -951,7 +951,7 @@ async fn docker_metrics_with_prometheus(
         .await
         .unwrap();
 
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     WorkflowService::list_namespaces(
         &mut client.clone(),
         ListNamespacesRequest::default().into_request(),
@@ -1176,7 +1176,7 @@ async fn nexus_metrics() {
         .register_workflow::<NexusMetricsWf>()
         .unwrap();
     let mut worker = starter.worker().await;
-    let core_worker = starter.get_worker().await;
+    let core_worker = starter.get_core_worker().await;
     let endpoint = mk_nexus_endpoint(&mut starter).await;
 
     #[workflow]

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -497,6 +497,10 @@ async fn idle_activity_worker_reports_zero_slots_used() {
     starter.sdk_config.register_activities(BlockingActivity {
         finish: finish_activity.clone(),
     });
+    starter
+        .sdk_config
+        .register_workflow::<OneActivity>()
+        .unwrap();
     let mut worker = starter.worker().await;
 
     #[workflow]
@@ -519,7 +523,6 @@ async fn idle_activity_worker_reports_zero_slots_used() {
         }
     }
 
-    worker.register_workflow::<OneActivity>().unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
         .submit_workflow(
@@ -1018,6 +1021,10 @@ async fn activity_metrics() {
     }
 
     starter.sdk_config.register_activities(PassFailActivities);
+    starter
+        .sdk_config
+        .register_workflow::<ActivityMetricsWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
 
     #[workflow]
@@ -1083,7 +1090,6 @@ async fn activity_metrics() {
         }
     }
 
-    worker.register_workflow::<ActivityMetricsWf>().unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     let workflow_id = wf_name.to_owned();
     worker
@@ -1156,15 +1162,19 @@ async fn nexus_metrics() {
     let rt = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
     let wf_name = "nexus_metrics";
     let mut starter = CoreWfStarter::new_with_runtime(wf_name, rt);
-    starter.sdk_config.task_types = WorkerTaskTypes {
+    starter.set_core_task_types(WorkerTaskTypes {
         enable_workflows: true,
         enable_local_activities: false,
         enable_remote_activities: false,
         enable_nexus: true,
-    };
+    });
     // Nexus operation handling involves internal async coordination that can
     // trigger false positives in nondeterminism detection.
     starter.sdk_config.detect_nondeterministic_futures = false;
+    starter
+        .sdk_config
+        .register_workflow::<NexusMetricsWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
     let core_worker = starter.get_worker().await;
     let endpoint = mk_nexus_endpoint(&mut starter).await;
@@ -1211,7 +1221,6 @@ async fn nexus_metrics() {
         }
     }
 
-    worker.register_workflow::<NexusMetricsWf>().unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     let workflow_id = wf_name.to_owned();
     worker
@@ -1349,7 +1358,10 @@ async fn evict_on_complete_does_not_count_as_forced_eviction() {
     let rt = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
     let wf_name = "evict_on_complete_does_not_count_as_forced_eviction";
     let mut starter = CoreWfStarter::new_with_runtime(wf_name, rt);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<EvictOnCompleteWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
 
     #[workflow]
@@ -1364,7 +1376,6 @@ async fn evict_on_complete_does_not_count_as_forced_eviction() {
         }
     }
 
-    worker.register_workflow::<EvictOnCompleteWf>().unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     let workflow_id = wf_name.to_owned();
     worker
@@ -1441,13 +1452,16 @@ async fn metrics_available_from_custom_slot_supplier() {
     let rt = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
     let mut starter =
         CoreWfStarter::new_with_runtime("metrics_available_from_custom_slot_supplier", rt);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     let mut tb = TunerBuilder::default();
     tb.workflow_slot_supplier(Arc::new(MetricRecordingSlotSupplier::<WorkflowSlotKind> {
         inner: FixedSizeSlotSupplier::new(5),
         metrics: OnceLock::new(),
     }));
     starter.sdk_config.tuner = Arc::new(tb.build());
+    starter
+        .sdk_config
+        .register_workflow::<CustomSlotSupplierWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
 
     #[workflow]
@@ -1462,7 +1476,6 @@ async fn metrics_available_from_custom_slot_supplier() {
         }
     }
 
-    worker.register_workflow::<CustomSlotSupplierWf>().unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     worker
         .submit_workflow(
@@ -1619,7 +1632,10 @@ async fn sticky_queue_label_strategy(
     let mut starter = CoreWfStarter::new_with_runtime(&wf_name, rt);
     // Enable sticky queues by setting a reasonable cache size
     starter.sdk_config.max_cached_workflows = 10_usize;
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<StickyQueueLabelStrategyWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
 
     #[workflow]
@@ -1635,9 +1651,6 @@ async fn sticky_queue_label_strategy(
         }
     }
 
-    worker
-        .register_workflow::<StickyQueueLabelStrategyWf>()
-        .unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     worker
         .submit_workflow(
@@ -1705,10 +1718,13 @@ async fn resource_based_tuner_metrics() {
     let rt = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
     let wf_name = "resource_based_tuner_metrics";
     let mut starter = CoreWfStarter::new_with_runtime(wf_name, rt);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     // Create a resource-based tuner with reasonable thresholds
     let tuner = ResourceBasedTuner::new(0.8, 0.8);
     starter.sdk_config.tuner = Arc::new(tuner);
+    starter
+        .sdk_config
+        .register_workflow::<ResourceBasedTunerMetricsWf>()
+        .unwrap();
 
     let mut worker = starter.worker().await;
 
@@ -1725,9 +1741,6 @@ async fn resource_based_tuner_metrics() {
         }
     }
 
-    worker
-        .register_workflow::<ResourceBasedTunerMetricsWf>()
-        .unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     let workflow_id = wf_name.to_owned();
     worker

--- a/crates/sdk-core/tests/integ_tests/pagination_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/pagination_tests.rs
@@ -1,4 +1,3 @@
-use crate::common::*;
 use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
@@ -118,19 +117,23 @@ async fn weird_pagination_doesnt_drop_wft_events() {
         .times(1);
 
     let mh = MockPollCfg::from_resp_batches(wf_id, t, [ResponseType::Raw(wft_resp)], mock_client);
-    let mut worker = mock_sdk_cfg(mh, |cfg| {
-        cfg.max_cached_workflows = 2;
-        cfg.ignore_evicts_on_shutdown = false;
-    });
-
     let sig_ctr = Arc::new(AtomicUsize::new(0));
     let sig_ctr_clone = sig_ctr.clone();
-    worker
-        .register_workflow_with_factory(move || WeirdPaginationWf {
-            sig_ctr: sig_ctr_clone.clone(),
-            signal_count: 0,
-        })
-        .unwrap();
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |cfg| {
+            cfg.max_cached_workflows = 2;
+            cfg.ignore_evicts_on_shutdown = false;
+        },
+        |options| {
+            options
+                .register_workflow_with_factory(move || WeirdPaginationWf {
+                    sig_ctr: sig_ctr_clone.clone(),
+                    signal_count: 0,
+                })
+                .unwrap();
+        },
+    );
 
     worker.run_until_done().await.unwrap();
     assert_eq!(sig_ctr.load(Ordering::Acquire), 2);
@@ -263,19 +266,23 @@ async fn extreme_pagination_doesnt_drop_wft_events_worker() {
     wft_resp.started_event_id = 15;
 
     let mh = MockPollCfg::from_resp_batches(wf_id, t, [ResponseType::Raw(wft_resp)], mock_client);
-    let mut worker = mock_sdk_cfg(mh, |cfg| {
-        cfg.max_cached_workflows = 2;
-        cfg.ignore_evicts_on_shutdown = false;
-    });
-
     let sig_ctr = Arc::new(AtomicUsize::new(0));
     let sig_ctr_clone = sig_ctr.clone();
-    worker
-        .register_workflow_with_factory(move || ExtremePaginationWf {
-            sig_ctr: sig_ctr_clone.clone(),
-            signal_count: 0,
-        })
-        .unwrap();
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |cfg| {
+            cfg.max_cached_workflows = 2;
+            cfg.ignore_evicts_on_shutdown = false;
+        },
+        |options| {
+            options
+                .register_workflow_with_factory(move || ExtremePaginationWf {
+                    sig_ctr: sig_ctr_clone.clone(),
+                    signal_count: 0,
+                })
+                .unwrap();
+        },
+    );
 
     worker.run_until_done().await.unwrap();
     assert_eq!(sig_ctr.load(Ordering::Acquire), 6);

--- a/crates/sdk-core/tests/integ_tests/plugin_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/plugin_tests.rs
@@ -1,6 +1,4 @@
-use crate::common::{
-    CoreWfStarter, get_integ_server_options, get_integ_telem_options, integ_namespace,
-};
+use crate::common::{get_integ_server_options, get_integ_telem_options, integ_namespace};
 use futures_util::future::BoxFuture;
 use std::{
     sync::{
@@ -25,7 +23,6 @@ use temporalio_common::{
     protos::{
         coresdk::workflow_activation::WorkflowActivation, temporal::api::common::v1::Payload,
     },
-    worker::WorkerTaskTypes,
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
@@ -113,7 +110,10 @@ async fn plugins_configure_client_and_worker() {
         .unwrap();
     assert_eq!(client.connection().identity(), "integration-plugin-client");
     assert_eq!(client.namespace(), integ_namespace());
-    let worker_options = WorkerOptions::new(format!("plugins-{}", Uuid::new_v4())).build();
+    let worker_options = WorkerOptions::new(format!("plugins-{}", Uuid::new_v4()))
+        .register_workflow::<SimplePluginWorkflow>()
+        .unwrap()
+        .build();
     let worker = Worker::new(&runtime, client, worker_options).unwrap();
 
     assert_eq!(connection_calls.load(Relaxed), 1);
@@ -245,22 +245,17 @@ async fn simple_plugin_configures_working_client_and_worker() {
     let client = Client::connect(get_integ_server_options(), client_options)
         .await
         .unwrap();
-    let mut starter = CoreWfStarter::new_with_overrides(
-        "simple_plugin_configures_working_client_and_worker",
-        None,
-        Some(client),
-    );
-    starter.set_core_task_types(WorkerTaskTypes {
-        enable_workflows: true,
-        enable_local_activities: true,
-        enable_remote_activities: true,
-        enable_nexus: false,
-    });
-    let task_queue = starter.get_task_queue().to_owned();
-    let mut worker = starter.worker().await;
+    let runtime = new_sdk_runtime();
+    let task_queue = format!("simple-plugin-{}", Uuid::new_v4());
+    let mut worker = Worker::new(
+        &runtime,
+        client.clone(),
+        WorkerOptions::new(task_queue.clone()).build(),
+    )
+    .unwrap();
     let workflow_id = format!("simple-plugin-{}", Uuid::new_v4());
-    let handle = worker
-        .submit_workflow(
+    let handle = client
+        .start_workflow(
             SimplePluginWorkflow::run,
             "Temporal".to_owned(),
             WorkflowStartOptions::new(task_queue, workflow_id).build(),
@@ -268,8 +263,17 @@ async fn simple_plugin_configures_working_client_and_worker() {
         .await
         .unwrap();
 
-    worker.run_until_done().await.unwrap();
-    let workflow_result = handle.get_result(Default::default()).await.unwrap();
+    let shutdown = worker.shutdown_handle();
+    let (workflow_result, worker_result) = tokio::join!(
+        async {
+            let result = handle.get_result(Default::default()).await;
+            shutdown();
+            result
+        },
+        worker.run(),
+    );
+    worker_result.unwrap();
+    let workflow_result = workflow_result.unwrap();
     assert_eq!(workflow_result, "Hello, Temporal!");
     assert_eq!(client_interceptor_calls.load(Ordering::Relaxed), 1);
     assert!(worker_interceptor_calls.load(Ordering::Relaxed) > 0);
@@ -392,6 +396,8 @@ async fn worker_metadata_includes_client_and_worker_plugin_names() {
         &runtime,
         client,
         WorkerOptions::new(format!("plugin-metadata-{}", Uuid::new_v4()))
+            .register_workflow::<SimplePluginWorkflow>()
+            .unwrap()
             .worker_plugin(WorkerOnlyMetadataPlugin)
             .build(),
     )

--- a/crates/sdk-core/tests/integ_tests/plugin_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/plugin_tests.rs
@@ -250,12 +250,12 @@ async fn simple_plugin_configures_working_client_and_worker() {
         None,
         Some(client),
     );
-    starter.sdk_config.task_types = WorkerTaskTypes {
+    starter.set_core_task_types(WorkerTaskTypes {
         enable_workflows: true,
         enable_local_activities: true,
         enable_remote_activities: true,
         enable_nexus: false,
-    };
+    });
     let task_queue = starter.get_task_queue().to_owned();
     let mut worker = starter.worker().await;
     let workflow_id = format!("simple-plugin-{}", Uuid::new_v4());

--- a/crates/sdk-core/tests/integ_tests/poll_loop_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/poll_loop_tests.rs
@@ -113,8 +113,8 @@ impl ChainWf {
 /// updates and signals, and asserts everything completes within 5 seconds.
 async fn run_scripted_test(name: &str, script: TestScript) {
     let mut starter = CoreWfStarter::new(name);
+    starter.sdk_config.register_workflow::<ChainWf>().unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<ChainWf>().unwrap();
 
     let num_updates = script.update_scripts.len();
     let num_signals = script.signal_scripts.len();

--- a/crates/sdk-core/tests/integ_tests/polling_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/polling_tests.rs
@@ -46,7 +46,7 @@ use url::Url;
 #[tokio::test]
 async fn out_of_order_completion_doesnt_hang() {
     let mut starter = init_core_and_create_wf("out_of_order_completion_doesnt_hang").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let task_q = starter.get_task_queue();
     let activity_id = "act-1";
     let task = core.poll_workflow_activation().await.unwrap();
@@ -321,7 +321,7 @@ async fn small_workflow_slots_and_pollers(#[values(false, true)] use_autoscaling
         .any(|e| e.event_type() == EventType::WorkflowTaskTimedOut);
     assert!(!any_task_timeouts);
     let events = starter
-        .get_client()
+        .get_core_client()
         .await
         .get_workflow_handle::<UntypedWorkflow>(&wf2id)
         .fetch_history(Default::default())

--- a/crates/sdk-core/tests/integ_tests/polling_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/polling_tests.rs
@@ -287,12 +287,12 @@ async fn small_workflow_slots_and_pollers(#[values(false, true)] use_autoscaling
     }
     starter.sdk_config.activity_task_poller_behavior = Some(PollerBehavior::SimpleMaximum(1));
     starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(2, 1, 1, 1));
-    starter.sdk_config.register_activities(StdActivities);
-    let mut worker = starter.worker().await;
-
-    worker
+    starter
+        .sdk_config
+        .register_activities(StdActivities)
         .register_workflow::<OnlyOneWorkflowSlotAndTwoPollers>()
         .unwrap();
+    let mut worker = starter.worker().await;
     let task_queue = starter.get_task_queue().to_owned();
     worker
         .submit_workflow(

--- a/crates/sdk-core/tests/integ_tests/queries_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/queries_tests.rs
@@ -27,7 +27,7 @@ use tokio::join;
 async fn simple_query_legacy() {
     let query_resp = b"response";
     let mut starter = init_core_and_create_wf("simple_query_legacy").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let workflow_id = starter.get_task_queue().to_string();
     let task = core.poll_workflow_activation().await.unwrap();
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
@@ -51,12 +51,12 @@ async fn simple_query_legacy() {
     // Query after timer should have fired and there should be new WFT
     let query_fut = async {
         WorkflowExecutionInfo {
-            namespace: starter.get_client().await.namespace(),
+            namespace: starter.get_core_client().await.namespace(),
             workflow_id,
             run_id: Some(task.run_id.to_string()),
             first_execution_run_id: None,
         }
-        .bind_untyped(starter.get_client().await.clone())
+        .bind_untyped(starter.get_core_client().await.clone())
         .query(
             UntypedQuery::new("myquery"),
             RawValue::empty(),
@@ -124,7 +124,7 @@ async fn query_after_execution_complete(#[case] do_evict: bool) {
     let query_resp = b"response";
     let mut starter =
         init_core_and_create_wf(&format!("query_after_execution_complete-{do_evict}")).await;
-    let core = &starter.get_worker().await;
+    let core = &starter.get_core_worker().await;
     let workflow_id = &starter.get_task_queue().to_string();
 
     let do_workflow = |go_until_query: bool| async move {
@@ -195,7 +195,7 @@ async fn query_after_execution_complete(#[case] do_evict: bool) {
     // we could screw-up re-applying the final WFT)
     let mut query_futs = FuturesUnordered::new();
     for _ in 0..3 {
-        let gw = starter.get_client().await.clone();
+        let gw = starter.get_core_client().await.clone();
         let query_fut = async move {
             let q_resp: RawValue = WorkflowExecutionInfo {
                 namespace: gw.namespace(),
@@ -229,7 +229,7 @@ async fn query_after_execution_complete(#[case] do_evict: bool) {
 async fn fail_legacy_query(#[case] with_nde: bool) {
     let query_err = "oh no broken";
     let mut starter = CoreWfStarter::new("fail_legacy_query");
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     starter.workflow_options.task_timeout = Some(Duration::from_secs(1));
     starter.start_wf().await;
     let workflow_id = starter.get_task_queue().to_string();
@@ -240,12 +240,12 @@ async fn fail_legacy_query(#[case] with_nde: bool) {
     core.handle_eviction().await;
     let query_fut = async {
         WorkflowExecutionInfo {
-            namespace: starter.get_client().await.namespace(),
+            namespace: starter.get_core_client().await.namespace(),
             workflow_id: workflow_id.to_string(),
             run_id: Some(task.run_id.to_string()),
             first_execution_run_id: None,
         }
-        .bind_untyped(starter.get_client().await.clone())
+        .bind_untyped(starter.get_core_client().await.clone())
         .query(
             UntypedQuery::new("myquery"),
             RawValue::empty(),
@@ -298,7 +298,7 @@ async fn fail_legacy_query(#[case] with_nde: bool) {
 #[tokio::test]
 async fn multiple_concurrent_queries_no_new_history() {
     let mut starter = init_core_and_create_wf("multiple_concurrent_queries_no_new_history").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let workflow_id = starter.get_task_queue().to_string();
     let started = Instant::now();
     let task = core.poll_workflow_activation().await.unwrap();
@@ -308,7 +308,7 @@ async fn multiple_concurrent_queries_no_new_history() {
     ))
     .await
     .unwrap();
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let num_queries = 10;
     let query_futs = (1..=num_queries).map(|_| async {
         WorkflowExecutionInfo {
@@ -369,7 +369,7 @@ async fn multiple_concurrent_queries_no_new_history() {
 #[tokio::test]
 async fn queries_handled_before_next_wft() {
     let mut starter = init_core_and_create_wf("queries_handled_before_next_wft").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let workflow_id = starter.get_task_queue().to_string();
     let task = core.poll_workflow_activation().await.unwrap();
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
@@ -378,7 +378,7 @@ async fn queries_handled_before_next_wft() {
     ))
     .await
     .unwrap();
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     // Send two queries so that one of them is buffered
     let query_futs = (1..=2).map(|_| async {
         WorkflowExecutionInfo {
@@ -478,9 +478,9 @@ async fn queries_handled_before_next_wft() {
 async fn query_should_not_be_sent_if_wft_about_to_fail() {
     let mut starter =
         init_core_and_create_wf("query_should_not_be_sent_if_wft_about_to_fail").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let workflow_id = starter.get_task_queue().to_string();
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     // query straight away
     let handle = client.get_workflow_handle::<UntypedWorkflow>(workflow_id.to_string());
     let query_fut = handle.query(

--- a/crates/sdk-core/tests/integ_tests/update_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/update_tests.rs
@@ -69,8 +69,8 @@ enum CompleteWorkflow {
 #[tokio::test]
 async fn update_workflow(#[values(FailUpdate::Yes, FailUpdate::No)] will_fail: FailUpdate) {
     let mut starter = init_core_and_create_wf("update_workflow").await;
-    let core = starter.get_worker().await;
-    let client = starter.get_client().await;
+    let core = starter.get_core_worker().await;
+    let client = starter.get_core_client().await;
     let workflow_id = starter.get_task_queue();
     let update_id = "some_update";
     send_and_handle_update(
@@ -104,8 +104,8 @@ async fn update_workflow(#[values(FailUpdate::Yes, FailUpdate::No)] will_fail: F
 #[tokio::test]
 async fn reapplied_updates_due_to_reset() {
     let mut starter = init_core_and_create_wf("update_workflow").await;
-    let core = starter.get_worker().await;
-    let client = starter.get_client().await;
+    let core = starter.get_core_worker().await;
+    let client = starter.get_core_client().await;
     let workflow_id = starter.get_task_queue();
     let pre_reset_run_id = send_and_handle_update(
         workflow_id,
@@ -300,8 +300,8 @@ async fn handle_update(
 #[tokio::test]
 async fn update_rejection() {
     let mut starter = init_core_and_create_wf("update_workflow").await;
-    let core = starter.get_worker().await;
-    let client = starter.get_client().await;
+    let core = starter.get_core_worker().await;
+    let client = starter.get_core_client().await;
     let workflow_id = starter.get_task_queue().to_string();
 
     let update_id = "some_update";
@@ -379,8 +379,8 @@ async fn update_rejection() {
 #[tokio::test]
 async fn update_insta_complete(#[values(true, false)] accept_first: bool) {
     let mut starter = init_core_and_create_wf("update_workflow").await;
-    let core = starter.get_worker().await;
-    let client = starter.get_client().await;
+    let core = starter.get_core_worker().await;
+    let client = starter.get_core_client().await;
     let workflow_id = starter.get_task_queue().to_string();
 
     let update_id = "some_update";
@@ -472,8 +472,8 @@ async fn update_insta_complete(#[values(true, false)] accept_first: bool) {
 #[tokio::test]
 async fn update_complete_after_accept_without_new_task() {
     let mut starter = init_core_and_create_wf("update_workflow").await;
-    let core = starter.get_worker().await;
-    let client = starter.get_client().await;
+    let core = starter.get_core_worker().await;
+    let client = starter.get_core_client().await;
     let workflow_id = starter.get_task_queue().to_string();
 
     let update_id = "some_update";
@@ -572,8 +572,8 @@ async fn update_complete_after_accept_without_new_task() {
 #[tokio::test]
 async fn update_speculative_wft() {
     let mut starter = init_core_and_create_wf("update_workflow").await;
-    let core = starter.get_worker().await;
-    let client = starter.get_client().await;
+    let core = starter.get_core_worker().await;
+    let client = starter.get_core_client().await;
     let workflow_id = starter.get_task_queue().to_string();
 
     let update_id = "some_update";
@@ -866,7 +866,7 @@ async fn unknown_update_rejected_sdk() {
         .register_workflow::<UnknownUpdateRejectedSdkWf>()
         .unwrap();
     let mut worker = starter.worker().await;
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
 
     #[workflow]
     #[derive(Default)]
@@ -1083,9 +1083,7 @@ async fn task_failure_during_validation() {
 async fn task_failure_during_update_handler() {
     let wf_name = "task_failure_during_update_handler";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.workflow_options.task_timeout = Some(Duration::from_secs(1));
-    let mut worker = starter.worker().await;
     #[workflow]
     #[derive(Default)]
     struct TaskFailureDuringUpdateHandlerWf {
@@ -1118,9 +1116,11 @@ async fn task_failure_during_update_handler() {
         }
     }
 
-    worker
+    starter
+        .sdk_config
         .register_workflow::<TaskFailureDuringUpdateHandlerWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
         .submit_workflow(
@@ -1253,7 +1253,7 @@ async fn worker_restarted_in_middle_of_update() {
         .register_workflow::<WorkerRestartedInMiddleOfUpdateWf>()
         .unwrap();
     let mut worker = starter.worker().await;
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
 
     #[workflow]
     #[derive(Default)]
@@ -1318,7 +1318,7 @@ async fn worker_restarted_in_middle_of_update() {
             .await
             .unwrap();
     };
-    let core_worker = starter.get_worker().await;
+    let core_worker = starter.get_core_worker().await;
     let mut second_starter = starter.clone_no_worker();
     let stopper = async {
         // Wait for the activity to start
@@ -1344,7 +1344,7 @@ async fn worker_restarted_in_middle_of_update() {
         // This run attempt will get shut down
         worker.inner_mut().run().await.unwrap();
         // Start up a new worker
-        let new_worker = second_starter.get_worker().await;
+        let new_worker = second_starter.get_core_worker().await;
         // Replace with new core and run again
         worker.inner_mut().with_new_core_worker(new_worker);
         worker.run_until_done().await.unwrap();

--- a/crates/sdk-core/tests/integ_tests/update_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/update_tests.rs
@@ -37,7 +37,6 @@ use temporalio_common::{
             workflowservice::v1::{ResetStickyTaskQueueRequest, ResetWorkflowExecutionRequest},
         },
     },
-    worker::WorkerTaskTypes,
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
@@ -660,7 +659,6 @@ async fn update_with_local_acts() {
     // Short task timeout to get activities to heartbeat without taking ages
     starter.workflow_options.task_timeout = Some(Duration::from_secs(1));
     starter.sdk_config.register_activities(StdActivities);
-    let mut worker = starter.worker().await;
 
     #[workflow]
     #[derive(Default)]
@@ -696,7 +694,11 @@ async fn update_with_local_acts() {
         }
     }
 
-    worker.register_workflow::<UpdateWithLocalActsWf>().unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<UpdateWithLocalActsWf>()
+        .unwrap();
+    let mut worker = starter.worker().await;
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
         .submit_workflow(
@@ -738,8 +740,6 @@ async fn update_with_local_acts() {
 async fn update_rejection_sdk() {
     let wf_name = "update_rejection_sdk";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
     #[workflow]
     #[derive(Default)]
     struct UpdateRejectionSdkWf;
@@ -770,7 +770,11 @@ async fn update_rejection_sdk() {
         }
     }
 
-    worker.register_workflow::<UpdateRejectionSdkWf>().unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<UpdateRejectionSdkWf>()
+        .unwrap();
+    let mut worker = starter.worker().await;
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
         .submit_workflow(
@@ -801,8 +805,6 @@ async fn update_rejection_sdk() {
 async fn update_fail_sdk() {
     let wf_name = "update_fail_sdk";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
     #[workflow]
     #[derive(Default)]
     struct UpdateFailSdkWf;
@@ -824,7 +826,11 @@ async fn update_fail_sdk() {
         }
     }
 
-    worker.register_workflow::<UpdateFailSdkWf>().unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<UpdateFailSdkWf>()
+        .unwrap();
+    let mut worker = starter.worker().await;
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
         .submit_workflow(
@@ -855,7 +861,10 @@ async fn update_fail_sdk() {
 async fn unknown_update_rejected_sdk() {
     let wf_name = "unknown_update_rejected_sdk";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<UnknownUpdateRejectedSdkWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
     let client = starter.get_client().await;
 
@@ -882,9 +891,6 @@ async fn unknown_update_rejected_sdk() {
         }
     }
 
-    worker
-        .register_workflow::<UnknownUpdateRejectedSdkWf>()
-        .unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
         .submit_workflow(
@@ -930,8 +936,6 @@ async fn unknown_update_rejected_sdk() {
 async fn update_timer_sequence() {
     let wf_name = "update_timer_sequence";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
     #[workflow]
     #[derive(Default)]
     struct UpdateTimerSequenceWf {
@@ -958,7 +962,11 @@ async fn update_timer_sequence() {
         }
     }
 
-    worker.register_workflow::<UpdateTimerSequenceWf>().unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<UpdateTimerSequenceWf>()
+        .unwrap();
+    let mut worker = starter.worker().await;
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
         .submit_workflow(
@@ -989,8 +997,11 @@ async fn update_timer_sequence() {
 async fn task_failure_during_validation() {
     let wf_name = "task_failure_during_validation";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.workflow_options.task_timeout = Some(Duration::from_secs(1));
+    starter
+        .sdk_config
+        .register_workflow::<TaskFailureDuringValidationWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
     #[workflow]
     #[derive(Default)]
@@ -1029,9 +1040,6 @@ async fn task_failure_during_validation() {
         }
     }
 
-    worker
-        .register_workflow::<TaskFailureDuringValidationWf>()
-        .unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
         .submit_workflow(
@@ -1161,8 +1169,11 @@ async fn task_failure_during_update_handler() {
 async fn task_failure_after_update() {
     let wf_name = "task_failure_after_update";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.workflow_options.task_timeout = Some(Duration::from_secs(1));
+    starter
+        .sdk_config
+        .register_workflow::<TaskFailureAfterUpdateWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
     #[workflow]
     #[derive(Default)]
@@ -1189,9 +1200,6 @@ async fn task_failure_after_update() {
         }
     }
 
-    worker
-        .register_workflow::<TaskFailureAfterUpdateWf>()
-        .unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
         .submit_workflow(
@@ -1240,6 +1248,10 @@ async fn worker_restarted_in_middle_of_update() {
     }
 
     starter.sdk_config.register_activities(BlockingActivities);
+    starter
+        .sdk_config
+        .register_workflow::<WorkerRestartedInMiddleOfUpdateWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
     let client = starter.get_client().await;
 
@@ -1277,9 +1289,6 @@ async fn worker_restarted_in_middle_of_update() {
         }
     }
 
-    worker
-        .register_workflow::<WorkerRestartedInMiddleOfUpdateWf>()
-        .unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
         .submit_workflow(
@@ -1349,7 +1358,6 @@ async fn update_after_empty_wft() {
     let wf_name = "update_after_empty_wft";
     let mut starter = CoreWfStarter::new(wf_name);
     starter.sdk_config.register_activities(StdActivities);
-    let mut worker = starter.worker().await;
 
     static ACT_STARTED: AtomicBool = AtomicBool::new(false);
 
@@ -1403,7 +1411,11 @@ async fn update_after_empty_wft() {
         }
     }
 
-    worker.register_workflow::<UpdateAfterEmptyWftWf>().unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<UpdateAfterEmptyWftWf>()
+        .unwrap();
+    let mut worker = starter.worker().await;
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
         .submit_workflow(
@@ -1445,6 +1457,10 @@ async fn update_lost_on_activity_mismatch() {
     let wf_name = "update_lost_on_activity_mismatch";
     let mut starter = CoreWfStarter::new(wf_name);
     starter.sdk_config.register_activities(StdActivities);
+    starter
+        .sdk_config
+        .register_workflow::<UpdateLostOnActivityMismatchWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
 
     #[workflow]
@@ -1478,9 +1494,6 @@ async fn update_lost_on_activity_mismatch() {
         }
     }
 
-    worker
-        .register_workflow::<UpdateLostOnActivityMismatchWf>()
-        .unwrap();
     let core_worker = worker.core_worker();
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker

--- a/crates/sdk-core/tests/integ_tests/visibility_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/visibility_tests.rs
@@ -21,8 +21,8 @@ use tonic::IntoRequest;
 async fn client_list_open_closed_workflow_executions() {
     let wf_name = "client_list_open_closed_workflow_executions".to_owned();
     let mut starter = CoreWfStarter::new(&wf_name);
-    let core = starter.get_worker().await;
-    let mut client = starter.get_client().await;
+    let core = starter.get_core_worker().await;
+    let mut client = starter.get_core_client().await;
 
     let earliest = std::time::SystemTime::now();
     let latest = earliest + Duration::from_secs(60);

--- a/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
@@ -238,8 +238,6 @@ async fn docker_worker_heartbeat_basic(#[values("otel", "prom", "no_metrics")] b
         acts_started: acts_started.clone(),
         acts_done: acts_done.clone(),
     });
-    let mut worker = starter.worker().await;
-    let worker_instance_key = worker.worker_instance_key();
 
     #[workflow]
     #[derive(Default)]
@@ -261,7 +259,12 @@ async fn docker_worker_heartbeat_basic(#[values("otel", "prom", "no_metrics")] b
         }
     }
 
-    worker.register_workflow::<HeartbeatBasicWf>().unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<HeartbeatBasicWf>()
+        .unwrap();
+    let mut worker = starter.worker().await;
+    let worker_instance_key = worker.worker_instance_key();
 
     starter
         .start_with_worker(HeartbeatBasicWf::name(), &mut worker)
@@ -413,8 +416,6 @@ async fn docker_worker_heartbeat_tuner() {
     });
     starter.sdk_config.tuner = Arc::new(tuner);
     starter.sdk_config.register_activities(StdActivities);
-    let mut worker = starter.worker().await;
-    let worker_instance_key = worker.worker_instance_key();
 
     #[workflow]
     #[derive(Default)]
@@ -436,7 +437,12 @@ async fn docker_worker_heartbeat_tuner() {
         }
     }
 
-    worker.register_workflow::<HeartbeatTunerWf>().unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<HeartbeatTunerWf>()
+        .unwrap();
+    let mut worker = starter.worker().await;
+    let worker_instance_key = worker.worker_instance_key();
 
     starter
         .start_with_worker(HeartbeatTunerWf::name(), &mut worker)
@@ -693,15 +699,6 @@ async fn worker_heartbeat_sticky_cache_miss() {
         .sdk_config
         .register_activities(StickyCacheActivities);
 
-    let mut worker = starter.worker().await;
-    worker.fetch_results = false;
-    let worker_key = worker.worker_instance_key().to_string();
-    let worker_core = worker.core_worker();
-    let submitter = worker.get_submitter_handle();
-    let wf_opts = starter.workflow_options.clone();
-    let client = starter.get_client().await;
-    let client_for_orchestrator = client.clone();
-
     #[workflow]
     #[derive(Default)]
     struct StickyCacheMissWf;
@@ -723,7 +720,18 @@ async fn worker_heartbeat_sticky_cache_miss() {
         }
     }
 
-    worker.register_workflow::<StickyCacheMissWf>().unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<StickyCacheMissWf>()
+        .unwrap();
+    let mut worker = starter.worker().await;
+    worker.fetch_results = false;
+    let worker_key = worker.worker_instance_key().to_string();
+    let worker_core = worker.core_worker();
+    let submitter = worker.get_submitter_handle();
+    let wf_opts = starter.workflow_options.clone();
+    let client = starter.get_client().await;
+    let client_for_orchestrator = client.clone();
 
     let wf1_id = format!("{wf_name}_wf1");
     let wf2_id = format!("{wf_name}_wf2");
@@ -814,6 +822,10 @@ async fn worker_heartbeat_multiple_workers() {
     starter.sdk_config.max_cached_workflows = 5_usize;
     starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(5, 10, 10, 10));
     starter.sdk_config.register_activities(StdActivities);
+    starter
+        .sdk_config
+        .register_workflow::<MultiWorkersWf>()
+        .unwrap();
 
     let client = starter.get_client().await;
     let starting_hb_len = list_worker_heartbeats(&client, String::new()).await.len();
@@ -832,11 +844,9 @@ async fn worker_heartbeat_multiple_workers() {
     }
 
     let mut worker_a = starter.worker().await;
-    worker_a.register_workflow::<MultiWorkersWf>().unwrap();
 
     let mut starter_b = starter.clone_no_worker();
     let mut worker_b = starter_b.worker().await;
-    worker_b.register_workflow::<MultiWorkersWf>().unwrap();
 
     let worker_a_key = worker_a.worker_instance_key().to_string();
     let worker_b_key = worker_b.worker_instance_key().to_string();
@@ -986,9 +996,6 @@ async fn worker_heartbeat_failure_metrics() {
 
     starter.sdk_config.register_activities(FailingActivities);
 
-    let mut worker = starter.worker().await;
-    let worker_instance_key = worker.worker_instance_key();
-
     #[workflow]
     #[derive(Default)]
     struct FailureMetricsWf {
@@ -1030,7 +1037,12 @@ async fn worker_heartbeat_failure_metrics() {
         }
     }
 
-    worker.register_workflow::<FailureMetricsWf>().unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<FailureMetricsWf>()
+        .unwrap();
+    let mut worker = starter.worker().await;
+    let worker_instance_key = worker.worker_instance_key();
 
     let worker_key = worker_instance_key.to_string();
     let task_queue = starter.get_task_queue().to_owned();
@@ -1129,8 +1141,6 @@ async fn worker_heartbeat_no_runtime_heartbeat() {
     let rt = CoreRuntime::new_assume_tokio(runtimeopts).unwrap();
     let mut starter = CoreWfStarter::new_with_runtime(wf_name, rt);
     starter.sdk_config.register_activities(StdActivities);
-    let mut worker = starter.worker().await;
-    let worker_instance_key = worker.worker_instance_key();
 
     #[workflow]
     #[derive(Default)]
@@ -1152,7 +1162,12 @@ async fn worker_heartbeat_no_runtime_heartbeat() {
         }
     }
 
-    worker.register_workflow::<NoRuntimeHeartbeatWf>().unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<NoRuntimeHeartbeatWf>()
+        .unwrap();
+    let mut worker = starter.worker().await;
+    let worker_instance_key = worker.worker_instance_key();
 
     starter
         .start_with_worker(NoRuntimeHeartbeatWf::name(), &mut worker)
@@ -1201,6 +1216,10 @@ async fn worker_heartbeat_skip_client_worker_set_check() {
     let mut starter = CoreWfStarter::new_with_runtime(wf_name, rt);
     starter.set_core_cfg_mutator(|m| m.skip_client_worker_set_check = true);
     starter.sdk_config.register_activities(StdActivities);
+    starter
+        .sdk_config
+        .register_workflow::<SkipClientWorkerSetCheckWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
     let worker_instance_key = worker.worker_instance_key();
 
@@ -1223,10 +1242,6 @@ async fn worker_heartbeat_skip_client_worker_set_check() {
             Ok(())
         }
     }
-
-    worker
-        .register_workflow::<SkipClientWorkerSetCheckWf>()
-        .unwrap();
 
     starter
         .start_with_worker(SkipClientWorkerSetCheckWf::name(), &mut worker)

--- a/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
@@ -277,7 +277,7 @@ async fn docker_worker_heartbeat_basic(#[values("otel", "prom", "no_metrics")] b
         // Give enough time to ensure heartbeat interval has been hit
         tokio::time::sleep(Duration::from_millis(1500)).await;
         acts_started.notified().await;
-        let client = starter.get_client().await;
+        let client = starter.get_core_client().await;
         let mut raw_client = client.clone();
         let workers_list = WorkflowService::list_workers(
             &mut raw_client,
@@ -449,7 +449,7 @@ async fn docker_worker_heartbeat_tuner() {
         .await;
     worker.run_until_done().await.unwrap();
 
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let mut raw_client = client.clone();
     let workers_list = WorkflowService::list_workers(
         &mut raw_client,
@@ -730,7 +730,7 @@ async fn worker_heartbeat_sticky_cache_miss() {
     let worker_core = worker.core_worker();
     let submitter = worker.get_submitter_handle();
     let wf_opts = starter.workflow_options.clone();
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let client_for_orchestrator = client.clone();
 
     let wf1_id = format!("{wf_name}_wf1");
@@ -827,7 +827,7 @@ async fn worker_heartbeat_multiple_workers() {
         .register_workflow::<MultiWorkersWf>()
         .unwrap();
 
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let starting_hb_len = list_worker_heartbeats(&client, String::new()).await.len();
 
     #[workflow]
@@ -1064,7 +1064,7 @@ async fn worker_heartbeat_failure_metrics() {
     let query = format!("WorkerInstanceKey=\"{worker_key}\"");
     let test_fut = async {
         ACT_FAIL.notified().await;
-        let client = starter.get_client().await;
+        let client = starter.get_core_client().await;
         eventually(
             || async {
                 let heartbeats = list_worker_heartbeats(&client, query.clone()).await;
@@ -1118,7 +1118,7 @@ async fn worker_heartbeat_failure_metrics() {
     };
     tokio::join!(test_fut, runner);
 
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let mut heartbeats = list_worker_heartbeats(&client, query).await;
     assert_eq!(heartbeats.len(), 1);
     let heartbeat = heartbeats.pop().unwrap();
@@ -1174,7 +1174,7 @@ async fn worker_heartbeat_no_runtime_heartbeat() {
         .await;
 
     worker.run_until_done().await.unwrap();
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let mut raw_client = client.clone();
     let workers_list = WorkflowService::list_workers(
         &mut raw_client,
@@ -1248,7 +1248,7 @@ async fn worker_heartbeat_skip_client_worker_set_check() {
         .await;
 
     worker.run_until_done().await.unwrap();
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let mut raw_client = client.clone();
     let workers_list = WorkflowService::list_workers(
         &mut raw_client,

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -1,4 +1,3 @@
-use super::client_tests::make_ok_response;
 use crate::{
     common::{
         CoreWfStarter, activity_functions::StdActivities, fake_grpc_server::fake_server,
@@ -20,7 +19,7 @@ use std::{
     time::Duration,
 };
 use temporalio_client::{
-    Client, ClientOptions, Connection, PayloadLimitsOptions, RetryOptions, WorkflowStartOptions,
+    Client, ClientOptions, Connection, PayloadLimitsOptions, WorkflowStartOptions,
     errors::WorkflowGetResultError,
 };
 use temporalio_common::{
@@ -48,11 +47,9 @@ use temporalio_common::{
                     Attributes::{self as EventAttributes},
                 },
             },
-            namespace::v1::{NamespaceInfo, namespace_info::Capabilities},
             workflowservice::v1::{
-                DescribeNamespaceResponse, GetWorkflowExecutionHistoryResponse,
-                PollActivityTaskQueueResponse, PollWorkflowTaskQueueResponse,
-                RespondActivityTaskCompletedResponse, ShutdownWorkerResponse,
+                GetWorkflowExecutionHistoryResponse, PollActivityTaskQueueResponse,
+                RespondActivityTaskCompletedResponse,
             },
         },
     },
@@ -118,6 +115,10 @@ async fn worker_validation_fails_on_nonexistent_namespace() {
 async fn worker_handles_unknown_workflow_types_gracefully() {
     let wf_type = "worker_handles_unknown_workflow_types_gracefully";
     let mut starter = CoreWfStarter::new(wf_type);
+    starter
+        .sdk_config
+        .register_workflow::<ResourceBasedNonStickyWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
@@ -181,7 +182,7 @@ async fn worker_handles_unknown_workflow_types_gracefully() {
     let inner = worker.inner_mut();
     tokio::join!(async { inner.run().await.unwrap() }, async move {
         notify.notified().await;
-        let worker = starter.get_worker().await.clone();
+        let worker = starter.get_core_worker().await.clone();
         drain_pollers_and_shutdown(&worker).await;
     });
 }
@@ -1427,83 +1428,9 @@ async fn shutdown_worker_not_retried() {
 
     let wf_type = "shutdown_worker_not_retried";
     let mut starter = CoreWfStarter::new_with_overrides(wf_type, None, Some(client));
-    let worker = starter.get_worker().await;
+    let worker = starter.get_core_worker().await;
     drain_pollers_and_shutdown(&worker).await;
     assert_eq!(shutdown_call_count.load(Ordering::Relaxed), 1);
-}
-
-#[tokio::test]
-async fn high_level_workflow_only_worker_shuts_down() {
-    let workflow_poll_started = Arc::new(Notify::new());
-    let workflow_poll_started_for_server = workflow_poll_started.clone();
-    let shutdown_rpc_started = Arc::new(AtomicBool::new(false));
-    let shutdown_rpc_started_for_server = shutdown_rpc_started.clone();
-    let release_workflow_polls = Arc::new(Notify::new());
-    let release_workflow_polls_for_server = release_workflow_polls.clone();
-    let fs = fake_server(move |req| {
-        let workflow_poll_started = workflow_poll_started_for_server.clone();
-        let shutdown_rpc_started = shutdown_rpc_started_for_server.clone();
-        let release_workflow_polls = release_workflow_polls_for_server.clone();
-        async move {
-            let path = req.uri().path();
-            if path.contains("DescribeNamespace") {
-                make_ok_response(DescribeNamespaceResponse {
-                    namespace_info: Some(NamespaceInfo {
-                        capabilities: Some(Capabilities {
-                            worker_poll_complete_on_shutdown: true,
-                            ..Default::default()
-                        }),
-                        ..Default::default()
-                    }),
-                    ..Default::default()
-                })
-            } else if path.contains("PollWorkflowTaskQueue") {
-                workflow_poll_started.notify_one();
-                release_workflow_polls.notified().await;
-                make_ok_response(PollWorkflowTaskQueueResponse::default())
-            } else if path.contains("ShutdownWorker") {
-                shutdown_rpc_started.store(true, Ordering::Relaxed);
-                release_workflow_polls.notify_waiters();
-                make_ok_response(ShutdownWorkerResponse::default())
-            } else {
-                tonic::Status::unimplemented(path.to_owned()).into_http()
-            }
-        }
-        .boxed()
-    })
-    .await;
-
-    let mut connection_options = get_integ_server_options();
-    connection_options.target = format!("http://localhost:{}", fs.addr.port())
-        .parse::<url::Url>()
-        .unwrap();
-    connection_options.set_skip_get_system_info(true);
-    connection_options.retry_options = RetryOptions::no_retries();
-    let connection = Connection::connect(connection_options).await.unwrap();
-    let client = Client::new(connection, ClientOptions::new("default").build()).unwrap();
-    let runtime =
-        CoreRuntime::new_assume_tokio(get_integ_runtime_options(get_integ_telem_options()))
-            .unwrap();
-    let options = WorkerOptions::new("workflow_only_shutdown")
-        .register_workflow::<ResourceBasedNonStickyWf>()
-        .unwrap()
-        .build();
-    let mut worker = temporalio_sdk::Worker::new(&runtime, client, options).unwrap();
-    let shutdown = worker.shutdown_handle();
-    let mut worker_run = Box::pin(worker.run());
-
-    tokio::select! {
-        _ = workflow_poll_started.notified() => {}
-        result = &mut worker_run => panic!("worker stopped before shutdown: {result:?}"),
-    }
-    shutdown();
-    let shutdown_result = tokio::time::timeout(Duration::from_secs(1), &mut worker_run).await;
-    fs.server_handle.abort();
-
-    shutdown_result
-        .expect("workflow-only worker should shut down without an activity poll loop")
-        .unwrap();
-    assert!(shutdown_rpc_started.load(Ordering::Relaxed));
 }
 
 #[test]

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -1,8 +1,9 @@
+use super::client_tests::make_ok_response;
 use crate::{
     common::{
         CoreWfStarter, activity_functions::StdActivities, fake_grpc_server::fake_server,
         get_integ_runtime_options, get_integ_server_options, get_integ_telem_options,
-        integ_namespace, mock_sdk_cfg,
+        integ_namespace,
     },
     shared_tests::{self, is_oversize_grpc_event},
 };
@@ -19,7 +20,7 @@ use std::{
     time::Duration,
 };
 use temporalio_client::{
-    Client, ClientOptions, Connection, PayloadLimitsOptions, WorkflowStartOptions,
+    Client, ClientOptions, Connection, PayloadLimitsOptions, RetryOptions, WorkflowStartOptions,
     errors::WorkflowGetResultError,
 };
 use temporalio_common::{
@@ -47,9 +48,11 @@ use temporalio_common::{
                     Attributes::{self as EventAttributes},
                 },
             },
+            namespace::v1::{NamespaceInfo, namespace_info::Capabilities},
             workflowservice::v1::{
-                GetWorkflowExecutionHistoryResponse, PollActivityTaskQueueResponse,
-                RespondActivityTaskCompletedResponse,
+                DescribeNamespaceResponse, GetWorkflowExecutionHistoryResponse,
+                PollActivityTaskQueueResponse, PollWorkflowTaskQueueResponse,
+                RespondActivityTaskCompletedResponse, ShutdownWorkerResponse,
             },
         },
     },
@@ -199,20 +202,20 @@ impl ResourceBasedNonStickyWf {
 async fn resource_based_few_pollers_guarantees_non_sticky_poll() {
     let wf_name = "resource_based_few_pollers_guarantees_non_sticky_poll";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     // 3 pollers so the minimum slots of 2 can both be handed out to a sticky poller
     starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::SimpleMaximum(3_usize));
     // Set the limits to zero so it's essentially unwilling to hand out slots
     let mut tuner = ResourceBasedTuner::new(0.0, 0.0);
     tuner.with_workflow_slots_options(ResourceSlotOptions::new(2, 10, Duration::from_millis(0)));
     starter.sdk_config.tuner = Arc::new(tuner);
+    starter
+        .sdk_config
+        .register_workflow::<ResourceBasedNonStickyWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
 
     // Workflow doesn't actually need to do anything. We just need to see that we don't get stuck
     // by assigning all slots to sticky pollers.
-    worker
-        .register_workflow::<ResourceBasedNonStickyWf>()
-        .unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     for i in 0..20 {
         worker
@@ -235,9 +238,7 @@ async fn oversize_grpc_message() {
     let (telemopts, addr, _aborter) = prom_metrics(None);
     let runtime = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
     let mut starter = CoreWfStarter::new_with_runtime(wf_name, runtime);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.sdk_config.disable_payload_error_limit = true;
-    let mut core = starter.worker().await;
 
     let has_run = Arc::new(AtomicBool::new(false));
     let has_run_clone = has_run.clone();
@@ -261,10 +262,13 @@ async fn oversize_grpc_message() {
         }
     }
 
-    core.register_workflow_with_factory(move || OversizeGrpcMessageWf {
-        has_run: has_run_clone.clone(),
-    })
-    .unwrap();
+    starter
+        .sdk_config
+        .register_workflow_with_factory(move || OversizeGrpcMessageWf {
+            has_run: has_run_clone.clone(),
+        })
+        .unwrap();
+    let mut core = starter.worker().await;
     starter
         .start_with_worker(OversizeGrpcMessageWf::name(), &mut core)
         .await;
@@ -328,8 +332,6 @@ fn is_wft_payloads_too_large(e: &HistoryEvent) -> bool {
 async fn oversize_wft_payload_fails_retryably_then_completes() {
     let wf_name = "oversize_wft_payload_retryable";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut core = starter.worker().await;
 
     let has_run = Arc::new(AtomicBool::new(false));
     let has_run_clone = has_run.clone();
@@ -351,10 +353,13 @@ async fn oversize_wft_payload_fails_retryably_then_completes() {
         }
     }
 
-    core.register_workflow_with_factory(move || OversizeWftWf {
-        has_run: has_run_clone.clone(),
-    })
-    .unwrap();
+    starter
+        .sdk_config
+        .register_workflow_with_factory(move || OversizeWftWf {
+            has_run: has_run_clone.clone(),
+        })
+        .unwrap();
+    let mut core = starter.worker().await;
     let handle = core
         .submit_workflow(OversizeWftWf::run, (), starter.workflow_options.clone())
         .await
@@ -404,6 +409,10 @@ async fn oversize_activity_result_fails_retryably_then_completes() {
     starter.sdk_config.register_activities(OversizeResultActs {
         max_attempt: max_attempt.clone(),
     });
+    starter
+        .sdk_config
+        .register_workflow_with_factory(|| OversizeActResultWf)
+        .unwrap();
     let mut core = starter.worker().await;
 
     #[workflow]
@@ -429,8 +438,6 @@ async fn oversize_activity_result_fails_retryably_then_completes() {
         }
     }
 
-    core.register_workflow_with_factory(|| OversizeActResultWf)
-        .unwrap();
     let handle = core
         .submit_workflow(
             OversizeActResultWf::run,
@@ -486,6 +493,10 @@ async fn oversize_activity_heartbeat_fails_retryably_then_completes() {
     starter.sdk_config.register_activities(OversizeHbActs {
         max_attempt: max_attempt.clone(),
     });
+    starter
+        .sdk_config
+        .register_workflow_with_factory(|| OversizeHbWf)
+        .unwrap();
     let mut core = starter.worker().await;
 
     #[workflow]
@@ -512,8 +523,6 @@ async fn oversize_activity_heartbeat_fails_retryably_then_completes() {
         }
     }
 
-    core.register_workflow_with_factory(|| OversizeHbWf)
-        .unwrap();
     let handle = core
         .submit_workflow(OversizeHbWf::run, (), starter.workflow_options.clone())
         .await
@@ -552,7 +561,10 @@ async fn warn_band_payload_is_logged_and_completes() {
 
     let wf_name = "warn_band_payload";
     let mut starter = CoreWfStarter::new_with_overrides(wf_name, Some(runtime), Some(client));
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow_with_factory(|| WarnBandWf)
+        .unwrap();
     let mut core = starter.worker().await;
 
     #[workflow]
@@ -565,7 +577,6 @@ async fn warn_band_payload_is_logged_and_completes() {
             Ok(vec![0u8; 256])
         }
     }
-    core.register_workflow_with_factory(|| WarnBandWf).unwrap();
     let handle = core
         .submit_workflow(WarnBandWf::run, (), starter.workflow_options.clone())
         .await
@@ -622,6 +633,10 @@ async fn disabled_error_limit_lets_server_hard_fail() {
         .register_activities(DisabledOversizeActs {
             max_attempt: max_attempt.clone(),
         });
+    starter
+        .sdk_config
+        .register_workflow_with_factory(|| DisabledOversizeWf)
+        .unwrap();
     let mut core = starter.worker().await;
 
     #[workflow]
@@ -646,8 +661,6 @@ async fn disabled_error_limit_lets_server_hard_fail() {
             Ok(())
         }
     }
-    core.register_workflow_with_factory(|| DisabledOversizeWf)
-        .unwrap();
     let handle = core
         .submit_workflow(
             DisabledOversizeWf::run,
@@ -762,16 +775,26 @@ async fn activity_tasks_from_completion_reserve_slots() {
         cfg.max_outstanding_activities = Some(2);
     });
     let core = Arc::new(mock_worker(mock));
-    let mut worker = crate::common::TestWorker::new(temporalio_sdk::Worker::new_from_core(
-        core.clone(),
-        DataConverter::default(),
-    ));
+    let workflow_complete_token = CancellationToken::new();
+    let workflow_complete_token_clone = workflow_complete_token.clone();
+    let wf_token = workflow_complete_token.clone();
+    let client_options = ClientOptions::new(core.get_config().namespace.clone())
+        .data_converter(DataConverter::default())
+        .build();
+    let worker_options = WorkerOptions::new(core.get_config().task_queue.clone())
+        .register_workflow_with_factory(move || ActivityTasksCompletionWf {
+            complete_token: wf_token.clone(),
+        })
+        .unwrap()
+        .build();
+    let mut worker = crate::common::TestWorker::new(
+        temporalio_sdk::Worker::new_from_core_options(core.clone(), client_options, worker_options)
+            .unwrap(),
+    );
 
     // First poll for activities twice, occupying both slots
     let at1 = core.poll_activity_task().await.unwrap();
     let at2 = core.poll_activity_task().await.unwrap();
-    let workflow_complete_token = CancellationToken::new();
-    let workflow_complete_token_clone = workflow_complete_token.clone();
 
     struct FakeAct;
     #[activities]
@@ -812,13 +835,6 @@ async fn activity_tasks_from_completion_reserve_slots() {
             Ok(())
         }
     }
-
-    let wf_token = workflow_complete_token.clone();
-    worker
-        .register_workflow_with_factory(move || ActivityTasksCompletionWf {
-            complete_token: wf_token.clone(),
-        })
-        .unwrap();
 
     let act_completer = async {
         barr.wait().await;
@@ -862,10 +878,6 @@ async fn max_wft_respected() {
         }
     });
     let mh = MockPollCfg::new(hists.into_iter().collect(), true, 0);
-    let mut worker = mock_sdk_cfg(mh, |cfg| {
-        cfg.max_cached_workflows = total_wfs as usize;
-        cfg.max_outstanding_workflow_tasks = Some(1);
-    });
     static ACTIVE_COUNT: Semaphore = Semaphore::const_new(1);
 
     #[workflow]
@@ -886,7 +898,16 @@ async fn max_wft_respected() {
         }
     }
 
-    worker.register_workflow::<MaxWftWf>().unwrap();
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |cfg| {
+            cfg.max_cached_workflows = total_wfs as usize;
+            cfg.max_outstanding_workflow_tasks = Some(1);
+        },
+        |options| {
+            options.register_workflow::<MaxWftWf>().unwrap();
+        },
+    );
     worker.run_until_done().await.unwrap();
 }
 
@@ -961,11 +982,6 @@ async fn history_length_with_fail_and_timeout(
         // Expect the failed pagination fetch
         mh.num_expected_fails = 1;
     }
-    let mut worker = mock_sdk_cfg(mh, |wc| {
-        if use_cache {
-            wc.max_cached_workflows = 1;
-        }
-    });
     #[workflow]
     #[derive(Default)]
     struct HistoryLengthWf;
@@ -983,7 +999,17 @@ async fn history_length_with_fail_and_timeout(
         }
     }
 
-    worker.register_workflow::<HistoryLengthWf>().unwrap();
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |wc| {
+            if use_cache {
+                wc.max_cached_workflows = 1;
+            }
+        },
+        |options| {
+            options.register_workflow::<HistoryLengthWf>().unwrap();
+        },
+    );
     if force_failed_fetch_after_eviction {
         struct FirstCompletionNotifier(CancellationToken);
 
@@ -1045,13 +1071,16 @@ async fn sets_build_id_from_wft_complete() {
     t.add_workflow_task_scheduled_and_started();
 
     let mock = mock_worker_client();
-    let mut worker = mock_sdk_cfg(
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
         MockPollCfg::from_resp_batches(wfid, t, [ResponseType::AllHistory], mock),
         |cfg| {
             cfg.versioning_strategy = WorkerVersioningStrategy::None {
                 build_id: "fierce-predator".to_string(),
             };
             cfg.max_cached_workflows = 1;
+        },
+        |options| {
+            options.register_workflow::<BuildIdWf>().unwrap();
         },
     );
 
@@ -1085,7 +1114,6 @@ async fn sets_build_id_from_wft_complete() {
         }
     }
 
-    worker.register_workflow::<BuildIdWf>().unwrap();
     worker.run_until_done().await.unwrap();
 }
 
@@ -1196,6 +1224,10 @@ async fn test_custom_slot_supplier_simple() {
     tb.activity_slot_supplier(activity_supplier.clone());
     tb.local_activity_slot_supplier(local_activity_supplier.clone());
     starter.sdk_config.tuner = Arc::new(tb.build());
+    starter
+        .sdk_config
+        .register_workflow::<SlotSupplierWorkflow>()
+        .unwrap();
 
     let mut worker = starter.worker().await;
 
@@ -1226,8 +1258,6 @@ async fn test_custom_slot_supplier_simple() {
             Ok(())
         }
     }
-
-    worker.register_workflow::<SlotSupplierWorkflow>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -1400,6 +1430,80 @@ async fn shutdown_worker_not_retried() {
     let worker = starter.get_worker().await;
     drain_pollers_and_shutdown(&worker).await;
     assert_eq!(shutdown_call_count.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn high_level_workflow_only_worker_shuts_down() {
+    let workflow_poll_started = Arc::new(Notify::new());
+    let workflow_poll_started_for_server = workflow_poll_started.clone();
+    let shutdown_rpc_started = Arc::new(AtomicBool::new(false));
+    let shutdown_rpc_started_for_server = shutdown_rpc_started.clone();
+    let release_workflow_polls = Arc::new(Notify::new());
+    let release_workflow_polls_for_server = release_workflow_polls.clone();
+    let fs = fake_server(move |req| {
+        let workflow_poll_started = workflow_poll_started_for_server.clone();
+        let shutdown_rpc_started = shutdown_rpc_started_for_server.clone();
+        let release_workflow_polls = release_workflow_polls_for_server.clone();
+        async move {
+            let path = req.uri().path();
+            if path.contains("DescribeNamespace") {
+                make_ok_response(DescribeNamespaceResponse {
+                    namespace_info: Some(NamespaceInfo {
+                        capabilities: Some(Capabilities {
+                            worker_poll_complete_on_shutdown: true,
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })
+            } else if path.contains("PollWorkflowTaskQueue") {
+                workflow_poll_started.notify_one();
+                release_workflow_polls.notified().await;
+                make_ok_response(PollWorkflowTaskQueueResponse::default())
+            } else if path.contains("ShutdownWorker") {
+                shutdown_rpc_started.store(true, Ordering::Relaxed);
+                release_workflow_polls.notify_waiters();
+                make_ok_response(ShutdownWorkerResponse::default())
+            } else {
+                tonic::Status::unimplemented(path.to_owned()).into_http()
+            }
+        }
+        .boxed()
+    })
+    .await;
+
+    let mut connection_options = get_integ_server_options();
+    connection_options.target = format!("http://localhost:{}", fs.addr.port())
+        .parse::<url::Url>()
+        .unwrap();
+    connection_options.set_skip_get_system_info(true);
+    connection_options.retry_options = RetryOptions::no_retries();
+    let connection = Connection::connect(connection_options).await.unwrap();
+    let client = Client::new(connection, ClientOptions::new("default").build()).unwrap();
+    let runtime =
+        CoreRuntime::new_assume_tokio(get_integ_runtime_options(get_integ_telem_options()))
+            .unwrap();
+    let options = WorkerOptions::new("workflow_only_shutdown")
+        .register_workflow::<ResourceBasedNonStickyWf>()
+        .unwrap()
+        .build();
+    let mut worker = temporalio_sdk::Worker::new(&runtime, client, options).unwrap();
+    let shutdown = worker.shutdown_handle();
+    let mut worker_run = Box::pin(worker.run());
+
+    tokio::select! {
+        _ = workflow_poll_started.notified() => {}
+        result = &mut worker_run => panic!("worker stopped before shutdown: {result:?}"),
+    }
+    shutdown();
+    let shutdown_result = tokio::time::timeout(Duration::from_secs(1), &mut worker_run).await;
+    fs.server_handle.abort();
+
+    shutdown_result
+        .expect("workflow-only worker should shut down without an activity poll loop")
+        .unwrap();
+    assert!(shutdown_rpc_started.load(Ordering::Relaxed));
 }
 
 #[test]

--- a/crates/sdk-core/tests/integ_tests/worker_versioning_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_versioning_tests.rs
@@ -46,7 +46,7 @@ async fn sets_deployment_info_on_task_responses(#[values(true, false)] use_defau
         .use_worker_versioning(true)
         .default_versioning_behavior(VersioningBehavior::AutoUpgrade)
         .build();
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter.set_core_task_types(WorkerTaskTypes::workflow_only());
     let core = starter.get_worker().await;
     let client = starter.get_client().await;
 
@@ -181,12 +181,12 @@ async fn activity_has_deployment_stamp() {
     .default_versioning_behavior(VersioningBehavior::AutoUpgrade)
     .build();
     starter.sdk_config.register_activities(StdActivities);
-    let mut worker = starter.worker().await;
-    let client = starter.get_client().await;
-
-    worker
+    starter
+        .sdk_config
         .register_workflow::<ActivityHasDeploymentStampWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
+    let client = starter.get_client().await;
     let submitter = worker.get_submitter_handle();
     let shutdown_handle = worker.inner_mut().shutdown_handle();
 
@@ -273,7 +273,7 @@ async fn versioning_off_with_custom_build_id() {
         build_id: build_id.to_string(),
     })
     .build();
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter.set_core_task_types(WorkerTaskTypes::workflow_only());
     let core = starter.get_worker().await;
     starter.start_wf().await;
 
@@ -369,19 +369,18 @@ async fn continue_as_new_auto_upgrade_uses_current_deployment_version() {
         build_id: "2.0".to_string(),
     };
     starter.sdk_config.deployment_options = versioned_worker_options(v1.clone());
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker1 = starter.worker().await;
-    worker1
-        .register_workflow::<ContinueAsNewAutoUpgradeV1>()
-        .unwrap();
-
     let mut starter2 = starter.clone_no_worker();
     starter2.sdk_config.deployment_options = versioned_worker_options(v2.clone());
-    starter2.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker2 = starter2.worker().await;
-    worker2
+    starter
+        .sdk_config
+        .register_workflow::<ContinueAsNewAutoUpgradeV1>()
+        .unwrap();
+    starter2
+        .sdk_config
         .register_workflow::<ContinueAsNewAutoUpgradeV2>()
         .unwrap();
+    let mut worker1 = starter.worker().await;
+    let mut worker2 = starter2.worker().await;
 
     let client = starter.get_client().await;
     let task_queue = starter.get_task_queue().to_owned();
@@ -497,19 +496,18 @@ async fn continue_as_new_use_ramping_version_uses_ramping_deployment_version() {
         build_id: "2.0".to_string(),
     };
     starter.sdk_config.deployment_options = versioned_worker_options(v1.clone());
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker1 = starter.worker().await;
-    worker1
-        .register_workflow::<ContinueAsNewUseRampingVersionV1>()
-        .unwrap();
-
     let mut starter2 = starter.clone_no_worker();
     starter2.sdk_config.deployment_options = versioned_worker_options(v2.clone());
-    starter2.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker2 = starter2.worker().await;
-    worker2
+    starter
+        .sdk_config
+        .register_workflow::<ContinueAsNewUseRampingVersionV1>()
+        .unwrap();
+    starter2
+        .sdk_config
         .register_workflow::<ContinueAsNewUseRampingVersionV2>()
         .unwrap();
+    let mut worker1 = starter.worker().await;
+    let mut worker2 = starter2.worker().await;
 
     let client = starter.get_client().await;
     let task_queue = starter.get_task_queue().to_owned();

--- a/crates/sdk-core/tests/integ_tests/worker_versioning_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_versioning_tests.rs
@@ -47,8 +47,8 @@ async fn sets_deployment_info_on_task_responses(#[values(true, false)] use_defau
         .default_versioning_behavior(VersioningBehavior::AutoUpgrade)
         .build();
     starter.set_core_task_types(WorkerTaskTypes::workflow_only());
-    let core = starter.get_worker().await;
-    let client = starter.get_client().await;
+    let core = starter.get_core_worker().await;
+    let client = starter.get_core_client().await;
 
     // A bit annoying. We have to start up polling here so that the deployment will exist before
     // we can describe it and then set the current version.
@@ -186,7 +186,7 @@ async fn activity_has_deployment_stamp() {
         .register_workflow::<ActivityHasDeploymentStampWf>()
         .unwrap();
     let mut worker = starter.worker().await;
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let submitter = worker.get_submitter_handle();
     let shutdown_handle = worker.inner_mut().shutdown_handle();
 
@@ -274,7 +274,7 @@ async fn versioning_off_with_custom_build_id() {
     })
     .build();
     starter.set_core_task_types(WorkerTaskTypes::workflow_only());
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     starter.start_wf().await;
 
     let res = core.poll_workflow_activation().await.unwrap();
@@ -382,7 +382,7 @@ async fn continue_as_new_auto_upgrade_uses_current_deployment_version() {
     let mut worker1 = starter.worker().await;
     let mut worker2 = starter2.worker().await;
 
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let task_queue = starter.get_task_queue().to_owned();
     let workflow_id = starter.get_wf_id();
     let shutdown1 = worker1.inner_mut().shutdown_handle();
@@ -509,7 +509,7 @@ async fn continue_as_new_use_ramping_version_uses_ramping_deployment_version() {
     let mut worker1 = starter.worker().await;
     let mut worker2 = starter2.worker().await;
 
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let task_queue = starter.get_task_queue().to_owned();
     let workflow_id = starter.get_wf_id();
     let shutdown1 = worker1.inner_mut().shutdown_handle();

--- a/crates/sdk-core/tests/integ_tests/workflow_client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_client_tests.rs
@@ -13,7 +13,7 @@ use temporalio_client::{
     WorkflowCountOptions, WorkflowListOptions, WorkflowStartOptions, WorkflowTerminateOptions,
     errors::WorkflowStartError,
 };
-use temporalio_common::{data_converters::RawValue, worker::WorkerTaskTypes};
+use temporalio_common::data_converters::RawValue;
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{WorkflowContext, WorkflowResult};
 
@@ -98,10 +98,12 @@ async fn client_interceptor_start_workflow() {
 async fn list_workflows(#[case] limit: Option<usize>) {
     let test_name = "list_workflows_returns_started_workflows";
     let mut starter = CoreWfStarter::new(test_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<EmptyWorkflow>()
+        .unwrap();
     let client = starter.get_client().await;
     let mut worker = starter.worker().await;
-    worker.register_workflow::<EmptyWorkflow>().unwrap();
 
     let suffix = rand_6_chars();
     let num_workflows = 5;

--- a/crates/sdk-core/tests/integ_tests/workflow_client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_client_tests.rs
@@ -65,7 +65,7 @@ impl ClientInterceptor for StartWorkflowInterceptor {
 async fn client_interceptor_start_workflow() {
     let test_name = "client_interceptor_start_workflow";
     let mut starter = CoreWfStarter::new(test_name);
-    let mut client = starter.get_client().await;
+    let mut client = starter.get_core_client().await;
     let calls = Arc::new(AtomicUsize::new(0));
     client
         .options_mut()
@@ -102,8 +102,8 @@ async fn list_workflows(#[case] limit: Option<usize>) {
         .sdk_config
         .register_workflow::<EmptyWorkflow>()
         .unwrap();
-    let client = starter.get_client().await;
     let mut worker = starter.worker().await;
+    let client = starter.get_core_client().await;
 
     let suffix = rand_6_chars();
     let num_workflows = 5;
@@ -214,7 +214,7 @@ async fn list_workflows(#[case] limit: Option<usize>) {
 async fn already_started_error_contains_run_id() {
     let test_name = "already_started_error_contains_run_id";
     let mut starter = CoreWfStarter::new(test_name);
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let task_queue = starter.get_task_queue().to_owned();
     let wf_id = format!("{test_name}_{}", rand_6_chars());
 

--- a/crates/sdk-core/tests/integ_tests/workflow_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests.rs
@@ -121,7 +121,7 @@ async fn parallel_workflows_same_queue() {
 #[tokio::test]
 async fn shutdown_aborts_actively_blocked_poll() {
     let mut starter = CoreWfStarter::new("shutdown_aborts_actively_blocked_poll");
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     // Begin the poll, and request shutdown from another thread after a small period of time.
     let tcore = core.clone();
     let handle = tokio::spawn(async move {
@@ -159,7 +159,7 @@ async fn fail_wf_task(#[values(true, false)] replay: bool) {
         Arc::new(init_core_replay_preloaded("fail_wf_task", [hist, hist2]))
     } else {
         let mut starter = init_core_and_create_wf("fail_wf_task").await;
-        starter.get_worker().await
+        starter.get_core_worker().await
     };
     // Start with a timer
     let task = core.poll_workflow_activation().await.unwrap();
@@ -202,7 +202,7 @@ async fn fail_wf_task(#[values(true, false)] replay: bool) {
 async fn fail_workflow_execution() {
     let core = init_core_and_create_wf("fail_workflow_execution")
         .await
-        .get_worker()
+        .get_core_worker()
         .await;
     let task = core.poll_workflow_activation().await.unwrap();
     core.complete_timer(&task.run_id, 0, Duration::from_secs(1))
@@ -224,8 +224,8 @@ async fn fail_workflow_execution() {
 #[tokio::test]
 async fn signal_workflow() {
     let mut starter = init_core_and_create_wf("signal_workflow").await;
-    let core = starter.get_worker().await;
-    let client = starter.get_client().await;
+    let core = starter.get_core_worker().await;
+    let client = starter.get_core_client().await;
     let workflow_id = starter.get_task_queue().to_string();
 
     let signal_id_1 = "signal1";
@@ -307,7 +307,7 @@ async fn signal_workflow() {
 async fn signal_workflow_signal_not_handled_on_workflow_completion() {
     let mut starter =
         init_core_and_create_wf("signal_workflow_signal_not_handled_on_workflow_completion").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let workflow_id = starter.get_task_queue().to_string();
     let signal_id_1 = "signal1";
     for i in 1..=2 {
@@ -340,7 +340,7 @@ async fn signal_workflow_signal_not_handled_on_workflow_completion() {
             let run_id = res.run_id.clone();
 
             // Send the signal to the server
-            let sig_client = starter.get_client().await;
+            let sig_client = starter.get_core_client().await;
             WorkflowExecutionInfo {
                 namespace: sig_client.namespace(),
                 workflow_id: workflow_id.clone(),
@@ -393,8 +393,8 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
     wf_starter.sdk_config.workflow_task_poller_behavior =
         Some(PollerBehavior::SimpleMaximum(1_usize));
     wf_starter.workflow_options.task_timeout = Some(Duration::from_secs(1));
-    let core = wf_starter.get_worker().await;
-    let client = wf_starter.get_client().await;
+    let core = wf_starter.get_core_worker().await;
+    let client = wf_starter.get_core_client().await;
     let task_q = wf_starter.get_task_queue();
     let wf_id = &wf_starter.get_wf_id().to_owned();
 
@@ -573,9 +573,9 @@ async fn deployment_version_correct_in_wf_info(#[values(true, false)] use_only_b
         .build()
     };
     starter.set_core_task_types(WorkerTaskTypes::workflow_only());
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     starter.start_wf().await;
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let workflow_id = starter.get_task_queue().to_string();
 
     let res = core.poll_workflow_activation().await.unwrap();
@@ -689,7 +689,7 @@ async fn deployment_version_correct_in_wf_info(#[values(true, false)] use_only_b
         .build()
     };
 
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
 
     let query_fut = async {
         query_handle
@@ -833,7 +833,7 @@ async fn nondeterminism_errors_fail_workflow_when_configured_to(
         }
     }
 
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let core_worker = worker.core_worker();
     starter.start_with_worker(wf_name, &mut worker).await;
 
@@ -1030,7 +1030,7 @@ async fn history_out_of_order_on_restart() {
     join!(w1, w2);
     // The workflow should fail with the nondeterminism error
     let handle = starter
-        .get_client()
+        .get_core_client()
         .await
         .get_workflow_handle::<UntypedWorkflow>(wf_name);
     let res = handle.get_result(Default::default()).await;

--- a/crates/sdk-core/tests/integ_tests/workflow_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests.rs
@@ -24,7 +24,7 @@ use crate::{
     common::{
         CoreWfStarter, activity_functions::StdActivities, get_integ_runtime_options,
         history_from_proto_binary, init_core_and_create_wf, init_core_replay_preloaded,
-        mock_sdk_cfg, prom_metrics,
+        prom_metrics,
     },
     integ_tests::metrics_tests,
 };
@@ -97,10 +97,11 @@ impl ParallelWorkflowsWf {
 async fn parallel_workflows_same_queue() {
     let wf_name = "parallel_workflows_same_queue";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<ParallelWorkflowsWf>()
+        .unwrap();
     let mut core = starter.worker().await;
-
-    core.register_workflow::<ParallelWorkflowsWf>().unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     for i in 0..25 {
         core.submit_workflow(
@@ -520,11 +521,12 @@ async fn slow_completes_with_small_cache() {
     let mut starter = CoreWfStarter::new(wf_name);
     starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(5, 10, 1, 1));
     starter.sdk_config.max_cached_workflows = 5_usize;
+    starter.sdk_config.register_activities(StdActivities);
+    starter
+        .sdk_config
+        .register_workflow::<SlowCompletesWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
-
-    worker.register_activities(StdActivities);
-
-    worker.register_workflow::<SlowCompletesWf>().unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     for i in 0..20 {
         worker
@@ -570,7 +572,7 @@ async fn deployment_version_correct_in_wf_info(#[values(true, false)] use_only_b
         })
         .build()
     };
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter.set_core_task_types(WorkerTaskTypes::workflow_only());
     let core = starter.get_worker().await;
     starter.start_wf().await;
     let client = starter.get_client().await;
@@ -802,7 +804,6 @@ async fn nondeterminism_errors_fail_workflow_when_configured_to(
     let rt = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
     let wf_name = NONDETERMINISM_WF_NAME;
     let mut starter = CoreWfStarter::new_with_runtime(wf_name, rt);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     let typeset = HashSet::from([WorkflowErrorType::Nondeterminism]);
     if whole_worker {
         starter.sdk_config.workflow_failure_errors = typeset;
@@ -810,6 +811,11 @@ async fn nondeterminism_errors_fail_workflow_when_configured_to(
         starter.sdk_config.workflow_types_to_failure_errors =
             HashMap::from([(wf_name.to_owned(), typeset)]);
     }
+    let restarted_starter = starter.clone_no_worker();
+    starter
+        .sdk_config
+        .register_workflow::<NondeterminismTimerWf>()
+        .unwrap();
     let wf_id = starter.get_task_queue().to_owned();
     let mut worker = starter.worker().await;
     worker.fetch_results = false;
@@ -827,7 +833,6 @@ async fn nondeterminism_errors_fail_workflow_when_configured_to(
         }
     }
 
-    worker.register_workflow::<NondeterminismTimerWf>().unwrap();
     let client = starter.get_client().await;
     let core_worker = worker.core_worker();
     starter.start_with_worker(wf_name, &mut worker).await;
@@ -853,8 +858,12 @@ async fn nondeterminism_errors_fail_workflow_when_configured_to(
     join!(stopper, runner);
 
     // Restart the worker with a new, incompatible wf definition which will cause nondeterminism
-    let mut starter = starter.clone_no_worker();
+    let mut starter = restarted_starter;
     starter.sdk_config.register_activities(StdActivities);
+    starter
+        .sdk_config
+        .register_workflow::<NondeterminismActivityWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
 
     #[workflow]
@@ -875,9 +884,6 @@ async fn nondeterminism_errors_fail_workflow_when_configured_to(
         }
     }
 
-    worker
-        .register_workflow::<NondeterminismActivityWf>()
-        .unwrap();
     // We need to generate a task so that we'll encounter the error (first avoid WFT timeout)
     WorkflowService::reset_sticky_task_queue(
         &mut client.clone(),
@@ -921,9 +927,8 @@ async fn history_out_of_order_on_restart() {
     let wf_name = HISTORY_OUT_OF_ORDER_WF_NAME;
     let mut starter = CoreWfStarter::new(wf_name);
     starter.sdk_config.workflow_failure_errors = HashSet::from([WorkflowErrorType::Nondeterminism]);
-    let mut worker = starter.worker().await;
+    starter.sdk_config.register_activities(StdActivities);
     let mut starter2 = starter.clone_no_worker();
-    let mut worker2 = starter2.worker().await;
 
     let hit_sleep = Arc::new(Notify::new());
     let hit_sleep_clone1 = hit_sleep.clone();
@@ -987,14 +992,18 @@ async fn history_out_of_order_on_restart() {
         }
     }
 
-    worker.register_activities(StdActivities);
-    worker2.register_activities(StdActivities);
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || HistoryOutOfOrderWf1 {
             hit_sleep: hit_sleep_clone1.clone(),
         })
         .unwrap();
-    worker2.register_workflow::<HistoryOutOfOrderWf2>().unwrap();
+    starter2
+        .sdk_config
+        .register_workflow::<HistoryOutOfOrderWf2>()
+        .unwrap();
+    let mut worker = starter.worker().await;
+    let mut worker2 = starter2.worker().await;
     let task_queue = starter.get_task_queue().to_owned();
     worker
         .submit_workflow(
@@ -1071,8 +1080,13 @@ async fn pass_timer_summary_to_metadata() {
         }
     }
 
-    let mut worker = mock_sdk_cfg(mock_cfg, |_| {});
-    worker.register_workflow::<PassTimerSummaryWf>().unwrap();
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mock_cfg,
+        |_| {},
+        |options| {
+            options.register_workflow::<PassTimerSummaryWf>().unwrap();
+        },
+    );
     worker
         .submit_wf(
             DEFAULT_WORKFLOW_TYPE.to_owned(),

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -1,8 +1,8 @@
 use crate::{
     common::{
         ActivationAssertionsInterceptor, CoreWfStarter, INTEG_CLIENT_IDENTITY,
-        activity_functions::StdActivities, build_fake_sdk_intercepted, init_core_and_create_wf,
-        mock_sdk, mock_sdk_cfg,
+        activity_functions::StdActivities, build_fake_sdk_intercepted, eventually,
+        init_core_and_create_wf, mock_sdk, mock_sdk_cfg,
     },
     shared_tests,
 };
@@ -1030,6 +1030,10 @@ async fn workflow_observes_non_retryable_activity() {
     starter
         .sdk_config
         .register_activities(NonRetryableActivityErrorActivities);
+    starter
+        .sdk_config
+        .register_workflow::<NonRetryableActivityFailureWorkflow>()
+        .unwrap();
     let mut worker = starter.worker().await;
 
     #[workflow]
@@ -1086,10 +1090,6 @@ async fn workflow_observes_non_retryable_activity() {
             ))
         }
     }
-
-    worker
-        .register_workflow::<NonRetryableActivityFailureWorkflow>()
-        .unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -1827,6 +1827,10 @@ async fn graceful_shutdown() {
         acts_started: acts_started.clone(),
         acts_done: acts_done.clone(),
     });
+    starter
+        .sdk_config
+        .register_workflow::<GracefulShutdownWorkflow>()
+        .unwrap();
     let mut worker = starter.worker().await;
     let client = starter.get_client().await;
 
@@ -1855,10 +1859,6 @@ async fn graceful_shutdown() {
             Ok(())
         }
     }
-
-    worker
-        .register_workflow::<GracefulShutdownWorkflow>()
-        .unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -1922,6 +1922,10 @@ async fn activity_can_be_cancelled_by_local_timeout() {
         .register_activities(CancellableEchoActivities {
             was_cancelled: was_cancelled.clone(),
         });
+    starter
+        .sdk_config
+        .register_workflow::<ActivityLocalTimeoutWorkflow>()
+        .unwrap();
     let mut worker = starter.worker().await;
 
     #[workflow]
@@ -1961,10 +1965,6 @@ async fn activity_can_be_cancelled_by_local_timeout() {
         }
     }
 
-    worker
-        .register_workflow::<ActivityLocalTimeoutWorkflow>()
-        .unwrap();
-
     let task_queue = starter.get_task_queue().to_owned();
     worker
         .submit_workflow(
@@ -1998,6 +1998,10 @@ async fn long_activity_timeout_repro() {
     starter
         .set_core_cfg_mutator(|m| m.local_timeout_buffer_for_activities = Duration::from_secs(0));
     starter.sdk_config.register_activities(StdActivities);
+    starter
+        .sdk_config
+        .register_workflow::<LongActivityTimeoutReproWorkflow>()
+        .unwrap();
     let mut worker = starter.worker().await;
 
     #[workflow]
@@ -2032,10 +2036,6 @@ async fn long_activity_timeout_repro() {
         }
     }
 
-    worker
-        .register_workflow::<LongActivityTimeoutReproWorkflow>()
-        .unwrap();
-
     starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
 }
@@ -2069,8 +2069,6 @@ async fn pass_activity_summary_to_metadata() {
             });
     });
 
-    let mut worker = mock_sdk_cfg(mock_cfg, |_| {});
-
     #[workflow]
     #[derive(Default)]
     struct ActivitySummaryWorkflow;
@@ -2091,9 +2089,15 @@ async fn pass_activity_summary_to_metadata() {
         }
     }
 
-    worker
-        .register_workflow::<ActivitySummaryWorkflow>()
-        .unwrap();
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mock_cfg,
+        |_| {},
+        |options| {
+            options
+                .register_workflow::<ActivitySummaryWorkflow>()
+                .unwrap();
+        },
+    );
     let task_queue = worker.inner_mut().task_queue().to_owned();
     worker
         .submit_wf(
@@ -2132,8 +2136,6 @@ async fn abandoned_activities_ignore_start_and_complete(hist_batches: &'static [
     t.add_full_wf_task();
     t.add_workflow_execution_completed();
     let mock = mock_worker_client();
-    let mut worker = mock_sdk(MockPollCfg::from_resp_batches(wfid, t, hist_batches, mock));
-
     #[workflow]
     #[derive(Default)]
     struct AbandonedActivitiesWorkflow;
@@ -2166,9 +2168,15 @@ async fn abandoned_activities_ignore_start_and_complete(hist_batches: &'static [
         }
     }
 
-    worker
-        .register_workflow::<AbandonedActivitiesWorkflow>()
-        .unwrap();
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        MockPollCfg::from_resp_batches(wfid, t, hist_batches, mock),
+        |_| {},
+        |options| {
+            options
+                .register_workflow::<AbandonedActivitiesWorkflow>()
+                .unwrap();
+        },
+    );
     let task_queue = worker.inner_mut().task_queue().to_owned();
     worker
         .submit_wf(
@@ -2237,11 +2245,15 @@ async fn immediate_activity_cancelation() {
         )
     });
 
-    let mut worker =
-        build_fake_sdk_intercepted(MockPollCfg::from_resps(t, [ResponseType::AllHistory]), aai);
-    worker
-        .register_workflow::<ImmediateActivityCancelationWorkflow>()
-        .unwrap();
+    let mut worker = crate::common::build_fake_sdk_intercepted_with_options(
+        MockPollCfg::from_resps(t, [ResponseType::AllHistory]),
+        aai,
+        |options| {
+            options
+                .register_workflow::<ImmediateActivityCancelationWorkflow>()
+                .unwrap();
+        },
+    );
 
     worker.run().await.unwrap();
 }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -1,8 +1,7 @@
 use crate::{
     common::{
         ActivationAssertionsInterceptor, CoreWfStarter, INTEG_CLIENT_IDENTITY,
-        activity_functions::StdActivities, build_fake_sdk_intercepted, eventually,
-        init_core_and_create_wf, mock_sdk, mock_sdk_cfg,
+        activity_functions::StdActivities, init_core_and_create_wf,
     },
     shared_tests,
 };
@@ -828,7 +827,7 @@ async fn unregistered_activity_type_fails_activity_task_not_worker() {
 #[tokio::test]
 async fn activity_workflow() {
     let mut starter = init_core_and_create_wf("activity_workflow").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let task_q = starter.get_task_queue();
     let activity_id = "act-1";
     let task = core.poll_workflow_activation().await.unwrap();
@@ -893,7 +892,7 @@ async fn activity_workflow() {
 #[tokio::test]
 async fn activity_non_retryable_failure() {
     let mut starter = init_core_and_create_wf("activity_non_retryable_failure").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let task_q = starter.get_task_queue();
     let activity_id = "act-1";
     let task = core.poll_workflow_activation().await.unwrap();
@@ -960,7 +959,7 @@ async fn activity_non_retryable_failure() {
 #[tokio::test]
 async fn activity_non_retryable_failure_with_error() {
     let mut starter = init_core_and_create_wf("activity_non_retryable_failure").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let task_q = starter.get_task_queue();
     let activity_id = "act-1";
     let task = core.poll_workflow_activation().await.unwrap();
@@ -1106,7 +1105,7 @@ async fn workflow_observes_non_retryable_activity() {
 #[tokio::test]
 async fn activity_retry() {
     let mut starter = init_core_and_create_wf("activity_retry").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let task_q = starter.get_task_queue();
     let activity_id = "act-1";
     let task = core.poll_workflow_activation().await.unwrap();
@@ -1172,7 +1171,7 @@ async fn activity_retry() {
 #[tokio::test]
 async fn activity_cancellation_try_cancel() {
     let mut starter = init_core_and_create_wf("activity_cancellation_try_cancel").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let task_q = starter.get_task_queue();
     let activity_id = "act-1";
     let task = core.poll_workflow_activation().await.unwrap();
@@ -1229,7 +1228,7 @@ async fn activity_cancellation_try_cancel() {
 async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
     let mut starter =
         init_core_and_create_wf("activity_cancellation_plus_complete_doesnt_double_resolve").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let task_q = starter.get_task_queue();
     let activity_id = "act-1";
     let task = core.poll_workflow_activation().await.unwrap();
@@ -1321,7 +1320,7 @@ async fn activity_cancellation_plus_complete_doesnt_double_resolve() {
 #[tokio::test]
 async fn started_activity_timeout() {
     let mut starter = init_core_and_create_wf("started_activity_timeout").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let task_q = starter.get_task_queue();
     let activity_id = "act-1";
     let task = core.poll_workflow_activation().await.unwrap();
@@ -1373,7 +1372,7 @@ async fn started_activity_timeout() {
 async fn activity_cancellation_wait_cancellation_completed() {
     let mut starter =
         init_core_and_create_wf("activity_cancellation_wait_cancellation_completed").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let task_q = starter.get_task_queue();
     let activity_id = "act-1";
     let task = core.poll_workflow_activation().await.unwrap();
@@ -1435,7 +1434,7 @@ async fn activity_cancellation_wait_cancellation_completed() {
 #[tokio::test]
 async fn activity_cancellation_abandon() {
     let mut starter = init_core_and_create_wf("activity_cancellation_abandon").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let task_q = starter.get_task_queue();
     let activity_id = "act-1";
     let task = core.poll_workflow_activation().await.unwrap();
@@ -1493,7 +1492,7 @@ async fn activity_cancellation_abandon() {
 #[tokio::test]
 async fn async_activity_completion_workflow() {
     let mut starter = init_core_and_create_wf("async_activity_workflow").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let task_q = starter.get_task_queue();
     let activity_id = "act-1";
     let task = core.poll_workflow_activation().await.unwrap();
@@ -1527,7 +1526,7 @@ async fn async_activity_completion_workflow() {
     .await
     .unwrap();
     starter
-        .get_client()
+        .get_core_client()
         .await
         .get_async_activity_handle(ActivityIdentifier::TaskToken(task.task_token.into()))
         .complete(
@@ -1560,7 +1559,7 @@ async fn async_activity_completion_workflow() {
 #[tokio::test]
 async fn activity_cancelled_after_heartbeat_times_out() {
     let mut starter = init_core_and_create_wf("activity_cancelled_after_heartbeat_times_out").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let task_q = starter.get_task_queue().to_string();
     let activity_id = "act-1";
     let task = core.poll_workflow_activation().await.unwrap();
@@ -1612,7 +1611,7 @@ async fn activity_cancelled_after_heartbeat_times_out() {
     drain_pollers_and_shutdown(&core).await;
     // Cleanup just in case
     starter
-        .get_client()
+        .get_core_client()
         .await
         .get_workflow_handle::<UntypedWorkflow>(task_q)
         .terminate(WorkflowTerminateOptions::default())
@@ -1624,7 +1623,7 @@ async fn activity_cancelled_after_heartbeat_times_out() {
 async fn activity_failure_includes_latest_heartbeat_on_retry() {
     let mut starter =
         init_core_and_create_wf("activity_failure_includes_latest_heartbeat_on_retry").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let task_q = starter.get_task_queue().to_string();
     let task = core.poll_workflow_activation().await.unwrap();
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
@@ -1832,7 +1831,7 @@ async fn graceful_shutdown() {
         .register_workflow::<GracefulShutdownWorkflow>()
         .unwrap();
     let mut worker = starter.worker().await;
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
 
     #[workflow]
     #[derive(Default)]

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_external.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_external.rs
@@ -1,11 +1,8 @@
-use crate::common::{CoreWfStarter, build_fake_sdk};
+use crate::common::CoreWfStarter;
 use temporalio_client::WorkflowStartOptions;
-use temporalio_common::{
-    protos::{
-        coresdk::common::NamespacedWorkflowExecution,
-        temporal::api::enums::v1::{CommandType, EventType},
-    },
-    worker::WorkerTaskTypes,
+use temporalio_common::protos::{
+    coresdk::common::NamespacedWorkflowExecution,
+    temporal::api::enums::v1::{CommandType, EventType},
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{WorkflowContext, WorkflowResult};
@@ -47,10 +44,15 @@ impl CancelReceiver {
 #[tokio::test]
 async fn sends_cancel_to_other_wf() {
     let mut starter = CoreWfStarter::new("sends_cancel_to_other_wf");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<CancelSender>()
+        .unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<CancelReceiver>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<CancelSender>().unwrap();
-    worker.register_workflow::<CancelReceiver>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     let receiver_wfid = "sends-cancel-receiver";
@@ -157,7 +159,8 @@ async fn sends_cancel_canned(#[case] fails: bool) {
                 }
             });
     });
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<CancelSenderCanned>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<CancelSenderCanned>().unwrap();
+    });
     worker.run().await.unwrap();
 }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_wf.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_wf.rs
@@ -47,7 +47,7 @@ async fn cancel_during_timer() {
         .register_workflow::<CancelledWf>()
         .unwrap();
     let mut worker = starter.worker().await;
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let task_queue = starter.get_task_queue().to_owned();
     let wf_id = task_queue.clone();
     let wf_handle = worker

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_wf.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_wf.rs
@@ -1,15 +1,12 @@
-use crate::common::{ActivationAssertionsInterceptor, CoreWfStarter, build_fake_sdk_intercepted};
+use crate::common::{ActivationAssertionsInterceptor, CoreWfStarter};
 use std::{sync::Arc, time::Duration};
 use temporalio_client::{
     UntypedWorkflow, WorkflowCancelOptions, WorkflowDescribeOptions, WorkflowStartOptions,
     errors::WorkflowGetResultError,
 };
-use temporalio_common::{
-    protos::{
-        coresdk::workflow_activation::{WorkflowActivationJob, workflow_activation_job},
-        temporal::api::enums::v1::{CommandType, WorkflowExecutionStatus},
-    },
-    worker::WorkerTaskTypes,
+use temporalio_common::protos::{
+    coresdk::workflow_activation::{WorkflowActivationJob, workflow_activation_job},
+    temporal::api::enums::v1::{CommandType, WorkflowExecutionStatus},
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
@@ -45,10 +42,12 @@ impl CancelledWf {
 async fn cancel_during_timer() {
     let wf_name = "cancel_during_timer";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<CancelledWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
     let client = starter.get_client().await;
-    worker.register_workflow::<CancelledWf>().unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     let wf_id = task_queue.clone();
     let wf_handle = worker
@@ -112,11 +111,11 @@ impl ShieldedCancellationWf {
 async fn detached_token_shields_work_after_workflow_cancellation() {
     let wf_name = "detached_token_shields_work_after_workflow_cancellation";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<ShieldedCancellationWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
     let task_queue = starter.get_task_queue().to_owned();
     let wf_handle = worker
         .submit_workflow(
@@ -270,11 +269,12 @@ async fn workflow_cancellation_propagates_to_operations() {
         .register_activities(CancellationPropagationActivities {
             started: started.clone(),
         });
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<CancellationPropagationParent>()
         .unwrap();
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory({
             let started = started.clone();
             move || CancellationPropagationChild {
@@ -282,6 +282,7 @@ async fn workflow_cancellation_propagates_to_operations() {
             }
         })
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let wf_handle = worker
@@ -365,7 +366,9 @@ async fn wf_completing_with_cancelled() {
             });
     });
 
-    let mut worker = build_fake_sdk_intercepted(mock_cfg, aai);
-    worker.register_workflow::<WfWithTimer>().unwrap();
+    let mut worker =
+        crate::common::build_fake_sdk_intercepted_with_options(mock_cfg, aai, |options| {
+            options.register_workflow::<WfWithTimer>().unwrap();
+        });
     worker.run().await.unwrap();
 }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -1,4 +1,4 @@
-use crate::common::{CoreWfStarter, WorkflowHandleExt, build_fake_sdk, mock_sdk, mock_sdk_cfg};
+use crate::common::{CoreWfStarter, WorkflowHandleExt};
 use anyhow::anyhow;
 use assert_matches::assert_matches;
 use std::{sync::Arc, time::Duration};
@@ -30,7 +30,6 @@ use temporalio_common::{
             sdk::v1::UserMetadata,
         },
     },
-    worker::WorkerTaskTypes,
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
@@ -88,11 +87,12 @@ impl HappyParent {
 #[tokio::test]
 async fn child_workflow_happy_path() {
     let mut starter = CoreWfStarter::new("child-workflows");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<HappyParent>()
+        .unwrap();
+    starter.sdk_config.register_workflow::<ChildWf>().unwrap();
     let mut worker = starter.worker().await;
-
-    worker.register_workflow::<HappyParent>().unwrap();
-    worker.register_workflow::<ChildWf>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -154,19 +154,19 @@ impl AbandonedChildBugReproChild {
 #[tokio::test]
 async fn abandoned_child_bug_repro() {
     let mut starter = CoreWfStarter::new("child-workflow-abandon-bug");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-
     let barr = Arc::new(Barrier::new(2));
     let barr_clone = barr.clone();
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || AbandonedChildBugReproParent {
             barr: barr_clone.clone(),
         })
         .unwrap();
-    worker
+    starter
+        .sdk_config
         .register_workflow::<AbandonedChildBugReproChild>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -243,19 +243,19 @@ impl AbandonedChildResolvesPostCancelChild {
 #[tokio::test]
 async fn abandoned_child_resolves_post_cancel() {
     let mut starter = CoreWfStarter::new("child-workflow-resolves-post-cancel");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-
     let barr = Arc::new(Barrier::new(2));
     let barr_clone = barr.clone();
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || AbandonedChildResolvesPostCancelParent {
             barr: barr_clone.clone(),
         })
         .unwrap();
-    worker
+    starter
+        .sdk_config
         .register_workflow::<AbandonedChildResolvesPostCancelChild>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -346,15 +346,15 @@ impl CancelledChildGetsReasonChild {
 async fn cancelled_child_gets_reason() {
     let wf_name = "cancelled-child-gets-reason";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-
-    worker
+    starter
+        .sdk_config
         .register_workflow::<CancelledChildGetsReasonParent>()
         .unwrap();
-    worker
+    starter
+        .sdk_config
         .register_workflow::<CancelledChildGetsReasonChild>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -430,16 +430,15 @@ async fn signal_child_workflow(#[case] serial: bool) {
     let wf_type = DEFAULT_WORKFLOW_TYPE;
     let t = canned_histories::single_child_workflow_signaled("child-id-1", SIGNAME);
     let mock = mock_worker_client();
-    let mut worker = mock_sdk(MockPollCfg::from_resp_batches(
-        wf_id,
-        t,
-        [ResponseType::AllHistory],
-        mock,
-    ));
-
-    worker
-        .register_workflow_with_factory(move || SignalChildWorkflowWf { serial })
-        .unwrap();
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        MockPollCfg::from_resp_batches(wf_id, t, [ResponseType::AllHistory], mock),
+        |_| {},
+        |options| {
+            options
+                .register_workflow_with_factory(move || SignalChildWorkflowWf { serial })
+                .unwrap();
+        },
+    );
     let task_queue = worker.inner_mut().task_queue().to_owned();
     worker
         .submit_wf(
@@ -490,8 +489,12 @@ impl ParentCancelsChildWf {
 #[tokio::test]
 async fn cancel_child_workflow() {
     let t = canned_histories::single_child_workflow_cancelled("child-id-1");
-    let mut worker = build_fake_sdk(MockPollCfg::from_resps(t, [ResponseType::AllHistory]));
-    worker.register_workflow::<ParentCancelsChildWf>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(
+        MockPollCfg::from_resps(t, [ResponseType::AllHistory]),
+        |options| {
+            options.register_workflow::<ParentCancelsChildWf>().unwrap();
+        },
+    );
     worker.run().await.unwrap();
 }
 
@@ -534,13 +537,15 @@ impl RuntimeParentCancelsChildWf {
 #[tokio::test]
 async fn cancel_child_workflow_runtime_shape() {
     let mut starter = CoreWfStarter::new("cancel-child-workflow-runtime-shape");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-
-    worker
+    starter
+        .sdk_config
         .register_workflow::<RuntimeParentCancelsChildWf>()
         .unwrap();
-    worker.register_workflow::<GrandchildCancelled>().unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<GrandchildCancelled>()
+        .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -643,16 +648,19 @@ impl GrandchildCancellationWf {
 #[tokio::test]
 async fn child_workflow_cancellation_propigates() {
     let mut starter = CoreWfStarter::new("child-workflow-cancellation-propigates");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-
-    worker
+    starter
+        .sdk_config
         .register_workflow::<GrandchildCancellationWf>()
         .unwrap();
-    worker
+    starter
+        .sdk_config
         .register_workflow::<PropagatesChildCancellationWf>()
         .unwrap();
-    worker.register_workflow::<GrandchildCancelled>().unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<GrandchildCancelled>()
+        .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -835,13 +843,18 @@ async fn pass_child_workflow_summary_to_metadata() {
             });
     });
 
-    let mut worker = mock_sdk_cfg(mock_cfg, |_| {});
     let child_wf_id = wf_id.to_string();
-    worker
-        .register_workflow_with_factory(move || PassChildWorkflowSummaryToMetadata {
-            child_wf_id: child_wf_id.clone(),
-        })
-        .unwrap();
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mock_cfg,
+        |_| {},
+        |options| {
+            options
+                .register_workflow_with_factory(move || PassChildWorkflowSummaryToMetadata {
+                    child_wf_id: child_wf_id.clone(),
+                })
+                .unwrap();
+        },
+    );
     let task_queue = worker.inner_mut().task_queue().to_owned();
     worker
         .submit_wf(
@@ -952,8 +965,9 @@ async fn single_child_workflow_until_completion(mut mock_cfg: MockPollCfg) {
             });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<ParentWf>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<ParentWf>().unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -997,8 +1011,9 @@ async fn single_child_workflow_start_fail() {
             });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<ParentWf>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<ParentWf>().unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -1042,8 +1057,9 @@ async fn single_child_workflow_cancel_before_sent() {
         });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<CancelBeforeSendWf>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<CancelBeforeSendWf>().unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -1139,10 +1155,14 @@ impl CancelChildBeforeStartedCannedWf {
 #[tokio::test]
 async fn cancel_child_before_started_event_exposes_cancelled_error() {
     let t = canned_histories::cancel_child_workflow_before_started_event("child-id-1");
-    let mut worker = build_fake_sdk(MockPollCfg::from_resps(t, [ResponseType::AllHistory]));
-    worker
-        .register_workflow::<CancelChildBeforeStartedCannedWf>()
-        .unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(
+        MockPollCfg::from_resps(t, [ResponseType::AllHistory]),
+        |options| {
+            options
+                .register_workflow::<CancelChildBeforeStartedCannedWf>()
+                .unwrap();
+        },
+    );
     worker.run().await.unwrap();
 }
 
@@ -1175,19 +1195,19 @@ impl CancelChildBeforeStartedParent {
 #[tokio::test]
 async fn cancel_child_wf_before_started_event_real_server() {
     let mut starter = CoreWfStarter::new("child-wf-cancel-before-start");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-
     let barr = Arc::new(Notify::new());
     let barr_clone = barr.clone();
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || CancelChildBeforeStartedParent {
             barr: barr_clone.clone(),
         })
         .unwrap();
-    worker
+    starter
+        .sdk_config
         .register_workflow::<AbandonedChildBugReproChild>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -1261,11 +1281,12 @@ impl UntypedHappyParent {
 #[tokio::test]
 async fn untyped_child_workflow_happy_path() {
     let mut starter = CoreWfStarter::new("untyped-child-workflows");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<UntypedHappyParent>()
+        .unwrap();
+    starter.sdk_config.register_workflow::<ChildWf>().unwrap();
     let mut worker = starter.worker().await;
-
-    worker.register_workflow::<UntypedHappyParent>().unwrap();
-    worker.register_workflow::<ChildWf>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -1352,15 +1373,15 @@ impl ChildStartSerializationFailParent {
 #[tokio::test]
 async fn child_workflow_start_serialization_failure_returns_error() {
     let mut starter = CoreWfStarter::new("child-wf-start-ser-fail");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-
-    worker
+    starter
+        .sdk_config
         .register_workflow::<ChildStartSerializationFailParent>()
         .unwrap();
-    worker
+    starter
+        .sdk_config
         .register_workflow::<UnserializableStartInputChild>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -1409,15 +1430,15 @@ impl ChildSignalSerializationFailParent {
 #[tokio::test]
 async fn child_workflow_signal_serialization_failure_returns_error() {
     let mut starter = CoreWfStarter::new("child-wf-signal-ser-fail");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-
-    worker
+    starter
+        .sdk_config
         .register_workflow::<ChildSignalSerializationFailParent>()
         .unwrap();
-    worker
+    starter
+        .sdk_config
         .register_workflow::<UnserializableSignalChild>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -1470,8 +1491,12 @@ impl UnitChildParentWf {
 async fn child_workflow_unit_result_none_payload() {
     // single_child_workflow produces a completion with result: None
     let t = canned_histories::single_child_workflow("child-id-1");
-    let mut worker = build_fake_sdk(MockPollCfg::from_resps(t, [ResponseType::AllHistory]));
-    worker.register_workflow::<UnitChildParentWf>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(
+        MockPollCfg::from_resps(t, [ResponseType::AllHistory]),
+        |options| {
+            options.register_workflow::<UnitChildParentWf>().unwrap();
+        },
+    );
     worker.run().await.unwrap();
 }
 
@@ -1506,15 +1531,15 @@ impl CancelResultFutureParent {
 async fn cancel_child_result_future_does_not_fail_wft() {
     let wf_name = "cancel-child-result-future";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-
-    worker
+    starter
+        .sdk_config
         .register_workflow::<CancelResultFutureParent>()
         .unwrap();
-    worker
+    starter
+        .sdk_config
         .register_workflow::<CancelledChildGetsReasonChild>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
 
@@ -1592,16 +1617,19 @@ impl CancelExternalThenChildParent {
 async fn cancel_child_after_cancel_external_uses_correct_seq() {
     let wf_name = "cancel-child-after-cancel-external";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-
-    worker
+    starter
+        .sdk_config
         .register_workflow::<CancelExternalThenChildParent>()
         .unwrap();
-    worker
+    starter
+        .sdk_config
         .register_workflow::<CancelledChildGetsReasonChild>()
         .unwrap();
-    worker.register_workflow::<CancelExternalTarget>().unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<CancelExternalTarget>()
+        .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
 

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -177,7 +177,7 @@ async fn abandoned_child_bug_repro() {
         )
         .await
         .unwrap();
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let canceller = async {
         barr.wait().await;
         let parent_handle = client.get_workflow_handle::<UntypedWorkflow>("parent-abandoner");
@@ -266,7 +266,7 @@ async fn abandoned_child_resolves_post_cancel() {
         )
         .await
         .unwrap();
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let canceller = async {
         barr.wait().await;
         handle

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/client_interactions.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/client_interactions.rs
@@ -590,7 +590,7 @@ async fn test_typed_signal_query_update() {
         .await
         .unwrap();
     let handle = starter
-        .get_client()
+        .get_core_client()
         .await
         .get_workflow_handle::<InteractionWorkflow>(wfid);
 
@@ -740,8 +740,8 @@ async fn client_interceptors_respect_registration_order() {
         .sdk_config
         .register_workflow::<ImmediatelyCompletingWf>()
         .unwrap();
-    let client = starter.get_client().await;
     let mut worker = starter.worker().await;
+    let client = starter.get_core_client().await;
     let task_queue = starter.get_task_queue().to_owned();
     let events = Arc::new(Mutex::new(Vec::new()));
 

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/client_interactions.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/client_interactions.rs
@@ -7,10 +7,7 @@ use temporalio_client::{
     UntypedSignal, UntypedUpdate, WorkflowDescribeOptions, WorkflowExecuteUpdateOptions,
     WorkflowQueryOptions, WorkflowSignalOptions, WorkflowStartOptions, errors::WorkflowStartError,
 };
-use temporalio_common::{
-    data_converters::{PayloadConverter, RawValue},
-    worker::WorkerTaskTypes,
-};
+use temporalio_common::data_converters::{PayloadConverter, RawValue};
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{SyncWorkflowContext, WorkflowContext, WorkflowContextView, WorkflowResult};
 
@@ -133,9 +130,11 @@ impl InteractionWorkflow {
 async fn test_typed_signal() {
     let wf_name = InteractionWorkflow::name();
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<InteractionWorkflow>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<InteractionWorkflow>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -174,9 +173,11 @@ async fn test_typed_signal() {
 async fn test_typed_update() {
     let wf_name = InteractionWorkflow::name();
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<InteractionWorkflow>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<InteractionWorkflow>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -231,9 +232,11 @@ async fn test_typed_update() {
 async fn test_typed_query() {
     let wf_name = InteractionWorkflow::name();
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<InteractionWorkflow>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<InteractionWorkflow>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -298,9 +301,11 @@ async fn test_typed_query() {
 async fn test_update_validation() {
     let wf_name = InteractionWorkflow::name();
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<InteractionWorkflow>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<InteractionWorkflow>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -360,9 +365,11 @@ async fn test_update_validation() {
 async fn test_async_signal() {
     let wf_name = InteractionWorkflow::name();
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<InteractionWorkflow>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<InteractionWorkflow>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -422,9 +429,11 @@ async fn test_async_signal() {
 async fn test_fallible_query() {
     let wf_name = InteractionWorkflow::name();
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<InteractionWorkflow>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<InteractionWorkflow>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -489,9 +498,11 @@ async fn test_fallible_query() {
 async fn test_untyped_signal_query_update() {
     let wf_name = InteractionWorkflow::name();
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<InteractionWorkflow>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<InteractionWorkflow>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -562,9 +573,11 @@ async fn test_untyped_signal_query_update() {
 async fn test_typed_signal_query_update() {
     let wf_name = InteractionWorkflow::name();
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<InteractionWorkflow>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<InteractionWorkflow>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     let wfid = format!("{}_typed", starter.get_task_queue());
@@ -646,11 +659,11 @@ impl ImmediatelyCompletingWf {
 async fn static_summary_and_details_visible_after_start() {
     let wf_name = "static_summary_and_details_visible_after_start";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<ImmediatelyCompletingWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -723,12 +736,12 @@ fn client_with_interceptors(
 async fn client_interceptors_respect_registration_order() {
     let test_name = "client_interceptors_respect_registration_order";
     let mut starter = CoreWfStarter::new(test_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let client = starter.get_client().await;
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<ImmediatelyCompletingWf>()
         .unwrap();
+    let client = starter.get_client().await;
+    let mut worker = starter.worker().await;
     let task_queue = starter.get_task_queue().to_owned();
     let events = Arc::new(Mutex::new(Vec::new()));
 

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/continue_as_new.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/continue_as_new.rs
@@ -1,4 +1,4 @@
-use crate::common::{CoreWfStarter, SEARCH_ATTR_TXT, build_fake_sdk};
+use crate::common::{CoreWfStarter, SEARCH_ATTR_TXT};
 use std::{sync::Arc, time::Duration};
 use temporalio_client::WorkflowStartOptions;
 use temporalio_common::{
@@ -10,7 +10,6 @@ use temporalio_common::{
         history::v1::history_event,
     },
     search_attributes::{SearchAttributeKey, SearchAttributes},
-    worker::WorkerTaskTypes,
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{ContinueAsNewOptions, WorkflowContext, WorkflowResult, WorkflowTermination};
@@ -43,9 +42,11 @@ impl ContinueAsNewWf {
 async fn continue_as_new_happy_path() {
     let wf_name = "continue_as_new_happy_path";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<ContinueAsNewWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<ContinueAsNewWf>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -63,11 +64,13 @@ async fn continue_as_new_happy_path() {
 async fn continue_as_new_multiple_concurrent() {
     let wf_name = "continue_as_new_multiple_concurrent";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.sdk_config.max_cached_workflows = 5_usize;
     starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(5, 1, 1, 1));
+    starter
+        .sdk_config
+        .register_workflow::<ContinueAsNewWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<ContinueAsNewWf>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     let wf_names = (1..=20).map(|i| format!("{wf_name}-{i}"));
@@ -125,8 +128,9 @@ async fn wf_completing_with_continue_as_new() {
             });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<WfWithTimer>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<WfWithTimer>().unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -164,10 +168,11 @@ async fn continue_as_new_suggested_flag_exposed() {
     });
 
     let mock_cfg = MockPollCfg::from_hist_builder(t);
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker
-        .register_workflow::<ContinueAsNewSuggestedWf>()
-        .unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options
+            .register_workflow::<ContinueAsNewSuggestedWf>()
+            .unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -194,11 +199,11 @@ impl ClearSearchAttrsOnContinueAsNewWf {
 async fn clear_search_attributes_on_continue_as_new() {
     let wf_name = "clear_search_attrs_on_continue_as_new";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<ClearSearchAttrsOnContinueAsNewWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     worker

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
@@ -1,6 +1,4 @@
-use crate::common::{
-    CoreWfStarter, WorkflowHandleExt, activity_functions::StdActivities, mock_sdk, mock_sdk_cfg,
-};
+use crate::common::{CoreWfStarter, WorkflowHandleExt, activity_functions::StdActivities};
 use futures::FutureExt;
 use std::{
     sync::{
@@ -21,7 +19,6 @@ use temporalio_common::{
             history::v1::history_event::Attributes::WorkflowTaskFailedEventAttributes,
         },
     },
-    worker::WorkerTaskTypes,
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
@@ -69,16 +66,15 @@ impl TimerWfNondeterministic {
 async fn test_determinism_error_then_recovers() {
     let wf_name = "test_determinism_error_then_recovers";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-
     let run_ct = Arc::new(AtomicUsize::new(1));
     let run_ct_clone = run_ct.clone();
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || TimerWfNondeterministic {
             run_ct: run_ct_clone.clone(),
         })
         .unwrap();
+    let mut worker = starter.worker().await;
     let task_queue = starter.get_task_queue().to_owned();
     worker
         .submit_workflow(
@@ -124,15 +120,15 @@ async fn task_fail_causes_replay_unset_too_soon() {
     let wf_name = "task_fail_causes_replay_unset_too_soon";
     let mut starter = CoreWfStarter::new(wf_name);
     starter.sdk_config.register_activities(StdActivities);
-    let mut worker = starter.worker().await;
-
     let did_fail = Arc::new(AtomicBool::new(false));
     let did_fail_clone = did_fail.clone();
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || TaskFailReplayWf {
             did_fail: did_fail_clone.clone(),
         })
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -164,9 +160,11 @@ impl RandomReplayWf {
 async fn random_workflow_replays() {
     let wf_name = "random_workflow_replays";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<RandomReplayWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<RandomReplayWf>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -230,14 +228,18 @@ async fn test_panic_wf_task_rejected_properly() {
             WorkflowTaskFailedCause::WorkflowWorkerUnhandledFailure
         )
     });
-    let mut worker = mock_sdk(mh);
-
     let did_fail = Arc::new(AtomicBool::new(false));
-    worker
-        .register_workflow_with_factory(move || TimerWfFailsOnce {
-            did_fail: did_fail.clone(),
-        })
-        .unwrap();
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |_| {},
+        |options| {
+            options
+                .register_workflow_with_factory(move || TimerWfFailsOnce {
+                    did_fail: did_fail.clone(),
+                })
+                .unwrap();
+        },
+    );
     let task_queue = "fake_tq".to_owned();
     worker
         .submit_wf(
@@ -287,19 +289,23 @@ async fn test_wf_task_rejected_properly_due_to_nondeterminism(#[case] use_cache:
     mh.num_expected_fails = 1;
     mh.expect_fail_wft_matcher =
         Box::new(|_, cause, _| matches!(cause, WorkflowTaskFailedCause::NonDeterministicError));
-    let mut worker = mock_sdk_cfg(mh, |cfg| {
-        if use_cache {
-            cfg.max_cached_workflows = 2;
-        }
-    });
-
     let started_count = Arc::new(AtomicUsize::new(0));
     let count_clone = started_count.clone();
-    worker
-        .register_workflow_with_factory(move || NondeterministicTimerWf {
-            started_count: count_clone.clone(),
-        })
-        .unwrap();
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |cfg| {
+            if use_cache {
+                cfg.max_cached_workflows = 2;
+            }
+        },
+        |options| {
+            options
+                .register_workflow_with_factory(move || NondeterministicTimerWf {
+                    started_count: count_clone.clone(),
+                })
+                .unwrap();
+        },
+    );
 
     let task_queue = "fake_tq".to_owned();
     worker
@@ -396,14 +402,19 @@ async fn activity_id_or_type_change_is_nondeterministic(
                 ..
             }) if message.contains(should_contain))
     });
-    let mut worker = mock_sdk_cfg(mh, |cfg| {
-        if use_cache {
-            cfg.max_cached_workflows = 2;
-        }
-    });
-    worker
-        .register_workflow::<ActivityIdOrTypeChangeWf>()
-        .unwrap();
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |cfg| {
+            if use_cache {
+                cfg.max_cached_workflows = 2;
+            }
+        },
+        |options| {
+            options
+                .register_workflow::<ActivityIdOrTypeChangeWf>()
+                .unwrap();
+        },
+    );
 
     let task_queue = "fake_tq".to_owned();
     worker
@@ -475,15 +486,19 @@ async fn child_wf_id_or_type_change_is_nondeterministic(
                 ..
             }) if message.contains(should_contain))
     });
-    let mut worker = mock_sdk_cfg(mh, |cfg| {
-        if use_cache {
-            cfg.max_cached_workflows = 2;
-        }
-    });
-
-    worker
-        .register_workflow::<ChildWfIdOrTypeChangeWf>()
-        .unwrap();
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |cfg| {
+            if use_cache {
+                cfg.max_cached_workflows = 2;
+            }
+        },
+        |options| {
+            options
+                .register_workflow::<ChildWfIdOrTypeChangeWf>()
+                .unwrap();
+        },
+    );
 
     let task_queue = "fake_tq".to_owned();
     worker
@@ -527,16 +542,15 @@ impl TokioSleepWf {
 async fn nondeterministic_future_detection_fails_wft() {
     let wf_name = "nondeterministic_future_detection_fails_wft";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-
     let attempt = Arc::new(AtomicUsize::new(0));
     let attempt_clone = attempt.clone();
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || TokioSleepWf {
             attempt: attempt_clone.clone(),
         })
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -615,12 +629,18 @@ async fn repro_channel_missing_because_nondeterminism() {
         let mut mh =
             MockPollCfg::from_resp_batches(wf_id, t, [1.into(), ResponseType::AllHistory], mock);
         mh.num_expected_fails = 1;
-        let mut worker = mock_sdk_cfg(mh, |cfg| {
-            cfg.max_cached_workflows = 2;
-            cfg.ignore_evicts_on_shutdown = false;
-        });
-
-        worker.register_workflow::<ReproChannelMissingWf>().unwrap();
+        let mut worker = crate::common::mock_sdk_cfg_with_options(
+            mh,
+            |cfg| {
+                cfg.max_cached_workflows = 2;
+                cfg.ignore_evicts_on_shutdown = false;
+            },
+            |options| {
+                options
+                    .register_workflow::<ReproChannelMissingWf>()
+                    .unwrap();
+            },
+        );
 
         let task_queue = "fake_tq".to_owned();
         worker

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/eager.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/eager.rs
@@ -36,7 +36,7 @@ async fn eager_wf_start() {
     let res = eager_start(
         wf_name,
         task_queue,
-        &starter.get_client().await,
+        &starter.get_core_client().await,
         starter.workflow_options.clone(),
     )
     .await;

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/eager.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/eager.rs
@@ -1,14 +1,11 @@
 use crate::common::{CoreWfStarter, NAMESPACE, get_integ_connection};
 use std::time::Duration;
 use temporalio_client::{Client, NamespacedClient, WorkflowStartOptions, grpc::WorkflowService};
-use temporalio_common::{
-    protos::temporal::api::{
-        common::v1::WorkflowType,
-        enums::v1::TaskQueueKind,
-        taskqueue::v1::TaskQueue,
-        workflowservice::v1::{StartWorkflowExecutionRequest, StartWorkflowExecutionResponse},
-    },
-    worker::WorkerTaskTypes,
+use temporalio_common::protos::temporal::api::{
+    common::v1::WorkflowType,
+    enums::v1::TaskQueueKind,
+    taskqueue::v1::TaskQueue,
+    workflowservice::v1::{StartWorkflowExecutionRequest, StartWorkflowExecutionResponse},
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{WorkflowContext, WorkflowResult};
@@ -30,12 +27,11 @@ impl EagerWf {
 async fn eager_wf_start() {
     let wf_name = "eager_wf_start";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.workflow_options.enable_eager_workflow_start = true;
     // hang the test if eager task dispatch failed
     starter.workflow_options.task_timeout = Some(Duration::from_secs(1500));
+    starter.sdk_config.register_workflow::<EagerWf>().unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<EagerWf>().unwrap();
     let task_queue = starter.get_task_queue().to_string();
     let res = eager_start(
         wf_name,
@@ -55,12 +51,11 @@ async fn eager_wf_start() {
 async fn eager_wf_start_different_clients() {
     let wf_name = "eager_wf_start";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.workflow_options.enable_eager_workflow_start = true;
     // hang the test if wf task needs retry
     starter.workflow_options.task_timeout = Some(Duration::from_secs(1500));
+    starter.sdk_config.register_workflow::<EagerWf>().unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<EagerWf>().unwrap();
 
     let connection = get_integ_connection(None).await;
     let client_opts = temporalio_client::ClientOptions::new(NAMESPACE).build();

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/interceptors.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/interceptors.rs
@@ -12,13 +12,10 @@ use std::{
 use temporalio_client::{
     WorkflowExecuteUpdateOptions, WorkflowQueryOptions, WorkflowSignalOptions, WorkflowStartOptions,
 };
-use temporalio_common::{
-    protos::temporal::api::{
-        common::v1::Payload,
-        enums::v1::{EventType, WorkflowTaskFailedCause},
-        history::v1::{History, history_event::Attributes::WorkflowTaskFailedEventAttributes},
-    },
-    worker::WorkerTaskTypes,
+use temporalio_common::protos::temporal::api::{
+    common::v1::Payload,
+    enums::v1::{EventType, WorkflowTaskFailedCause},
+    history::v1::{History, history_event::Attributes::WorkflowTaskFailedEventAttributes},
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
@@ -223,18 +220,14 @@ impl WorkflowInterceptor for MutatingWorkflowInterceptor {
 #[tokio::test]
 async fn workflow_interceptors_mutate_inputs_and_replace_outputs() {
     let mut starter = CoreWfStarter::new("workflow_interceptors_mutate_inputs_and_replace_outputs");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    starter
-        .sdk_config
-        .register_workflow::<InboundInterceptorWorkflow>()
-        .unwrap();
-
     let signal_post_handler_done = Arc::new(Notify::new());
     let saw_query_history_replay = Arc::new(Mutex::new(None));
     let signal_post_handler_done_ref = signal_post_handler_done.clone();
     let saw_query_history_replay_ref = saw_query_history_replay.clone();
     starter
         .sdk_config
+        .register_workflow::<InboundInterceptorWorkflow>()
+        .unwrap()
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(move |_| {
             MutatingWorkflowInterceptor {
                 signal_post_handler_done: signal_post_handler_done_ref.clone(),
@@ -389,25 +382,24 @@ impl WorkflowInterceptor for RecordingWorkflowInterceptor {
 #[tokio::test]
 async fn workflow_interceptors_wrap_execute_in_order() {
     let mut starter = CoreWfStarter::new("workflow_interceptors_wrap_execute_in_order");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    starter
-        .sdk_config
-        .register_workflow::<InboundInterceptorOrderWorkflow>()
-        .unwrap();
 
     let records = Arc::new(Mutex::new(Vec::new()));
     let outer_records = records.clone();
     let inner_records = records.clone();
-    starter.sdk_config.register_workflow_interceptors(vec![
-        WorkflowInterceptorConstructor::new(move |_| RecordingWorkflowInterceptor {
-            name: "outer",
-            records: outer_records.clone(),
-        }),
-        WorkflowInterceptorConstructor::new(move |_| RecordingWorkflowInterceptor {
-            name: "inner",
-            records: inner_records.clone(),
-        }),
-    ]);
+    starter
+        .sdk_config
+        .register_workflow::<InboundInterceptorOrderWorkflow>()
+        .unwrap()
+        .register_workflow_interceptors(vec![
+            WorkflowInterceptorConstructor::new(move |_| RecordingWorkflowInterceptor {
+                name: "outer",
+                records: outer_records.clone(),
+            }),
+            WorkflowInterceptorConstructor::new(move |_| RecordingWorkflowInterceptor {
+                name: "inner",
+                records: inner_records.clone(),
+            }),
+        ]);
     let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
@@ -494,16 +486,13 @@ impl WorkflowInterceptor for InitInputMutationInterceptor {
 #[tokio::test]
 async fn workflow_initialize_interceptor_mutates_init_input() {
     let mut starter = CoreWfStarter::new("workflow_initialize_interceptor_mutates_init_input");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    starter
-        .sdk_config
-        .register_workflow::<InitInputInterceptorWorkflow>()
-        .unwrap();
 
     let received_input = Arc::new(AtomicUsize::new(0));
     let received_input_ref = received_input.clone();
     starter
         .sdk_config
+        .register_workflow::<InitInputInterceptorWorkflow>()
+        .unwrap()
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(move |_| {
             InitInputMutationInterceptor {
                 received_input: received_input_ref.clone(),
@@ -772,13 +761,11 @@ impl WorkflowInterceptor for SdkTimerBeforeNextInterceptor {
 #[tokio::test]
 async fn sdk_future_before_next_produces_an_activation() {
     let mut starter = CoreWfStarter::new("sdk_future_before_next_produces_an_activation");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+
     starter
         .sdk_config
         .register_workflow::<ConstructionWakeWorkflow>()
-        .unwrap();
-    starter
-        .sdk_config
+        .unwrap()
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(|_| {
             SdkTimerBeforeNextInterceptor
         })]);
@@ -819,7 +806,6 @@ async fn nondeterministic_future_detection_is_respected_for_interceptors(
         "nde_future_detection_{}",
         detect_nondeterministic_futures
     ));
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.sdk_config.detect_nondeterministic_futures = detect_nondeterministic_futures;
     starter
         .sdk_config
@@ -875,7 +861,6 @@ async fn nondeterministic_future_detection_is_respected_for_async_signal_interce
         "async_signal_nde_future_detection_{}",
         detect_nondeterministic_futures
     ));
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.sdk_config.detect_nondeterministic_futures = detect_nondeterministic_futures;
     starter
         .sdk_config
@@ -937,7 +922,6 @@ async fn nondeterministic_future_detection_is_respected_for_async_update_interce
         "async_update_nde_future_detection_{}",
         detect_nondeterministic_futures
     ));
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.sdk_config.detect_nondeterministic_futures = detect_nondeterministic_futures;
     starter
         .sdk_config
@@ -1023,11 +1007,6 @@ impl WorkflowInterceptor for ConstructionPollingInterceptor {
 async fn workflow_interceptors_are_polled_once_during_construction() {
     let mut starter =
         CoreWfStarter::new("workflow_interceptors_are_polled_once_during_construction");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    starter
-        .sdk_config
-        .register_workflow::<InterceptorConstructionPollingWorkflow>()
-        .unwrap();
 
     let sync_polls = Arc::new(AtomicUsize::new(0));
     let deferred_polls = Arc::new(AtomicUsize::new(0));
@@ -1037,6 +1016,8 @@ async fn workflow_interceptors_are_polled_once_during_construction() {
     let async_polls_ref = async_polls.clone();
     starter
         .sdk_config
+        .register_workflow::<InterceptorConstructionPollingWorkflow>()
+        .unwrap()
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(move |_| {
             ConstructionPollingInterceptor {
                 sync_polls: sync_polls_ref.clone(),
@@ -1165,15 +1146,12 @@ async fn workflow_interceptor_constructors_create_unified_per_instance_intercept
     let mut starter = CoreWfStarter::new(
         "workflow_interceptor_constructors_create_unified_per_instance_interceptors",
     );
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    starter
-        .sdk_config
-        .register_workflow::<ConstructorOutboundInterceptorWorkflow>()
-        .unwrap();
 
     let expected_task_queue = starter.get_task_queue().to_owned();
     starter
         .sdk_config
+        .register_workflow::<ConstructorOutboundInterceptorWorkflow>()
+        .unwrap()
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(move |ctx| {
             assert_eq!(
                 ctx.workflow_type(),
@@ -1292,16 +1270,13 @@ async fn inbound_interceptor_context_operations_use_the_outbound_chain_around_ne
     let mut starter = CoreWfStarter::new(
         "inbound_interceptor_context_operations_use_the_outbound_chain_around_next",
     );
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    starter
-        .sdk_config
-        .register_workflow::<InboundContextOutboundWorkflow>()
-        .unwrap();
 
     let events = Arc::new(Mutex::new(Vec::new()));
     let events_ref = events.clone();
     starter
         .sdk_config
+        .register_workflow::<InboundContextOutboundWorkflow>()
+        .unwrap()
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(move |_| {
             InboundContextOutboundInterceptor {
                 events: events_ref.clone(),
@@ -1458,13 +1433,11 @@ impl WorkflowInterceptor for OutboundActivityInterceptor {
 async fn workflow_outbound_interceptors_mutate_activity_calls_and_results() {
     let mut starter =
         CoreWfStarter::new("workflow_outbound_interceptors_mutate_activity_calls_and_results");
-    starter.sdk_config.register_activities(StdActivities);
     starter
         .sdk_config
+        .register_activities(StdActivities)
         .register_workflow::<OutboundActivityInterceptorWorkflow>()
-        .unwrap();
-    starter
-        .sdk_config
+        .unwrap()
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(|_| {
             OutboundActivityInterceptor
         })]);
@@ -1559,20 +1532,17 @@ impl WorkflowInterceptor for OutboundChildInterceptor {
 async fn workflow_outbound_interceptors_wrap_child_start_and_completion() {
     let mut starter =
         CoreWfStarter::new("workflow_outbound_interceptors_wrap_child_start_and_completion");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+
     starter
         .sdk_config
         .register_workflow::<OutboundChildInterceptorParent>()
-        .unwrap();
-    starter
-        .sdk_config
+        .unwrap()
         .register_workflow::<OutboundChildInterceptorChild>()
-        .unwrap();
-    starter
-        .sdk_config
+        .unwrap()
         .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(|_| {
             OutboundChildInterceptor
         })]);
+
     let mut worker = starter.worker().await;
 
     let handle = worker

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -942,7 +942,7 @@ async fn repro_nondeterminism_with_timer_bug() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let handle = WorkflowExecutionInfo {
         namespace: client.namespace(),
         workflow_id: wf_name.into(),
@@ -1109,7 +1109,7 @@ async fn la_resolve_same_time_as_other_cancel() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let handle = WorkflowExecutionInfo {
         namespace: client.namespace(),
         workflow_id: wf_name.into(),

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -1,8 +1,7 @@
 use crate::common::{
     ActivationAssertionsInterceptor, CoreWfStarter, WorkflowHandleExt,
-    activity_functions::StdActivities, build_fake_sdk, build_fake_sdk_intercepted,
-    history_from_proto_binary, init_core_replay_preloaded, mock_sdk, mock_sdk_cfg,
-    replay_sdk_worker, workflows::LaProblemWorkflow,
+    activity_functions::StdActivities, history_from_proto_binary, init_core_replay_preloaded,
+    workflows::LaProblemWorkflow,
 };
 use anyhow::anyhow;
 use crossbeam_queue::SegQueue;
@@ -101,8 +100,11 @@ async fn one_local_activity() {
     let wf_name = "one_local_activity";
     let mut starter = CoreWfStarter::new(wf_name);
     starter.sdk_config.register_activities(StdActivities);
+    starter
+        .sdk_config
+        .register_workflow::<OneLocalActivityWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<OneLocalActivityWf>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -141,10 +143,11 @@ async fn local_act_concurrent_with_timer() {
     let wf_name = "local_act_concurrent_with_timer";
     let mut starter = CoreWfStarter::new(wf_name);
     starter.sdk_config.register_activities(StdActivities);
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<LocalActConcurrentWithTimerWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -183,10 +186,11 @@ async fn local_act_then_timer_then_wait_result() {
     let wf_name = "local_act_then_timer_then_wait_result";
     let mut starter = CoreWfStarter::new(wf_name);
     starter.sdk_config.register_activities(StdActivities);
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<LocalActThenTimerThenWaitResult>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -226,10 +230,11 @@ async fn long_running_local_act_with_timer() {
     let mut starter = CoreWfStarter::new(wf_name);
     starter.workflow_options.task_timeout = Some(Duration::from_secs(1));
     starter.sdk_config.register_activities(StdActivities);
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<LocalActThenTimerThenWait>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -272,8 +277,11 @@ async fn local_act_fanout() {
     let mut starter = CoreWfStarter::new(wf_name);
     starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(5, 1, 1, 1));
     starter.sdk_config.register_activities(StdActivities);
+    starter
+        .sdk_config
+        .register_workflow::<LocalActFanoutWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<LocalActFanoutWf>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -325,10 +333,11 @@ async fn local_act_retry_timer_backoff() {
     let wf_name = "local_act_retry_timer_backoff";
     let mut starter = CoreWfStarter::new(wf_name);
     starter.sdk_config.register_activities(StdActivities);
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<LocalActRetryTimerBackoff>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -414,8 +423,11 @@ async fn cancel_immediate(#[case] cancel_type: ActivityCancellationType) {
         }
     }
 
+    starter
+        .sdk_config
+        .register_workflow::<CancelImmediate>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<CancelImmediate>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -580,11 +592,12 @@ async fn cancel_after_act_starts(
         }
     }
 
-    let mut worker = starter.worker().await;
     let bo_dur = cancel_on_backoff.unwrap_or_else(|| Duration::from_secs(1));
-    worker
+    starter
+        .sdk_config
         .register_workflow::<CancelAfterActStartsWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -680,13 +693,16 @@ async fn x_to_close_timeout(#[case] is_schedule: bool) {
         }
     }
 
-    let mut worker = starter.worker().await;
     let (sched, start) = if is_schedule {
         (Some(Duration::from_secs(2)), None)
     } else {
         (None, Some(Duration::from_secs(2)))
     };
-    worker.register_workflow::<XToCloseTimeoutWf>().unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<XToCloseTimeoutWf>()
+        .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -754,11 +770,6 @@ async fn schedule_to_close_timeout_across_timer_backoff(#[case] cached: bool) {
         }
     }
 
-    let mut worker = starter.worker().await;
-    worker
-        .register_workflow::<ScheduleToCloseTimeoutAcrossTimerBackoff>()
-        .unwrap();
-
     let num_attempts = Arc::new(AtomicU8::new(0));
 
     struct FailWithAtomicCounter {
@@ -773,9 +784,16 @@ async fn schedule_to_close_timeout_across_timer_backoff(#[case] cached: bool) {
         }
     }
 
-    worker.register_activities(FailWithAtomicCounter {
-        counter: num_attempts.clone(),
-    });
+    starter
+        .sdk_config
+        .register_activities(FailWithAtomicCounter {
+            counter: num_attempts.clone(),
+        });
+    starter
+        .sdk_config
+        .register_workflow::<ScheduleToCloseTimeoutAcrossTimerBackoff>()
+        .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -847,10 +865,11 @@ async fn timer_backoff_concurrent_with_non_timer_backoff() {
         }
     }
 
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<TimerBackoffConcurrentWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -907,10 +926,11 @@ async fn repro_nondeterminism_with_timer_bug() {
         }
     }
 
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<ReproNondeterminismWithTimerBugWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -949,9 +969,13 @@ async fn weird_la_nondeterminism_repro(#[values(true, false)] fix_hist: bool) {
         hist = thb.get_full_history_info().unwrap().into();
     }
 
-    let mut worker = replay_sdk_worker([HistoryForReplay::new(hist, "fake".to_owned())]);
-    worker.register_workflow::<LaProblemWorkflow>().unwrap();
-    worker.register_activities(StdActivities);
+    let mut worker = crate::common::replay_sdk_worker_with_options(
+        [HistoryForReplay::new(hist, "fake".to_owned())],
+        |options| {
+            options.register_workflow::<LaProblemWorkflow>().unwrap();
+            options.register_activities(StdActivities);
+        },
+    );
     worker.run().await.unwrap();
 }
 
@@ -967,9 +991,13 @@ async fn second_weird_la_nondeterminism_repro() {
     thb.add_workflow_execution_completed();
     hist = thb.get_full_history_info().unwrap().into();
 
-    let mut worker = replay_sdk_worker([HistoryForReplay::new(hist, "fake".to_owned())]);
-    worker.register_workflow::<LaProblemWorkflow>().unwrap();
-    worker.register_activities(StdActivities);
+    let mut worker = crate::common::replay_sdk_worker_with_options(
+        [HistoryForReplay::new(hist, "fake".to_owned())],
+        |options| {
+            options.register_workflow::<LaProblemWorkflow>().unwrap();
+            options.register_activities(StdActivities);
+        },
+    );
     worker.run().await.unwrap();
 }
 
@@ -983,9 +1011,13 @@ async fn third_weird_la_nondeterminism_repro() {
     thb.add_workflow_task_scheduled_and_started();
     hist = thb.get_full_history_info().unwrap().into();
 
-    let mut worker = replay_sdk_worker([HistoryForReplay::new(hist, "fake".to_owned())]);
-    worker.register_workflow::<LaProblemWorkflow>().unwrap();
-    worker.register_activities(StdActivities);
+    let mut worker = crate::common::replay_sdk_worker_with_options(
+        [HistoryForReplay::new(hist, "fake".to_owned())],
+        |options| {
+            options.register_workflow::<LaProblemWorkflow>().unwrap();
+            options.register_activities(StdActivities);
+        },
+    );
     worker.run().await.unwrap();
 }
 
@@ -1061,10 +1093,11 @@ async fn la_resolve_same_time_as_other_cancel() {
         }
     }
 
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<LaResolveSameTimeAsOtherCancelWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -1141,10 +1174,11 @@ async fn long_local_activity_with_update(
         }
     }
 
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<LongLocalActivityWithUpdateWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -1235,10 +1269,11 @@ async fn local_activity_with_heartbeat_only_causes_one_wakeup() {
         }
     }
 
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<LocalActivityWithHeartbeatOnlyCausesOneWakeupWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -1280,10 +1315,11 @@ async fn local_activity_with_summary() {
     let wf_name = "local_activity_with_summary";
     let mut starter = CoreWfStarter::new(wf_name);
     starter.sdk_config.register_activities(StdActivities);
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<LocalActivityWithSummaryWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let handle = starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
@@ -1340,12 +1376,6 @@ async fn local_act_two_wfts_before_marker(#[case] replay: bool, #[case] cached: 
         vec![1.into(), 2.into(), ResponseType::AllHistory]
     };
     let mh = MockPollCfg::from_resp_batches(wf_id, t, resps, mock);
-    let mut worker = mock_sdk_cfg(mh, |cfg| {
-        if cached {
-            cfg.max_cached_workflows = 1;
-        }
-    });
-
     #[workflow]
     #[derive(Default)]
     struct LocalActTwoWftsBeforeMarkerWf;
@@ -1361,10 +1391,20 @@ async fn local_act_two_wfts_before_marker(#[case] replay: bool, #[case] cached: 
         }
     }
 
-    worker
-        .register_workflow::<LocalActTwoWftsBeforeMarkerWf>()
-        .unwrap();
-    worker.register_activities(StdActivities);
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |cfg| {
+            if cached {
+                cfg.max_cached_workflows = 1;
+            }
+        },
+        |options| {
+            options
+                .register_workflow::<LocalActTwoWftsBeforeMarkerWf>()
+                .unwrap();
+            options.register_activities(StdActivities);
+        },
+    );
     worker.run_until_done().await.unwrap();
 }
 
@@ -1385,10 +1425,14 @@ async fn local_act_many_concurrent() {
     let wf_id = "fakeid";
     let mock = mock_worker_client();
     let mh = MockPollCfg::from_resp_batches(wf_id, t, [1, 2, 3], mock);
-    let mut worker = mock_sdk(mh);
-
-    worker.register_workflow::<LocalActFanoutWf>().unwrap();
-    worker.register_activities(StdActivities);
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |_| {},
+        |options| {
+            options.register_workflow::<LocalActFanoutWf>().unwrap();
+            options.register_activities(StdActivities);
+        },
+    );
     worker.run_until_done().await.unwrap();
 }
 
@@ -1415,12 +1459,6 @@ async fn local_act_heartbeat(#[case] shutdown_middle: bool) {
     let mock = mock_worker_client();
     let mut mh = MockPollCfg::from_resp_batches(wf_id, t, [1, 2, 2, 2], mock);
     mh.enforce_correct_number_of_polls = false;
-    let mut worker = mock_sdk_cfg(mh, |wc| {
-        wc.max_cached_workflows = 1;
-        wc.max_outstanding_workflow_tasks = Some(1);
-    });
-    let core = worker.core_worker();
-
     let shutdown_barr = Arc::new(Barrier::new(2));
 
     #[workflow]
@@ -1441,8 +1479,6 @@ async fn local_act_heartbeat(#[case] shutdown_middle: bool) {
             Ok(())
         }
     }
-
-    worker.register_workflow::<LocalActHeartbeatWf>().unwrap();
 
     struct EchoWithConditionalBarrier {
         shutdown_barr: Option<Arc<Barrier>>,
@@ -1466,14 +1502,25 @@ async fn local_act_heartbeat(#[case] shutdown_middle: bool) {
         }
     }
 
-    worker.register_activities(EchoWithConditionalBarrier {
-        shutdown_barr: if shutdown_middle {
-            Some(shutdown_barr.clone())
-        } else {
-            None
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |wc| {
+            wc.max_cached_workflows = 1;
+            wc.max_outstanding_workflow_tasks = Some(1);
         },
-        wft_timeout,
-    });
+        |options| {
+            options.register_workflow::<LocalActHeartbeatWf>().unwrap();
+            options.register_activities(EchoWithConditionalBarrier {
+                shutdown_barr: if shutdown_middle {
+                    Some(shutdown_barr.clone())
+                } else {
+                    None
+                },
+                wft_timeout,
+            });
+        },
+    );
+    let core = worker.core_worker();
     let (_, runres) = tokio::join!(
         async {
             if shutdown_middle {
@@ -1500,8 +1547,6 @@ async fn local_act_fail_and_retry(#[case] eventually_pass: bool) {
     let wf_id = "fakeid";
     let mock = mock_worker_client();
     let mh = MockPollCfg::from_resp_batches(wf_id, t, [1], mock);
-    let mut worker = mock_sdk(mh);
-
     #[workflow]
     #[derive(Default)]
     struct LocalActFailAndRetryWf;
@@ -1537,9 +1582,6 @@ async fn local_act_fail_and_retry(#[case] eventually_pass: bool) {
         }
     }
 
-    worker
-        .register_workflow::<LocalActFailAndRetryWf>()
-        .unwrap();
     let attempts = Arc::new(AtomicUsize::new(0));
 
     struct EventuallyPassingActivity {
@@ -1559,10 +1601,19 @@ async fn local_act_fail_and_retry(#[case] eventually_pass: bool) {
         }
     }
 
-    worker.register_activities(EventuallyPassingActivity {
-        attempts: attempts.clone(),
-        eventually_pass,
-    });
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |_| {},
+        |options| {
+            options
+                .register_workflow::<LocalActFailAndRetryWf>()
+                .unwrap();
+            options.register_activities(EventuallyPassingActivity {
+                attempts: attempts.clone(),
+                eventually_pass,
+            });
+        },
+    );
     worker.run_until_done().await.unwrap();
     let expected_attempts = if eventually_pass { 3 } else { 5 };
     assert_eq!(expected_attempts, attempts.load(Ordering::Relaxed));
@@ -1603,8 +1654,6 @@ async fn local_act_retry_long_backoff_uses_timer() {
         [1.into(), 2.into(), ResponseType::AllHistory],
         mock,
     );
-    let mut worker = mock_sdk_cfg(mh, |w| w.max_cached_workflows = 1);
-
     #[workflow]
     #[derive(Default)]
     struct LocalActRetryLongBackoffUsesTimerWf;
@@ -1637,10 +1686,16 @@ async fn local_act_retry_long_backoff_uses_timer() {
         }
     }
 
-    worker
-        .register_workflow::<LocalActRetryLongBackoffUsesTimerWf>()
-        .unwrap();
-    worker.register_activities(StdActivities);
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |w| w.max_cached_workflows = 1,
+        |options| {
+            options
+                .register_workflow::<LocalActRetryLongBackoffUsesTimerWf>()
+                .unwrap();
+            options.register_activities(StdActivities);
+        },
+    );
     worker.run_until_done().await.unwrap();
 }
 
@@ -1655,8 +1710,6 @@ async fn local_act_null_result() {
     let wf_id = "fakeid";
     let mock = mock_worker_client();
     let mh = MockPollCfg::from_resp_batches(wf_id, t, [ResponseType::AllHistory], mock);
-    let mut worker = mock_sdk_cfg(mh, |w| w.max_cached_workflows = 1);
-
     #[workflow]
     #[derive(Default)]
     struct LocalActNullResultWf;
@@ -1671,8 +1724,14 @@ async fn local_act_null_result() {
         }
     }
 
-    worker.register_workflow::<LocalActNullResultWf>().unwrap();
-    worker.register_activities(StdActivities);
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |w| w.max_cached_workflows = 1,
+        |options| {
+            options.register_workflow::<LocalActNullResultWf>().unwrap();
+            options.register_activities(StdActivities);
+        },
+    );
     worker.run_until_done().await.unwrap();
 }
 
@@ -1691,8 +1750,6 @@ async fn local_act_command_immediately_follows_la_marker() {
     let wf_id = "fakeid";
     let mock = mock_worker_client();
     let mh = MockPollCfg::from_resp_batches(wf_id, t, [3], mock);
-    let mut worker = mock_sdk_cfg(mh, |w| w.max_cached_workflows = 0);
-
     #[workflow]
     #[derive(Default)]
     struct LocalActCommandImmediatelyFollowsLaMarkerWf;
@@ -1708,10 +1765,16 @@ async fn local_act_command_immediately_follows_la_marker() {
         }
     }
 
-    worker
-        .register_workflow::<LocalActCommandImmediatelyFollowsLaMarkerWf>()
-        .unwrap();
-    worker.register_activities(StdActivities);
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |w| w.max_cached_workflows = 0,
+        |options| {
+            options
+                .register_workflow::<LocalActCommandImmediatelyFollowsLaMarkerWf>()
+                .unwrap();
+            options.register_activities(StdActivities);
+        },
+    );
     worker.run_until_done().await.unwrap();
 }
 
@@ -1980,7 +2043,6 @@ async fn test_schedule_to_start_timeout() {
     let wf_id = "fakeid";
     let mock = mock_worker_client();
     let mh = MockPollCfg::from_resp_batches(wf_id, t, [ResponseType::ToTaskNum(1)], mock);
-    let mut worker = mock_sdk_cfg(mh, |w| w.max_cached_workflows = 1);
 
     #[workflow]
     #[derive(Default)]
@@ -2011,10 +2073,16 @@ async fn test_schedule_to_start_timeout() {
         }
     }
 
-    worker
-        .register_workflow::<TestScheduleToStartTimeoutWf>()
-        .unwrap();
-    worker.register_activities(StdActivities);
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |w| w.max_cached_workflows = 1,
+        |options| {
+            options
+                .register_workflow::<TestScheduleToStartTimeoutWf>()
+                .unwrap();
+            options.register_activities(StdActivities);
+        },
+    );
     worker.run_until_done().await.unwrap();
 }
 
@@ -2065,7 +2133,6 @@ async fn test_schedule_to_start_timeout_not_based_on_original_time(
     let wf_id = "fakeid";
     let mock = mock_worker_client();
     let mh = MockPollCfg::from_resp_batches(wf_id, t, [ResponseType::AllHistory], mock);
-    let mut worker = mock_sdk_cfg(mh, |w| w.max_cached_workflows = 1);
 
     #[workflow]
     #[derive(Default)]
@@ -2111,10 +2178,16 @@ async fn test_schedule_to_start_timeout_not_based_on_original_time(
         }
     }
 
-    worker
-        .register_workflow::<TestScheduleToStartTimeoutNotBasedOnOriginalTimeWf>()
-        .unwrap();
-    worker.register_activities(StdActivities);
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |w| w.max_cached_workflows = 1,
+        |options| {
+            options
+                .register_workflow::<TestScheduleToStartTimeoutNotBasedOnOriginalTimeWf>()
+                .unwrap();
+            options.register_activities(StdActivities);
+        },
+    );
     worker.run_until_done().await.unwrap();
 }
 
@@ -2147,7 +2220,6 @@ async fn start_to_close_timeout_allows_retries(#[values(true, false)] la_complet
         [ResponseType::ToTaskNum(1), ResponseType::AllHistory],
         mock,
     );
-    let mut worker = mock_sdk_cfg(mh, |w| w.max_cached_workflows = 1);
 
     #[workflow]
     #[derive(Default)]
@@ -2188,9 +2260,6 @@ async fn start_to_close_timeout_allows_retries(#[values(true, false)] la_complet
         }
     }
 
-    worker
-        .register_workflow::<StartToCloseTimeoutAllowsRetriesWf>()
-        .unwrap();
     let attempts = Arc::new(AtomicUsize::new(0));
     let cancels = Arc::new(AtomicUsize::new(0));
 
@@ -2217,11 +2286,20 @@ async fn start_to_close_timeout_allows_retries(#[values(true, false)] la_complet
         }
     }
 
-    worker.register_activities(ActivityWithRetriesAndCancellation {
-        attempts: attempts.clone(),
-        cancels: cancels.clone(),
-        la_completes,
-    });
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |w| w.max_cached_workflows = 1,
+        |options| {
+            options
+                .register_workflow::<StartToCloseTimeoutAllowsRetriesWf>()
+                .unwrap();
+            options.register_activities(ActivityWithRetriesAndCancellation {
+                attempts: attempts.clone(),
+                cancels: cancels.clone(),
+                la_completes,
+            });
+        },
+    );
     worker.run_until_done().await.unwrap();
     assert_eq!(attempts.load(Ordering::Acquire), 5);
     let num_cancels = if la_completes { 4 } else { 5 };
@@ -2241,7 +2319,6 @@ async fn wft_failure_cancels_running_las() {
     let mock = mock_worker_client();
     let mut mh = MockPollCfg::from_resp_batches(wf_id, t, [1, 2], mock);
     mh.num_expected_fails = 1;
-    let mut worker = mock_sdk_cfg(mh, |w| w.max_cached_workflows = 1);
 
     #[workflow]
     #[derive(Default)]
@@ -2267,10 +2344,6 @@ async fn wft_failure_cancels_running_las() {
         }
     }
 
-    worker
-        .register_workflow::<WftFailureCancelsRunningLasWf>()
-        .unwrap();
-
     struct ActivityThatExpectsCancellation;
     #[activities]
     impl ActivityThatExpectsCancellation {
@@ -2284,7 +2357,16 @@ async fn wft_failure_cancels_running_las() {
         }
     }
 
-    worker.register_activities(ActivityThatExpectsCancellation);
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |w| w.max_cached_workflows = 1,
+        |options| {
+            options
+                .register_workflow::<WftFailureCancelsRunningLasWf>()
+                .unwrap();
+            options.register_activities(ActivityThatExpectsCancellation);
+        },
+    );
     worker.run_until_done().await.unwrap();
 }
 
@@ -2312,7 +2394,6 @@ async fn resolved_las_not_recorded_if_wft_fails_many_times() {
     );
     mh.num_expected_fails = 2;
     mh.num_expected_completions = Some(0.into());
-    let mut worker = mock_sdk_cfg(mh, |w| w.max_cached_workflows = 1);
 
     #[workflow]
     #[derive(Default)]
@@ -2333,10 +2414,16 @@ async fn resolved_las_not_recorded_if_wft_fails_many_times() {
         }
     }
 
-    worker
-        .register_workflow::<ResolvedLasNotRecordedIfWftFailsManyTimesWf>()
-        .unwrap();
-    worker.register_activities(StdActivities);
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |w| w.max_cached_workflows = 1,
+        |options| {
+            options
+                .register_workflow::<ResolvedLasNotRecordedIfWftFailsManyTimesWf>()
+                .unwrap();
+            options.register_activities(StdActivities);
+        },
+    );
     worker.run_until_done().await.unwrap();
 }
 
@@ -2362,10 +2449,6 @@ async fn local_act_records_nonfirst_attempts_ok() {
         );
         Ok(Default::default())
     }));
-    let mut worker = mock_sdk_cfg(mh, |wc| {
-        wc.max_cached_workflows = 1;
-        wc.max_outstanding_workflow_tasks = Some(1);
-    });
 
     #[workflow]
     #[derive(Default)]
@@ -2397,10 +2480,19 @@ async fn local_act_records_nonfirst_attempts_ok() {
         }
     }
 
-    worker
-        .register_workflow::<LocalActRecordsNonfirstAttemptsOkWf>()
-        .unwrap();
-    worker.register_activities(StdActivities);
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |wc| {
+            wc.max_cached_workflows = 1;
+            wc.max_outstanding_workflow_tasks = Some(1);
+        },
+        |options| {
+            options
+                .register_workflow::<LocalActRecordsNonfirstAttemptsOkWf>()
+                .unwrap();
+            options.register_activities(StdActivities);
+        },
+    );
     worker.run_until_done().await.unwrap();
     assert_eq!(nonfirst_counts.len(), 3);
     // First task's non-first count should, of course, be 0
@@ -2686,7 +2778,6 @@ async fn local_act_retry_explicit_delay() {
     let wf_id = "fakeid";
     let mock = mock_worker_client();
     let mh = MockPollCfg::from_resp_batches(wf_id, t, [1], mock);
-    let mut worker = mock_sdk(mh);
 
     #[workflow]
     #[derive(Default)]
@@ -2718,9 +2809,6 @@ async fn local_act_retry_explicit_delay() {
         }
     }
 
-    worker
-        .register_workflow::<LocalActRetryExplicitDelayWf>()
-        .unwrap();
     let attempts = Arc::new(AtomicUsize::new(0));
 
     struct ActivityWithExplicitBackoff {
@@ -2746,9 +2834,18 @@ async fn local_act_retry_explicit_delay() {
         }
     }
 
-    worker.register_activities(ActivityWithExplicitBackoff {
-        attempts: attempts.clone(),
-    });
+    let mut worker = crate::common::mock_sdk_cfg_with_options(
+        mh,
+        |_| {},
+        |options| {
+            options
+                .register_workflow::<LocalActRetryExplicitDelayWf>()
+                .unwrap();
+            options.register_activities(ActivityWithExplicitBackoff {
+                attempts: attempts.clone(),
+            });
+        },
+    );
     let start = Instant::now();
     worker.run_until_done().await.unwrap();
     let expected_attempts = 3;
@@ -2848,8 +2945,13 @@ async fn one_la_success(#[case] replay: bool, #[case] completes_ok: bool) {
         });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<LaWf>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<LaWf>().unwrap();
+        options.register_activities(ActivityWithReplayCheck {
+            replay,
+            completes_ok,
+        });
+    });
 
     struct ActivityWithReplayCheck {
         replay: bool,
@@ -2875,10 +2977,6 @@ async fn one_la_success(#[case] replay: bool, #[case] completes_ok: bool) {
         }
     }
 
-    worker.register_activities(ActivityWithReplayCheck {
-        replay,
-        completes_ok,
-    });
     worker.run().await.unwrap();
 }
 
@@ -2981,10 +3079,11 @@ async fn local_activity_resolutions_are_delivered_incrementally() {
             short_completed: Arc::new(AtomicUsize::new(0)),
             short_sequence_completed: short_sequence_completed.clone(),
         });
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<IncrementalLocalActivityResolutionWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
         .submit_workflow(
@@ -3086,11 +3185,16 @@ async fn old_batched_local_activity_history_replays() {
         });
     });
 
-    let mut worker = build_fake_sdk_intercepted(mock_cfg, activation_assertions);
-    worker
-        .register_workflow::<OldBatchedLocalActivityHistoryWf>()
-        .unwrap();
-    worker.register_activities(ResolvedActivity);
+    let mut worker = crate::common::build_fake_sdk_intercepted_with_options(
+        mock_cfg,
+        activation_assertions,
+        |options| {
+            options
+                .register_workflow::<OldBatchedLocalActivityHistoryWf>()
+                .unwrap();
+            options.register_activities(ResolvedActivity);
+        },
+    );
     worker.run().await.unwrap();
 }
 
@@ -3225,11 +3329,16 @@ async fn mixed_la_completion_times(#[values(true, false)] replay: bool) {
         }
     });
 
-    let mut worker = build_fake_sdk_intercepted(mock_cfg, activation_assertions);
-    worker
-        .register_workflow::<MixedCompletionTimesWf>()
-        .unwrap();
-    worker.register_activities(MixedCompletionTimesActivity { release_slow });
+    let mut worker = crate::common::build_fake_sdk_intercepted_with_options(
+        mock_cfg,
+        activation_assertions,
+        |options| {
+            options
+                .register_workflow::<MixedCompletionTimesWf>()
+                .unwrap();
+            options.register_activities(MixedCompletionTimesActivity { release_slow });
+        },
+    );
     worker.run().await.unwrap();
 }
 
@@ -3315,11 +3424,16 @@ async fn two_las_with_heartbeat(
         }
     });
 
-    let mut worker = build_fake_sdk_intercepted(mock_cfg, activation_assertions);
-    worker.register_workflow::<TwoLaWfParallel>().unwrap();
-    worker.register_activities(HeartbeatGatedActivity {
-        release: release_activities,
-    });
+    let mut worker = crate::common::build_fake_sdk_intercepted_with_options(
+        mock_cfg,
+        activation_assertions,
+        |options| {
+            options.register_workflow::<TwoLaWfParallel>().unwrap();
+            options.register_activities(HeartbeatGatedActivity {
+                release: release_activities,
+            });
+        },
+    );
     worker.run().await.unwrap();
 }
 
@@ -3428,13 +3542,15 @@ async fn two_sequential_las(
         });
     });
 
-    let mut worker = build_fake_sdk_intercepted(mock_cfg, aai);
-    if parallel {
-        worker.register_workflow::<TwoLaWfParallel>().unwrap();
-    } else {
-        worker.register_workflow::<TwoLaWf>().unwrap();
-    }
-    worker.register_activities(ResolvedActivity);
+    let mut worker =
+        crate::common::build_fake_sdk_intercepted_with_options(mock_cfg, aai, |options| {
+            if parallel {
+                options.register_workflow::<TwoLaWfParallel>().unwrap();
+            } else {
+                options.register_workflow::<TwoLaWf>().unwrap();
+            }
+            options.register_activities(ResolvedActivity);
+        });
     worker.run().await.unwrap();
 }
 
@@ -3523,9 +3639,11 @@ async fn las_separated_by_timer(#[case] replay: bool) {
         }
     });
 
-    let mut worker = build_fake_sdk_intercepted(mock_cfg, aai);
-    worker.register_workflow::<LaTimerLaWf>().unwrap();
-    worker.register_activities(ResolvedActivity);
+    let mut worker =
+        crate::common::build_fake_sdk_intercepted_with_options(mock_cfg, aai, |options| {
+            options.register_workflow::<LaTimerLaWf>().unwrap();
+            options.register_activities(ResolvedActivity);
+        });
     worker.run().await.unwrap();
 }
 
@@ -3555,9 +3673,10 @@ async fn one_la_heartbeating_wft_failure_still_executes() {
         });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<LaWf>().unwrap();
-    worker.register_activities(ResolvedActivity);
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<LaWf>().unwrap();
+        options.register_activities(ResolvedActivity);
+    });
     worker.run().await.unwrap();
 }
 
@@ -3590,8 +3709,6 @@ async fn immediate_cancel(
         });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-
     #[workflow]
     #[derive(Default)]
     struct CancelBeforeActStartsWf;
@@ -3616,9 +3733,11 @@ async fn immediate_cancel(
         }
     }
 
-    worker
-        .register_workflow::<CancelBeforeActStartsWf>()
-        .unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options
+            .register_workflow::<CancelBeforeActStartsWf>()
+            .unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -3706,8 +3825,6 @@ async fn cancel_after_act_starts_canned(
         });
     }
 
-    let mut worker = build_fake_sdk(mock_cfg);
-
     #[workflow]
     #[derive(Default)]
     struct CancelAfterActStartsCannedWf;
@@ -3738,10 +3855,6 @@ async fn cancel_after_act_starts_canned(
         }
     }
 
-    worker
-        .register_workflow::<CancelAfterActStartsCannedWf>()
-        .unwrap();
-
     struct ActivityWithConditionalCancelWait {
         cancel_type: ActivityCancellationType,
         allow_cancel_barr: CancellationToken,
@@ -3758,9 +3871,14 @@ async fn cancel_after_act_starts_canned(
         }
     }
 
-    worker.register_activities(ActivityWithConditionalCancelWait {
-        cancel_type,
-        allow_cancel_barr: allow_cancel_barr_clone,
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options
+            .register_workflow::<CancelAfterActStartsCannedWf>()
+            .unwrap();
+        options.register_activities(ActivityWithConditionalCancelWait {
+            cancel_type,
+            allow_cancel_barr: allow_cancel_barr_clone,
+        });
     });
     worker.run().await.unwrap();
 }
@@ -3877,11 +3995,11 @@ async fn heartbeat_timeout_does_not_overlap_local_activity_resolution_activation
             long_started: long_started.clone(),
             release_long: release_long.clone(),
         });
-
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<HeartbeatTimeoutOverlapWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -4030,11 +4148,11 @@ async fn replay_out_of_order_local_activity_markers_is_deterministic() {
         .register_activities(OutOfOrderMarkerActivities {
             release_first: release_first.clone(),
         });
-
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<OutOfOrderMarkerWorkflow>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/modify_wf_properties.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/modify_wf_properties.rs
@@ -1,16 +1,13 @@
-use crate::common::{CoreWfStarter, build_fake_sdk};
+use crate::common::CoreWfStarter;
 use temporalio_client::{
     NamespacedClient, WorkflowDescribeOptions, WorkflowExecutionInfo, WorkflowStartOptions,
 };
-use temporalio_common::{
-    protos::{
-        coresdk::FromJsonPayloadExt,
-        temporal::api::{
-            command::v1::{Command, command},
-            enums::v1::EventType,
-        },
+use temporalio_common::protos::{
+    coresdk::FromJsonPayloadExt,
+    temporal::api::{
+        command::v1::{Command, command},
+        enums::v1::EventType,
     },
-    worker::WorkerTaskTypes,
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{MemoValue, WorkflowContext, WorkflowResult};
@@ -50,10 +47,11 @@ async fn sends_modify_wf_props() {
     let wf_name = "can_upsert_memo";
     let wf_id = Uuid::new_v4();
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<MemoUpserter>()
+        .unwrap();
     let mut worker = starter.worker().await;
-
-    worker.register_workflow::<MemoUpserter>().unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     let run_id = worker
         .submit_wf(
@@ -134,7 +132,8 @@ async fn workflow_modify_props() {
         });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<ModifyPropsWf>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<ModifyPropsWf>().unwrap();
+    });
     worker.run().await.unwrap();
 }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/modify_wf_properties.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/modify_wf_properties.rs
@@ -63,7 +63,7 @@ async fn sends_modify_wf_props() {
         .unwrap();
     worker.run_until_done().await.unwrap();
 
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let description = WorkflowExecutionInfo {
         namespace: client.namespace(),
         workflow_id: wf_id.to_string(),

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/nexus.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/nexus.rs
@@ -118,7 +118,7 @@ async fn nexus_basic(
         .register_workflow::<NexusBasicWf>()
         .unwrap();
     let mut worker = starter.worker().await;
-    let core_worker = starter.get_worker().await;
+    let core_worker = starter.get_core_worker().await;
 
     let endpoint = mk_nexus_endpoint(&mut starter).await;
 
@@ -131,7 +131,7 @@ async fn nexus_basic(
         .await
         .unwrap();
 
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let nexus_task_handle = async {
         let nt = core_worker.poll_nexus_task().await.unwrap().unwrap_task();
         match outcome {
@@ -338,7 +338,7 @@ async fn nexus_async(
         .register_workflow::<AsyncCompleter>()
         .unwrap();
     let mut worker = starter.worker().await;
-    let core_worker = starter.get_worker().await;
+    let core_worker = starter.get_core_worker().await;
 
     let endpoint = mk_nexus_endpoint(&mut starter).await;
     let schedule_to_close_timeout = if outcome == Outcome::CancelAfterRecordedBeforeStarted {
@@ -362,7 +362,7 @@ async fn nexus_async(
         .await
         .unwrap();
 
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let nexus_task_handle = async {
         let mut nt = core_worker.poll_nexus_task().await.unwrap().unwrap_task();
         // Verify request header key for timeout exists and is lowercase
@@ -644,7 +644,7 @@ async fn workflow_cancellation_propagates_to_started_nexus_operation() {
         enable_remote_activities: false,
         enable_nexus: true,
     });
-    let core_worker = starter.get_worker().await;
+    let core_worker = starter.get_core_worker().await;
     let endpoint = mk_nexus_endpoint(&mut starter).await;
     let started = Arc::new(Semaphore::new(0));
 
@@ -787,7 +787,7 @@ async fn nexus_must_complete_task_to_shutdown(#[values(true, false)] use_grace_p
         .register_workflow::<NexusMustCompleteTaskWf>()
         .unwrap();
     let mut worker = starter.worker().await;
-    let core_worker = starter.get_worker().await;
+    let core_worker = starter.get_core_worker().await;
 
     let endpoint = mk_nexus_endpoint(&mut starter).await;
 
@@ -968,7 +968,7 @@ async fn nexus_cancellation_types(
     // This test uses a tokio watch channel directly from workflow code to
     // coordinate with the test harness, which triggers nondeterminism detection.
     starter.sdk_config.detect_nondeterministic_futures = false;
-    let core_worker = starter.get_worker().await;
+    let core_worker = starter.get_core_worker().await;
 
     let endpoint = mk_nexus_endpoint(&mut starter).await;
     let schedule_to_close_timeout = Some(Duration::from_secs(5));
@@ -1009,7 +1009,7 @@ async fn nexus_cancellation_types(
     let mut worker = starter.worker().await;
     let submitter = worker.get_submitter_handle();
     let wf_handle = starter.start_with_worker(wf_name, &mut worker).await;
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let (handler_wf_id_tx, mut handler_wf_id_rx) = tokio::sync::oneshot::channel();
     let completer_id = &format!("completer-{}", rand_6_chars());
     let nexus_task_handle = async {

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/nexus.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/nexus.rs
@@ -107,18 +107,21 @@ async fn nexus_basic(
 ) {
     let wf_name = "nexus_basic";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes {
+    starter.set_core_task_types(WorkerTaskTypes {
         enable_workflows: true,
         enable_local_activities: false,
         enable_remote_activities: false,
         enable_nexus: true,
-    };
+    });
+    starter
+        .sdk_config
+        .register_workflow::<NexusBasicWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
     let core_worker = starter.get_worker().await;
 
     let endpoint = mk_nexus_endpoint(&mut starter).await;
 
-    worker.register_workflow::<NexusBasicWf>().unwrap();
     let wf_handle = worker
         .submit_workflow(
             NexusBasicWf::run,
@@ -320,12 +323,20 @@ async fn nexus_async(
 ) {
     let wf_name = "nexus_async";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes {
+    starter.set_core_task_types(WorkerTaskTypes {
         enable_workflows: true,
         enable_local_activities: false,
         enable_remote_activities: false,
         enable_nexus: true,
-    };
+    });
+    starter
+        .sdk_config
+        .register_workflow::<NexusAsyncWf>()
+        .unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<AsyncCompleter>()
+        .unwrap();
     let mut worker = starter.worker().await;
     let core_worker = starter.get_worker().await;
 
@@ -336,8 +347,6 @@ async fn nexus_async(
         Some(Duration::from_secs(5))
     };
 
-    worker.register_workflow::<NexusAsyncWf>().unwrap();
-    worker.register_workflow::<AsyncCompleter>().unwrap();
     let submitter = worker.get_submitter_handle();
     let converter = PayloadConverter::default();
     let ser_ctx = SerializationContext {
@@ -565,19 +574,20 @@ impl NexusCancelBeforeStartWf {
 async fn nexus_cancel_before_start() {
     let wf_name = "nexus_cancel_before_start";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes {
+    starter.set_core_task_types(WorkerTaskTypes {
         enable_workflows: true,
         enable_local_activities: false,
         enable_remote_activities: false,
         enable_nexus: true,
-    };
+    });
+    starter
+        .sdk_config
+        .register_workflow::<NexusCancelBeforeStartWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
 
     let endpoint = mk_nexus_endpoint(&mut starter).await;
 
-    worker
-        .register_workflow::<NexusCancelBeforeStartWf>()
-        .unwrap();
     let handle = worker
         .submit_workflow(
             NexusCancelBeforeStartWf::run,
@@ -628,18 +638,18 @@ impl NexusRootCancellationWf {
 async fn workflow_cancellation_propagates_to_started_nexus_operation() {
     let wf_name = "workflow_cancellation_propagates_to_started_nexus_operation";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes {
+    starter.set_core_task_types(WorkerTaskTypes {
         enable_workflows: true,
         enable_local_activities: false,
         enable_remote_activities: false,
         enable_nexus: true,
-    };
-    let mut worker = starter.worker().await;
+    });
     let core_worker = starter.get_worker().await;
     let endpoint = mk_nexus_endpoint(&mut starter).await;
     let started = Arc::new(Semaphore::new(0));
 
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory({
             let endpoint = endpoint.clone();
             let started = started.clone();
@@ -649,6 +659,7 @@ async fn workflow_cancellation_propagates_to_started_nexus_operation() {
             }
         })
         .unwrap();
+    let mut worker = starter.worker().await;
     let wf_handle = worker
         .submit_workflow(
             NexusRootCancellationWf::run,
@@ -762,23 +773,24 @@ impl NexusMustCompleteTaskWf {
 async fn nexus_must_complete_task_to_shutdown(#[values(true, false)] use_grace_period: bool) {
     let wf_name = "nexus_must_complete_task_to_shutdown";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes {
+    starter.set_core_task_types(WorkerTaskTypes {
         enable_workflows: true,
         enable_local_activities: false,
         enable_remote_activities: false,
         enable_nexus: true,
-    };
+    });
     if use_grace_period {
         starter.sdk_config.graceful_shutdown_period = Some(Duration::from_millis(500));
     }
+    starter
+        .sdk_config
+        .register_workflow::<NexusMustCompleteTaskWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
     let core_worker = starter.get_worker().await;
 
     let endpoint = mk_nexus_endpoint(&mut starter).await;
 
-    worker
-        .register_workflow::<NexusMustCompleteTaskWf>()
-        .unwrap();
     let handle = worker
         .submit_workflow(
             NexusMustCompleteTaskWf::run,
@@ -947,23 +959,23 @@ async fn nexus_cancellation_types(
 ) {
     let wf_name = "nexus_cancellation_types";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes {
+    starter.set_core_task_types(WorkerTaskTypes {
         enable_workflows: true,
         enable_local_activities: false,
         enable_remote_activities: false,
         enable_nexus: true,
-    };
+    });
     // This test uses a tokio watch channel directly from workflow code to
     // coordinate with the test harness, which triggers nondeterminism detection.
     starter.sdk_config.detect_nondeterministic_futures = false;
-    let mut worker = starter.worker().await;
     let core_worker = starter.get_worker().await;
 
     let endpoint = mk_nexus_endpoint(&mut starter).await;
     let schedule_to_close_timeout = Some(Duration::from_secs(5));
 
     let (caller_op_future_tx, caller_op_future_rx) = watch::channel(false);
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory({
             let endpoint = endpoint.clone();
             let caller_op_future_tx = caller_op_future_tx.clone();
@@ -979,7 +991,8 @@ async fn nexus_cancellation_types(
     let cancellation_wait_happened = Arc::new(AtomicBool::new(false));
     let (cancellation_tx, mut cancellation_rx) = watch::channel(false);
     let (handler_exited_tx, mut handler_exited_rx) = watch::channel(false);
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory({
             let cancellation_wait_happened = cancellation_wait_happened.clone();
             let cancellation_tx = cancellation_tx.clone();
@@ -993,6 +1006,7 @@ async fn nexus_cancellation_types(
             }
         })
         .unwrap();
+    let mut worker = starter.worker().await;
     let submitter = worker.get_submitter_handle();
     let wf_handle = starter.start_with_worker(wf_name, &mut worker).await;
     let client = starter.get_client().await;

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
@@ -1,7 +1,4 @@
-use crate::common::{
-    ActivationAssertionsInterceptor, CoreWfStarter, WorkflowHandleExt, build_fake_sdk,
-    build_fake_sdk_intercepted,
-};
+use crate::common::{ActivationAssertionsInterceptor, CoreWfStarter, WorkflowHandleExt};
 use std::{
     collections::{HashSet, VecDeque, hash_map::RandomState},
     sync::{
@@ -37,7 +34,6 @@ use temporalio_common::{
     },
 };
 
-use temporalio_common::worker::WorkerTaskTypes;
 use temporalio_macros::{activity_definitions, workflow, workflow_methods};
 use temporalio_sdk::{
     ActivityOptions, PatchActivationCallback, SyncWorkflowContext, WorkflowContext, WorkflowResult,
@@ -79,9 +75,8 @@ impl ChangesWf {
 async fn writes_change_markers() {
     let wf_name = "writes_change_markers";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter.sdk_config.register_workflow::<ChangesWf>().unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<ChangesWf>().unwrap();
 
     starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
@@ -120,14 +115,14 @@ impl NoChangeThenChangeWf {
 async fn can_add_change_markers() {
     let wf_name = "can_add_change_markers";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
     let did_die = Arc::new(AtomicBool::new(false));
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || NoChangeThenChangeWf {
             did_die: did_die.clone(),
         })
         .unwrap();
+    let mut worker = starter.worker().await;
 
     starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
@@ -156,14 +151,14 @@ impl ReplayWithChangeMarkerWf {
 async fn replaying_with_patch_marker() {
     let wf_name = "replaying_with_patch_marker";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
     let did_die = Arc::new(AtomicBool::new(false));
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || ReplayWithChangeMarkerWf {
             did_die: did_die.clone(),
         })
         .unwrap();
+    let mut worker = starter.worker().await;
 
     starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
@@ -188,7 +183,6 @@ impl PatchActivationTwiceWf {
 async fn patch_activation_callback_is_memoized_across_replay() {
     let wf_name = "patch_activation_callback_is_memoized_across_replay";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.sdk_config.max_cached_workflows = 0;
     let callback_calls = Arc::new(AtomicUsize::new(0));
     let callback_calls_clone = callback_calls.clone();
@@ -196,10 +190,11 @@ async fn patch_activation_callback_is_memoized_across_replay() {
         callback_calls_clone.fetch_add(1, Ordering::Relaxed);
         false
     }));
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<PatchActivationTwiceWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
     let workflow_id = starter.get_task_queue().to_string();
     let handle = worker
         .submit_workflow(
@@ -273,7 +268,6 @@ impl PatchActivationOldRolloutWf {
 async fn declined_patch_can_roll_out_to_old_worker() {
     let wf_name = "declined_patch_can_roll_out_to_old_worker";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     let callback_calls = Arc::new(AtomicUsize::new(0));
     let callback_calls_clone = callback_calls.clone();
     let workflow_id = starter.get_task_queue().to_string();
@@ -285,15 +279,17 @@ async fn declined_patch_can_roll_out_to_old_worker() {
         false
     });
     starter.sdk_config.patch_activation_callback = Some(callback);
-    let mut worker = starter.worker().await;
+    let mut old_starter = starter.clone_no_worker();
     let ready = Arc::new(Notify::new());
     let ready_clone = ready.clone();
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || PatchActivationRolloutWf {
             ready: ready_clone.clone(),
             released: false,
         })
         .unwrap();
+    let mut worker = starter.worker().await;
     let handle = worker
         .submit_workflow(
             PatchActivationRolloutWf::run,
@@ -316,12 +312,12 @@ async fn declined_patch_can_roll_out_to_old_worker() {
             if attrs.marker_name == PATCH_MARKER_NAME
     )));
 
-    let mut old_starter = starter.clone_no_worker();
     old_starter.sdk_config.patch_activation_callback = None;
-    let mut old_worker = old_starter.worker().await;
-    old_worker
+    old_starter
+        .sdk_config
         .register_workflow::<PatchActivationOldRolloutWf>()
         .unwrap();
+    let mut old_worker = old_starter.worker().await;
     old_worker.expect_workflow_completion(workflow_id, handle.info().run_id.clone());
     let (signal_result, run_result) = join!(
         handle.signal(
@@ -340,22 +336,23 @@ async fn declined_patch_can_roll_out_to_old_worker() {
 async fn activated_patch_replays_without_consulting_declining_callback() {
     let wf_name = "activated_patch_replays_without_consulting_declining_callback";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     let activated_calls = Arc::new(AtomicUsize::new(0));
     let activated_calls_clone = activated_calls.clone();
     starter.sdk_config.patch_activation_callback = Some(Arc::new(move |_| {
         activated_calls_clone.fetch_add(1, Ordering::Relaxed);
         true
     }));
-    let mut worker = starter.worker().await;
+    let mut declining_starter = starter.clone_no_worker();
     let ready = Arc::new(Notify::new());
     let ready_clone = ready.clone();
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || PatchActivationRolloutWf {
             ready: ready_clone.clone(),
             released: false,
         })
         .unwrap();
+    let mut worker = starter.worker().await;
     let workflow_id = starter.get_task_queue().to_string();
     let handle = worker
         .submit_workflow(
@@ -379,20 +376,20 @@ async fn activated_patch_replays_without_consulting_declining_callback() {
             if attrs.marker_name == PATCH_MARKER_NAME
     )));
 
-    let mut declining_starter = starter.clone_no_worker();
     let declining_calls = Arc::new(AtomicUsize::new(0));
     let declining_calls_clone = declining_calls.clone();
     declining_starter.sdk_config.patch_activation_callback = Some(Arc::new(move |_| {
         declining_calls_clone.fetch_add(1, Ordering::Relaxed);
         false
     }));
-    let mut declining_worker = declining_starter.worker().await;
-    declining_worker
+    declining_starter
+        .sdk_config
         .register_workflow_with_factory(move || PatchActivationRolloutWf {
             ready: Arc::new(Notify::new()),
             released: false,
         })
         .unwrap();
+    let mut declining_worker = declining_starter.worker().await;
     declining_worker.expect_workflow_completion(workflow_id, handle.info().run_id.clone());
     let (signal_result, run_result) = join!(
         handle.signal(
@@ -437,14 +434,14 @@ async fn patched_on_second_workflow_task_is_deterministic() {
     let mut starter = CoreWfStarter::new(wf_name);
     // Disable caching to force replay from beginning
     starter.sdk_config.max_cached_workflows = 0_usize;
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
     let fail_once = Arc::new(AtomicBool::new(true));
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || TimerPatchedTimerWf {
             fail_once: fail_once.clone(),
         })
         .unwrap();
+    let mut worker = starter.worker().await;
 
     starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
@@ -480,14 +477,14 @@ impl RemoveDeprecatedPatchNearOtherPatchWf {
 async fn can_remove_deprecated_patch_near_other_patch() {
     let wf_name = "can_add_change_markers";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
     let did_die = Arc::new(AtomicBool::new(false));
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || RemoveDeprecatedPatchNearOtherPatchWf {
             did_die: did_die.clone(),
         })
         .unwrap();
+    let mut worker = starter.worker().await;
 
     starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
@@ -529,19 +526,19 @@ impl DeprecatedPatchRemovalWf {
 async fn deprecated_patch_removal() {
     let wf_name = "deprecated_patch_removal";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
     let wf_id = starter.get_task_queue().to_string();
     let did_die = Arc::new(AtomicBool::new(false));
     let send_sig = Arc::new(Notify::new());
     let send_sig_clone = send_sig.clone();
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || DeprecatedPatchRemovalWf {
             did_die: did_die.clone(),
             notify: send_sig_clone.clone(),
             signal_received: false,
         })
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let handle = worker
         .submit_workflow(
@@ -806,12 +803,14 @@ async fn v1_and_v4_changes(
         });
     }
 
-    let mut worker = build_fake_sdk_intercepted(mock_cfg, aai);
-    worker
-        .register_workflow_with_factory(move || PatchWf {
-            version: wf_version,
-        })
-        .unwrap();
+    let mut worker =
+        crate::common::build_fake_sdk_intercepted_with_options(mock_cfg, aai, |options| {
+            options
+                .register_workflow_with_factory(move || PatchWf {
+                    version: wf_version,
+                })
+                .unwrap();
+        });
     worker.run().await.unwrap();
 }
 
@@ -914,12 +913,14 @@ async fn v2_and_v3_changes(
         });
     }
 
-    let mut worker = build_fake_sdk_intercepted(mock_cfg, aai);
-    worker
-        .register_workflow_with_factory(move || PatchWf {
-            version: wf_version,
-        })
-        .unwrap();
+    let mut worker =
+        crate::common::build_fake_sdk_intercepted_with_options(mock_cfg, aai, |options| {
+            options
+                .register_workflow_with_factory(move || PatchWf {
+                    version: wf_version,
+                })
+                .unwrap();
+        });
     worker.run().await.unwrap();
 }
 
@@ -1044,10 +1045,11 @@ async fn same_change_multiple_spots(#[case] have_marker_in_hist: bool, #[case] r
         MockPollCfg::from_hist_builder(t)
     };
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker
-        .register_workflow::<SameChangeMultipleSpotsWf>()
-        .unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options
+            .register_workflow::<SameChangeMultipleSpotsWf>()
+            .unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -1125,10 +1127,11 @@ async fn many_patches_combine_in_search_attrib_update(#[case] num_patches: usize
         }
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker
-        .register_workflow_with_factory(move || ManyPatchesWf { num_patches })
-        .unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options
+            .register_workflow_with_factory(move || ManyPatchesWf { num_patches })
+            .unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -1157,9 +1160,11 @@ impl ManyPatchesInOneWftWf {
 async fn patch_marker_size_overflow_replay_is_deterministic() {
     let wf_name = "patch_marker_size_overflow_replay_is_deterministic";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<ManyPatchesInOneWftWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<ManyPatchesInOneWftWf>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/queries.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/queries.rs
@@ -1,6 +1,5 @@
 //! Tests for SDK-level query handling
 
-use crate::common::build_fake_sdk;
 use serde::{Deserialize, Serialize};
 use std::{cell::Cell, collections::HashMap, future::poll_fn, task::Poll, time::Duration};
 use temporalio_common::protos::{
@@ -111,10 +110,11 @@ async fn query_only_activation_should_not_advance_workflow() {
             });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker
-        .register_workflow::<CompleteOnSecondPollWf>()
-        .unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options
+            .register_workflow::<CompleteOnSecondPollWf>()
+            .unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -170,10 +170,11 @@ async fn nonexistent_query_should_not_advance_workflow() {
             });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker
-        .register_workflow::<CompleteOnSecondPollWf>()
-        .unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options
+            .register_workflow::<CompleteOnSecondPollWf>()
+            .unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -298,8 +299,9 @@ async fn non_legacy_query_should_see_state_after_workflow_advances() {
             });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<CounterWf>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<CounterWf>().unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -414,8 +416,9 @@ async fn query_returns_workflow_context_view_info() {
         });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<ContextViewWf>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<ContextViewWf>().unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -508,8 +511,9 @@ async fn workflow_metadata_query_returns_current_details() {
         true
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<CurrentDetailsWf>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<CurrentDetailsWf>().unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -583,7 +587,8 @@ async fn workflow_metadata_query_empty_details() {
         true
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<NoCurrentDetailsWf>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<NoCurrentDetailsWf>().unwrap();
+    });
     worker.run().await.unwrap();
 }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/replay.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/replay.rs
@@ -1,8 +1,6 @@
 use crate::{
     common::{
-        ActivationAssertionsInterceptor, build_fake_sdk_intercepted, history_from_proto_binary,
-        init_core_replay_preloaded, replay_sdk_worker, replay_sdk_worker_intercepted,
-        replay_sdk_worker_stream_intercepted,
+        ActivationAssertionsInterceptor, history_from_proto_binary, init_core_replay_preloaded,
     },
     integ_tests::workflow_tests::patches::ChangesWf,
 };
@@ -67,10 +65,13 @@ fn fire_happy_hist(num_timers: u32) -> Worker {
     for _ in 1..=num_timers + 1 {
         aai.then(|activation| assert!(activation.is_replaying));
     }
-    let mut worker =
-        build_fake_sdk_intercepted(MockPollCfg::from_resps(t, [ResponseType::AllHistory]), aai);
-    worker.register_workflow::<TimersWf>().unwrap();
-    worker
+    crate::common::build_fake_sdk_intercepted_with_options(
+        MockPollCfg::from_resps(t, [ResponseType::AllHistory]),
+        aai,
+        |options| {
+            options.register_workflow::<TimersWf>().unwrap();
+        },
+    )
 }
 
 #[rstest]
@@ -90,8 +91,13 @@ async fn replay_flag_is_correct_partial_history() {
     t.set_wf_input(1u32.as_json_payload().unwrap());
     let mut aai = ActivationAssertionsInterceptor::default();
     aai.then(|a| assert!(!a.is_replaying));
-    let mut worker = build_fake_sdk_intercepted(MockPollCfg::from_resps(t, [1]), aai);
-    worker.register_workflow::<TimersWf>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_intercepted_with_options(
+        MockPollCfg::from_resps(t, [1]),
+        aai,
+        |options| {
+            options.register_workflow::<TimersWf>().unwrap();
+        },
+    );
     worker.run().await.unwrap();
 }
 
@@ -197,8 +203,10 @@ async fn replay_using_wf_function() {
     let num_timers = 10u32;
     let mut t = canned_histories::long_sequential_timers(num_timers as usize);
     t.set_wf_input(num_timers.as_json_payload().unwrap());
-    let mut worker = replay_sdk_worker([test_hist_to_replay(t)]);
-    worker.register_workflow::<TimersWf>().unwrap();
+    let mut worker =
+        crate::common::replay_sdk_worker_with_options([test_hist_to_replay(t)], |options| {
+            options.register_workflow::<TimersWf>().unwrap();
+        });
     worker.run().await.unwrap();
 }
 
@@ -214,15 +222,19 @@ async fn replay_ending_wft_complete_with_commands_but_no_scheduled_started() {
         t.add_full_wf_task();
     }
     t.set_wf_input(3u32.as_json_payload().unwrap());
-    let mut worker = replay_sdk_worker([test_hist_to_replay(t)]);
-    worker.register_workflow::<TimersWf>().unwrap();
+    let mut worker =
+        crate::common::replay_sdk_worker_with_options([test_hist_to_replay(t)], |options| {
+            options.register_workflow::<TimersWf>().unwrap();
+        });
     worker.run().await.unwrap();
 }
 
 async fn replay_abrupt_ending(mut t: TestHistoryBuilder) {
     t.set_wf_input(1u32.as_json_payload().unwrap());
-    let mut worker = replay_sdk_worker([test_hist_to_replay(t)]);
-    worker.register_workflow::<TimersWf>().unwrap();
+    let mut worker =
+        crate::common::replay_sdk_worker_with_options([test_hist_to_replay(t)], |options| {
+            options.register_workflow::<TimersWf>().unwrap();
+        });
     worker.run().await.unwrap();
 }
 #[tokio::test]
@@ -244,8 +256,13 @@ async fn replay_shutdown_worker() {
     t.set_wf_input(1u32.as_json_payload().unwrap());
     let shutdown_ctr_i = UniqueShutdownWorker::default();
     let shutdown_ctr = shutdown_ctr_i.runs.clone();
-    let mut worker = replay_sdk_worker_intercepted([test_hist_to_replay(t)], shutdown_ctr_i);
-    worker.register_workflow::<TimersWf>().unwrap();
+    let mut worker = crate::common::replay_sdk_worker_intercepted_with_options(
+        [test_hist_to_replay(t)],
+        shutdown_ctr_i,
+        |options| {
+            options.register_workflow::<TimersWf>().unwrap();
+        },
+    );
     worker.run().await.unwrap();
     assert_eq!(shutdown_ctr.lock().len(), 1);
 }
@@ -308,18 +325,27 @@ async fn multiple_histories_replay(#[values(false, true)] use_feeder: bool) {
     let runs_ctr_i = UniqueRunsCounter::default();
     let runs_ctr = runs_ctr_i.runs.clone();
     let mut worker = if use_feeder {
-        replay_sdk_worker_stream_intercepted(stream, runs_ctr_i)
+        crate::common::replay_sdk_worker_stream_intercepted_with_options(
+            stream,
+            runs_ctr_i,
+            |options| {
+                options.register_workflow::<OneTimerWf>().unwrap();
+                options.register_workflow::<SeqTimerWf>().unwrap();
+            },
+        )
     } else {
-        replay_sdk_worker_intercepted(
+        crate::common::replay_sdk_worker_intercepted_with_options(
             [
                 test_hist_to_replay(one_timer_hist.clone()),
                 test_hist_to_replay(seq_timer_hist.clone()),
             ],
             runs_ctr_i,
+            |options| {
+                options.register_workflow::<OneTimerWf>().unwrap();
+                options.register_workflow::<SeqTimerWf>().unwrap();
+            },
         )
     };
-    worker.register_workflow::<OneTimerWf>().unwrap();
-    worker.register_workflow::<SeqTimerWf>().unwrap();
 
     if use_feeder {
         let feed_fut = async move {
@@ -345,25 +371,33 @@ async fn multiple_histories_can_handle_dupe_run_ids() {
     let mut hist1 = canned_histories::single_timer("1");
     hist1.set_wf_type("onetimer");
     hist1.set_wf_input(1u32.as_json_payload().unwrap());
-    let mut worker = replay_sdk_worker([
-        test_hist_to_replay(hist1.clone()),
-        test_hist_to_replay(hist1.clone()),
-        test_hist_to_replay(hist1),
-    ]);
-    worker.register_workflow::<OneTimerWf>().unwrap();
+    let mut worker = crate::common::replay_sdk_worker_with_options(
+        [
+            test_hist_to_replay(hist1.clone()),
+            test_hist_to_replay(hist1.clone()),
+            test_hist_to_replay(hist1),
+        ],
+        |options| {
+            options.register_workflow::<OneTimerWf>().unwrap();
+        },
+    );
     worker.run().await.unwrap();
 }
 
 // Verifies SDK can decode patch markers before changing them to use json encoding.
 #[tokio::test]
 async fn replay_old_patch_format() {
-    let mut worker = replay_sdk_worker([HistoryForReplay::new(
-        history_from_proto_binary("old_change_marker_format.bin")
-            .await
-            .unwrap(),
-        "fake".to_owned(),
-    )]);
-    worker.register_workflow::<ChangesWf>().unwrap();
+    let mut worker = crate::common::replay_sdk_worker_with_options(
+        [HistoryForReplay::new(
+            history_from_proto_binary("old_change_marker_format.bin")
+                .await
+                .unwrap(),
+            "fake".to_owned(),
+        )],
+        |options| {
+            options.register_workflow::<ChangesWf>().unwrap();
+        },
+    );
     worker.run().await.unwrap();
 }
 

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/resets.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/resets.rs
@@ -73,7 +73,7 @@ async fn reset_workflow() {
         .unwrap();
     let run_id = handle.info().run_id.clone().unwrap();
 
-    let mut client = starter.get_client().await;
+    let mut client = starter.get_core_client().await;
     let resetter_fut = async {
         notify.notified().await;
         // Do the reset
@@ -225,7 +225,7 @@ async fn reset_randomseed() {
         .unwrap();
     let run_id = handle.info().run_id.clone().unwrap();
 
-    let mut client = starter.get_client().await;
+    let mut client = starter.get_core_client().await;
     let client_fur = async {
         notify.notified().await;
         handle

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/resets.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/resets.rs
@@ -14,7 +14,6 @@ use temporalio_common::protos::temporal::api::{
     common::v1::WorkflowExecution, workflowservice::v1::ResetWorkflowExecutionRequest,
 };
 
-use temporalio_common::worker::WorkerTaskTypes;
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{LocalActivityOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult};
 use tokio::sync::Notify;
@@ -50,18 +49,18 @@ impl ResetMeWf {
 async fn reset_workflow() {
     let wf_name = "reset_me_wf";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-    worker.fetch_results = false;
 
     let notify = Arc::new(Notify::new());
     let notify_clone = notify.clone();
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || ResetMeWf {
             notify: notify_clone.clone(),
             post_reset_received: false,
         })
         .unwrap();
+    let mut worker = starter.worker().await;
+    worker.fetch_results = false;
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -191,14 +190,7 @@ impl ResetRandomseedWf {
 async fn reset_randomseed() {
     let wf_name = "reset_randomseed";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes {
-        enable_workflows: true,
-        enable_local_activities: true,
-        enable_remote_activities: false,
-        enable_nexus: true,
-    };
-    let mut worker = starter.worker().await;
-    worker.fetch_results = false;
+    starter.sdk_config.register_activities(StdActivities);
 
     let did_fail = Arc::new(AtomicBool::new(false));
     let initial_random = Arc::new(OnceLock::new());
@@ -208,7 +200,8 @@ async fn reset_randomseed() {
     let notify_clone = notify.clone();
     let reset_started_for_wf = reset_started.clone();
     let saw_updated_random_for_wf = saw_updated_random.clone();
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || ResetRandomseedWf {
             did_fail: did_fail.clone(),
             initial_random: initial_random.clone(),
@@ -219,8 +212,8 @@ async fn reset_randomseed() {
             post_reset_received: false,
         })
         .unwrap();
-    worker.register_activities(StdActivities);
-
+    let mut worker = starter.worker().await;
+    worker.fetch_results = false;
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
         .submit_workflow(

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
@@ -1,6 +1,4 @@
-use crate::common::{
-    ActivationAssertionsInterceptor, CoreWfStarter, build_fake_sdk, build_fake_sdk_intercepted,
-};
+use crate::common::{ActivationAssertionsInterceptor, CoreWfStarter};
 use std::collections::HashMap;
 use temporalio_client::{WorkflowStartOptions, WorkflowStartSignal};
 use temporalio_common::protos::{
@@ -18,7 +16,6 @@ use temporalio_common::protos::{
 };
 use temporalio_sdk_core::replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder};
 
-use temporalio_common::worker::WorkerTaskTypes;
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
     CancellableFuture, ChildWorkflowOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
@@ -61,9 +58,11 @@ impl SignalSender {
 async fn sends_signal_to_missing_wf() {
     let wf_name = "sends_signal_to_missing_wf";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<SignalSender>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<SignalSender>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -127,10 +126,15 @@ impl SignalWithCreateWfReceiver {
 #[tokio::test]
 async fn sends_signal_to_other_wf() {
     let mut starter = CoreWfStarter::new("sends_signal_to_other_wf");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<SignalSender>()
+        .unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<SignalReceiver>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<SignalSender>().unwrap();
-    worker.register_workflow::<SignalReceiver>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     let receiver_run_id = worker
@@ -155,11 +159,11 @@ async fn sends_signal_to_other_wf() {
 #[tokio::test]
 async fn sends_signal_with_create_wf() {
     let mut starter = CoreWfStarter::new("sends_signal_with_create_wf");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<SignalWithCreateWfReceiver>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let client = starter.get_client().await;
     let mut header: HashMap<String, Payload> = HashMap::new();
@@ -235,10 +239,15 @@ impl ChildSignalReceiver {
 #[tokio::test]
 async fn sends_signal_to_child() {
     let mut starter = CoreWfStarter::new("sends_signal_to_child");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<SignalsChild>()
+        .unwrap();
+    starter
+        .sdk_config
+        .register_workflow::<ChildSignalReceiver>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<SignalsChild>().unwrap();
-    worker.register_workflow::<ChildSignalReceiver>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     worker
@@ -317,8 +326,9 @@ async fn sends_signal(#[case] fails: bool) {
             });
         });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<SignalSenderCanned>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<SignalSenderCanned>().unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -374,8 +384,10 @@ async fn cancels_before_sending() {
         });
     });
 
-    let mut worker = build_fake_sdk_intercepted(mock_cfg, aai);
-    worker.register_workflow::<CancelsBeforeSending>().unwrap();
+    let mut worker =
+        crate::common::build_fake_sdk_intercepted_with_options(mock_cfg, aai, |options| {
+            options.register_workflow::<CancelsBeforeSending>().unwrap();
+        });
     worker.run().await.unwrap();
 }
 
@@ -417,11 +429,11 @@ impl SignalSerializationFailure {
 async fn signal_serialization_failure() {
     let wf_name = "signal_serialization_failure";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
         .register_workflow::<SignalSerializationFailure>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker
@@ -489,12 +501,15 @@ impl CrossTypeSignalReceiver {
 #[tokio::test]
 async fn external_workflow_signal() {
     let mut starter = CoreWfStarter::new("cross_type_signal_sends_successfully");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
-    let mut worker = starter.worker().await;
-    worker.register_workflow::<CrossTypeSignalSender>().unwrap();
-    worker
+    starter
+        .sdk_config
+        .register_workflow::<CrossTypeSignalSender>()
+        .unwrap();
+    starter
+        .sdk_config
         .register_workflow::<CrossTypeSignalReceiver>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let receiver_wfid = "cross-type-signal-receiver";

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
@@ -165,7 +165,7 @@ async fn sends_signal_with_create_wf() {
         .unwrap();
     let mut worker = starter.worker().await;
 
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let mut header: HashMap<String, Payload> = HashMap::new();
     header.insert("tupac".into(), "shakur".into());
     let task_queue = worker.inner_mut().task_queue().to_string();

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/stickyness.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/stickyness.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 use temporalio_client::WorkflowStartOptions;
-use temporalio_common::{protos::temporal::api::enums::v1::EventType, worker::WorkerTaskTypes};
+use temporalio_common::protos::temporal::api::enums::v1::EventType;
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{WorkflowContext, WorkflowResult};
 use temporalio_sdk_core::{PollerBehavior, TunerHolder};
@@ -17,10 +17,9 @@ use tokio::sync::Barrier;
 async fn timer_workflow_not_sticky() {
     let wf_name = "timer_wf_not_sticky";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.sdk_config.max_cached_workflows = 0_usize;
+    starter.sdk_config.register_workflow::<TimerWf>().unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<TimerWf>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     let workflow_id = starter.get_task_queue().to_owned();
@@ -62,19 +61,19 @@ async fn timer_workflow_timeout_on_sticky() {
     // on a not-sticky queue
     let wf_name = "timer_workflow_timeout_on_sticky";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.workflow_options.task_timeout = Some(Duration::from_secs(2));
-    let mut worker = starter.worker().await;
 
     let timed_out_once = Arc::new(AtomicBool::new(false));
     let run_ct = Arc::new(AtomicUsize::new(0));
     let run_ct_clone = run_ct.clone();
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || TimerTimeoutWf {
             timed_out_once: timed_out_once.clone(),
             run_ct: run_ct_clone.clone(),
         })
         .unwrap();
+    let mut worker = starter.worker().await;
 
     worker
         .submit_workflow(TimerTimeoutWf::run, (), starter.workflow_options.clone())
@@ -122,19 +121,19 @@ impl CacheMissWf {
 async fn cache_miss_ok() {
     let wf_name = "cache_miss_ok";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(2, 1, 1, 1));
     starter.sdk_config.max_cached_workflows = 0_usize;
     starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::SimpleMaximum(1_usize));
-    let mut worker = starter.worker().await;
 
     let barr = Arc::new(Barrier::new(2));
     let barr_clone = barr.clone();
-    worker
+    starter
+        .sdk_config
         .register_workflow_with_factory(move || CacheMissWf {
             barr: barr_clone.clone(),
         })
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/stickyness.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/stickyness.rs
@@ -144,7 +144,7 @@ async fn cache_miss_ok() {
         )
         .await
         .unwrap();
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let run_id = handle.info().run_id.clone().unwrap();
     let (r1, _) = tokio::join!(worker.run_until_done(), async move {
         barr.wait().await;

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/timers.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/timers.rs
@@ -1,19 +1,16 @@
-use crate::common::{CoreWfStarter, build_fake_sdk, init_core_and_create_wf};
+use crate::common::{CoreWfStarter, init_core_and_create_wf};
 use futures_util::{StreamExt, stream::FuturesUnordered};
 use std::{future::Future, pin::Pin, time::Duration};
 use temporalio_client::WorkflowStartOptions;
-use temporalio_common::{
-    protos::{
-        coresdk::{
-            workflow_commands::{CancelTimer, CompleteWorkflowExecution, StartTimer},
-            workflow_completion::WorkflowActivationCompletion,
-        },
-        temporal::api::{
-            enums::v1::{CommandType, EventType, WorkflowTaskFailedCause},
-            failure::v1::Failure,
-        },
+use temporalio_common::protos::{
+    coresdk::{
+        workflow_commands::{CancelTimer, CompleteWorkflowExecution, StartTimer},
+        workflow_completion::WorkflowActivationCompletion,
     },
-    worker::WorkerTaskTypes,
+    temporal::api::{
+        enums::v1::{CommandType, EventType, WorkflowTaskFailedCause},
+        failure::v1::Failure,
+    },
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{CancellableFuture, WorkflowContext, WorkflowResult};
@@ -40,9 +37,8 @@ impl TimerWf {
 async fn timer_workflow_workflow_driver() {
     let wf_name = "timer_wf_new";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter.sdk_config.register_workflow::<TimerWf>().unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<TimerWf>().unwrap();
 
     let task_queue = starter.get_task_queue().to_owned();
     let workflow_id = starter.get_task_queue().to_owned();
@@ -61,7 +57,6 @@ async fn timer_workflow_workflow_driver() {
 async fn timer_workflow_manual() {
     let mut starter = init_core_and_create_wf("timer_workflow").await;
     let core = starter.get_worker().await;
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     let task = core.poll_workflow_activation().await.unwrap();
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
         task.run_id,
@@ -85,7 +80,6 @@ async fn timer_workflow_manual() {
 async fn timer_cancel_workflow() {
     let mut starter = init_core_and_create_wf("timer_cancel_workflow").await;
     let core = starter.get_worker().await;
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     let task = core.poll_workflow_activation().await.unwrap();
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
         task.run_id,
@@ -152,9 +146,11 @@ impl ParallelTimerWf {
 async fn parallel_timers() {
     let wf_name = "parallel_timers";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<ParallelTimerWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<ParallelTimerWf>().unwrap();
 
     starter.start_with_worker(wf_name, &mut worker).await;
     worker.run_until_done().await.unwrap();
@@ -185,10 +181,12 @@ async fn cancel_unpolled_timer_after_both_timers_fire_same_activation() {
     t.add_workflow_task_completed();
     t.add_workflow_execution_completed();
 
-    let mut worker = build_fake_sdk(MockPollCfg::from_hist_builder(t));
-    worker
-        .register_workflow::<CancelAlreadyFiredTimerWf>()
-        .unwrap();
+    let mut worker =
+        crate::common::build_fake_sdk_with_options(MockPollCfg::from_hist_builder(t), |options| {
+            options
+                .register_workflow::<CancelAlreadyFiredTimerWf>()
+                .unwrap();
+        });
     worker.run().await.unwrap();
 }
 
@@ -224,8 +222,9 @@ async fn test_fire_happy_path_inc() {
             });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<HappyTimerWf>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<HappyTimerWf>().unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -252,8 +251,9 @@ async fn mismatched_timer_ids_errors() {
             && matches!(f, Some(Failure {message, .. })
         if message.contains("Timer fired event did not have expected timer id 1"))
     });
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<MismatchedTimerWf>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<MismatchedTimerWf>().unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -294,8 +294,9 @@ async fn incremental_cancellation() {
             });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<CancelTimerWf>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<CancelTimerWf>().unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -330,8 +331,9 @@ async fn cancel_before_sent_to_server() {
             );
         });
     });
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<CancelBeforeSentWf>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<CancelBeforeSentWf>().unwrap();
+    });
     worker.run().await.unwrap();
 }
 
@@ -372,10 +374,11 @@ impl WaitConditionWakerWf {
 async fn wait_condition_waker_in_futures_unordered() {
     let t = canned_histories::single_timer_wf_completes("1");
     let mock_cfg = MockPollCfg::from_hist_builder(t);
-    let mut worker = build_fake_sdk(mock_cfg);
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<WaitConditionWakerWf>().unwrap();
+    });
     // FuturesUnordered uses internal wakers that forward wake calls outside the
     // SdkWakeGuard scope.
     worker.set_detect_nondeterministic_futures(false);
-    worker.register_workflow::<WaitConditionWakerWf>().unwrap();
     worker.run().await.unwrap();
 }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/timers.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/timers.rs
@@ -56,7 +56,7 @@ async fn timer_workflow_workflow_driver() {
 #[tokio::test]
 async fn timer_workflow_manual() {
     let mut starter = init_core_and_create_wf("timer_workflow").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let task = core.poll_workflow_activation().await.unwrap();
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
         task.run_id,
@@ -79,7 +79,7 @@ async fn timer_workflow_manual() {
 #[tokio::test]
 async fn timer_cancel_workflow() {
     let mut starter = init_core_and_create_wf("timer_cancel_workflow").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let task = core.poll_workflow_activation().await.unwrap();
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
         task.run_id,
@@ -113,7 +113,7 @@ async fn timer_cancel_workflow() {
 #[tokio::test]
 async fn timer_immediate_cancel_workflow() {
     let mut starter = init_core_and_create_wf("timer_immediate_cancel_workflow").await;
-    let core = starter.get_worker().await;
+    let core = starter.get_core_worker().await;
     let task = core.poll_workflow_activation().await.unwrap();
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmds(
         task.run_id,

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/upsert_search_attrs.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/upsert_search_attrs.rs
@@ -1,4 +1,4 @@
-use crate::common::{CoreWfStarter, SEARCH_ATTR_INT, SEARCH_ATTR_TXT, build_fake_sdk};
+use crate::common::{CoreWfStarter, SEARCH_ATTR_INT, SEARCH_ATTR_TXT};
 use assert_matches::assert_matches;
 use std::time::Duration;
 use temporalio_client::{
@@ -13,7 +13,6 @@ use temporalio_common::{
         },
     },
     search_attributes::{SearchAttributeKey, SearchAttributes},
-    worker::WorkerTaskTypes,
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{WorkflowContext, WorkflowResult, WorkflowTermination};
@@ -54,10 +53,11 @@ async fn sends_upsert() {
     let wf_name = "sends_upsert_search_attrs";
     let wf_id = Uuid::new_v4();
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<SearchAttrUpdater>()
+        .unwrap();
     let mut worker = starter.worker().await;
-
-    worker.register_workflow::<SearchAttrUpdater>().unwrap();
     let task_queue = starter.get_task_queue().to_owned();
     worker
         .submit_wf(
@@ -150,7 +150,8 @@ async fn upsert_search_attrs_from_workflow() {
         });
     });
 
-    let mut worker = build_fake_sdk(mock_cfg);
-    worker.register_workflow::<UpsertTestWf>().unwrap();
+    let mut worker = crate::common::build_fake_sdk_with_options(mock_cfg, |options| {
+        options.register_workflow::<UpsertTestWf>().unwrap();
+    });
     worker.run().await.unwrap();
 }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/upsert_search_attrs.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/upsert_search_attrs.rs
@@ -75,7 +75,7 @@ async fn sends_upsert() {
         .unwrap();
     worker.run_until_done().await.unwrap();
 
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let search_attrs = client
         .get_workflow_handle::<UntypedWorkflow>(wf_id.to_string())
         .describe(WorkflowDescribeOptions::default())

--- a/crates/sdk-core/tests/main.rs
+++ b/crates/sdk-core/tests/main.rs
@@ -84,7 +84,7 @@ mod integ_tests {
     }
 
     pub(crate) async fn mk_nexus_endpoint(starter: &mut CoreWfStarter) -> String {
-        let client = starter.get_client().await;
+        let client = starter.get_core_client().await;
         let endpoint = format!("mycoolendpoint-{}", rand_6_chars());
         client
             .connection()

--- a/crates/sdk-core/tests/manual_tests.rs
+++ b/crates/sdk-core/tests/manual_tests.rs
@@ -24,9 +24,7 @@ use temporalio_client::{
     NamespacedClient, UntypedSignal, UntypedWorkflow, WorkflowExecutionInfo,
     WorkflowGetResultOptions, WorkflowSignalOptions, WorkflowStartOptions,
 };
-use temporalio_common::{
-    data_converters::RawValue, telemetry::PrometheusExporterOptions, worker::WorkerTaskTypes,
-};
+use temporalio_common::{data_converters::RawValue, telemetry::PrometheusExporterOptions};
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
     ActivityOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
@@ -146,11 +144,13 @@ async fn poller_load_spiky() {
         maximum: 200,
         initial: 5,
     });
+    starter
+        .sdk_config
+        .register_activities(JitteryEchoActivities)
+        .register_workflow::<PollerLoadSpikyWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
     let submitter = worker.get_submitter_handle();
-
-    worker.register_activities(JitteryEchoActivities);
-    worker.register_workflow::<PollerLoadSpikyWf>().unwrap();
     let client = starter.get_client().await;
     let tq = starter.get_task_queue().to_owned();
 
@@ -283,9 +283,11 @@ async fn poller_load_sustained() {
         maximum: 200,
         initial: 5,
     });
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
+    starter
+        .sdk_config
+        .register_workflow::<PollerLoadSustainedWf>()
+        .unwrap();
     let mut worker = starter.worker().await;
-    worker.register_workflow::<PollerLoadSustainedWf>().unwrap();
     let client = starter.get_client().await;
     let tq = starter.get_task_queue().to_owned();
 
@@ -363,13 +365,13 @@ async fn poller_load_spike_then_sustained() {
         maximum: 200,
         initial: 5,
     });
-    let mut worker = starter.worker().await;
-    let submitter = worker.get_submitter_handle();
-
-    worker.register_activities(JitteryEchoActivities);
-    worker
+    starter
+        .sdk_config
+        .register_activities(JitteryEchoActivities)
         .register_workflow::<PollerLoadSpikeThenSustainedWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
+    let submitter = worker.get_submitter_handle();
     let client = starter.get_client().await;
     let tq = starter.get_task_queue().to_owned();
 

--- a/crates/sdk-core/tests/manual_tests.rs
+++ b/crates/sdk-core/tests/manual_tests.rs
@@ -151,7 +151,7 @@ async fn poller_load_spiky() {
         .unwrap();
     let mut worker = starter.worker().await;
     let submitter = worker.get_submitter_handle();
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let tq = starter.get_task_queue().to_owned();
 
     info!("Prom bound to {:?}", addr);
@@ -288,7 +288,7 @@ async fn poller_load_sustained() {
         .register_workflow::<PollerLoadSustainedWf>()
         .unwrap();
     let mut worker = starter.worker().await;
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let tq = starter.get_task_queue().to_owned();
 
     info!("Prom bound to {:?}", addr);
@@ -372,7 +372,7 @@ async fn poller_load_spike_then_sustained() {
         .unwrap();
     let mut worker = starter.worker().await;
     let submitter = worker.get_submitter_handle();
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let tq = starter.get_task_queue().to_owned();
 
     info!("Prom bound to {:?}", addr);

--- a/crates/sdk-core/tests/shared_tests/mod.rs
+++ b/crates/sdk-core/tests/shared_tests/mod.rs
@@ -373,7 +373,7 @@ pub(crate) async fn shutdown_during_active_timer_activity_workflows() {
         "Worker shutdown took {shutdown_elapsed:?}, expected < 5s"
     );
 
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     for wf_id in &wf_ids {
         client
             .get_workflow_handle::<UntypedWorkflow>(wf_id)

--- a/crates/sdk-core/tests/shared_tests/mod.rs
+++ b/crates/sdk-core/tests/shared_tests/mod.rs
@@ -37,7 +37,6 @@ use temporalio_common::{
             workflowservice::v1::{DescribeNamespaceRequest, ListWorkflowExecutionsRequest},
         },
     },
-    worker::WorkerTaskTypes,
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
@@ -242,7 +241,6 @@ pub(crate) async fn grpc_message_too_large() {
     let mut starter = CoreWfStarter::new_cloud_or_local(wf_name, "")
         .await
         .unwrap();
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.sdk_config.disable_payload_error_limit = true;
     starter
         .sdk_config
@@ -326,11 +324,12 @@ pub(crate) async fn shutdown_during_active_timer_activity_workflows() {
         } else {
             return;
         };
-    starter.sdk_config.register_activities(StdActivities);
-    let mut worker = starter.worker().await;
-    worker
+    starter
+        .sdk_config
+        .register_activities(StdActivities)
         .register_workflow::<ShutdownTimerActivityLoopWf>()
         .unwrap();
+    let mut worker = starter.worker().await;
 
     let core = worker.core_worker();
     core.validate().await.unwrap();
@@ -446,15 +445,6 @@ pub(crate) async fn activity_cancel_delivered_without_heartbeat(disable_eager: b
     starter
         .sdk_config
         .register_activities(WaitForCancelActivities);
-    let mut worker = starter.worker().await;
-    if !worker
-        .core_worker()
-        .get_namespace_capabilities()
-        .worker_commands()
-    {
-        warn!("Skipping test: worker_commands not supported in this namespace");
-        return;
-    }
 
     #[workflow]
     #[derive(Default)]
@@ -494,9 +484,19 @@ pub(crate) async fn activity_cancel_delivered_without_heartbeat(disable_eager: b
         }
     }
 
-    worker
+    starter
+        .sdk_config
         .register_workflow::<CancelWithoutHeartbeatWorkflow>()
         .unwrap();
+    let mut worker = starter.worker().await;
+    if !worker
+        .core_worker()
+        .get_namespace_capabilities()
+        .worker_commands()
+    {
+        warn!("Skipping test: worker_commands not supported in this namespace");
+        return;
+    }
 
     let task_queue = starter.get_task_queue().to_owned();
     let handle = worker

--- a/crates/sdk-core/tests/shared_tests/priority.rs
+++ b/crates/sdk-core/tests/shared_tests/priority.rs
@@ -24,7 +24,6 @@ pub(crate) async fn priority_values_sent_to_server() {
         fairness_key: Some("fair-wf".to_string()),
         fairness_weight: Some(4.2),
     };
-    let mut worker = starter.worker().await;
     let child_type = "child-wf";
 
     struct PriorityActivities;
@@ -107,13 +106,16 @@ pub(crate) async fn priority_values_sent_to_server() {
         }
     }
 
-    worker.register_activities(PriorityActivities);
-    worker
+    starter
+        .sdk_config
+        .register_activities(PriorityActivities)
         .register_workflow_with_factory::<ParentWf, _>(move || ParentWf {
             child_type: child_type.to_owned(),
         })
+        .unwrap()
+        .register_workflow::<ChildWf>()
         .unwrap();
-    worker.register_workflow::<ChildWf>().unwrap();
+    let mut worker = starter.worker().await;
 
     worker
         .submit_workflow(ParentWf::run, (), starter.workflow_options.clone())

--- a/crates/sdk-core/tests/shared_tests/priority.rs
+++ b/crates/sdk-core/tests/shared_tests/priority.rs
@@ -123,7 +123,7 @@ pub(crate) async fn priority_values_sent_to_server() {
         .unwrap();
     worker.run_until_done().await.unwrap();
 
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let handle = client.get_workflow_handle::<UntypedWorkflow>(starter.get_task_queue());
     handle
         .get_result(WorkflowGetResultOptions::default())

--- a/crates/sdk-core/tests/wasm_workflow_tests.rs
+++ b/crates/sdk-core/tests/wasm_workflow_tests.rs
@@ -28,7 +28,6 @@ use temporalio_common::{
             },
         },
     },
-    worker::WorkerTaskTypes,
 };
 use temporalio_sdk::{PatchActivationCallback, WasmWorkflowComponent};
 use tokio::process::Command;
@@ -152,7 +151,6 @@ async fn wasm_patch_activation_callback_panic_fails_workflow_task() {
         .expect("sample WASM component should be loadable");
     let mut starter =
         CoreWfStarter::new("wasm_patch_activation_callback_panic_fails_workflow_task");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.sdk_config.patch_activation_callback =
         Some(Arc::new(|_| panic!("wasm patch activation callback panic")));
     starter.sdk_config.register_wasm_workflow(component);
@@ -212,7 +210,6 @@ async fn wasm_task_failure_preserves_wit_failure_details() {
         .expect("sample WASM component should be loadable");
 
     let mut starter = CoreWfStarter::new("wasm_task_failure_preserves_wit_failure_details");
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.sdk_config.register_wasm_workflow(component);
 
     let mut worker = starter.worker().await;
@@ -272,7 +269,6 @@ async fn run_string_workflow(
     expected_result: &'static str,
 ) {
     let mut starter = CoreWfStarter::new(test_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.sdk_config.register_wasm_workflow(component);
 
     let mut worker = starter.worker().await;
@@ -310,7 +306,6 @@ async fn run_patch_activation_workflow(
     let component = WasmWorkflowComponent::from_file(WASM_COMPONENT_ID, component_path)
         .expect("sample WASM component should be loadable");
     let mut starter = CoreWfStarter::new(test_name);
-    starter.sdk_config.task_types = WorkerTaskTypes::workflow_only();
     starter.sdk_config.patch_activation_callback = callback;
     starter.sdk_config.register_wasm_workflow(component);
 

--- a/crates/sdk-core/tests/wasm_workflow_tests.rs
+++ b/crates/sdk-core/tests/wasm_workflow_tests.rs
@@ -272,7 +272,7 @@ async fn run_string_workflow(
     starter.sdk_config.register_wasm_workflow(component);
 
     let mut worker = starter.worker().await;
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let payload_converter = PayloadConverter::default();
     let input = RawValue::from_value(&"workflow", &payload_converter);
     let workflow_id = starter.get_wf_id().to_owned();
@@ -310,7 +310,7 @@ async fn run_patch_activation_workflow(
     starter.sdk_config.register_wasm_workflow(component);
 
     let mut worker = starter.worker().await;
-    let client = starter.get_client().await;
+    let client = starter.get_core_client().await;
     let payload_converter = PayloadConverter::default();
     let input = RawValue::from_value(&WASM_PATCH_ID, &payload_converter);
     let workflow_id = starter.get_wf_id().to_owned();

--- a/crates/sdk/examples/child_workflows/worker.rs
+++ b/crates/sdk/examples/child_workflows/worker.rs
@@ -3,7 +3,6 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::worker::WorkerTaskTypes;
 use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::{GreetingChildWorkflow, ParentWorkflow};
 
@@ -18,7 +17,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let worker_options = WorkerOptions::new("child-workflows")
         .register_workflow::<ParentWorkflow>()?
         .register_workflow::<GreetingChildWorkflow>()?
-        .task_types(WorkerTaskTypes::workflow_only())
         .build();
 
     let mut worker = Worker::new(&runtime, client, worker_options)?;

--- a/crates/sdk/examples/continue_as_new/worker.rs
+++ b/crates/sdk/examples/continue_as_new/worker.rs
@@ -3,7 +3,6 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::worker::WorkerTaskTypes;
 use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::ContinueAsNewWorkflow;
 
@@ -17,7 +16,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let worker_options = WorkerOptions::new("continue-as-new")
         .register_workflow::<ContinueAsNewWorkflow>()?
-        .task_types(WorkerTaskTypes::workflow_only())
         .build();
 
     let mut worker = Worker::new(&runtime, client, worker_options)?;

--- a/crates/sdk/examples/message_passing/worker.rs
+++ b/crates/sdk/examples/message_passing/worker.rs
@@ -3,7 +3,6 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::worker::WorkerTaskTypes;
 use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::MessagePassingWorkflow;
 
@@ -17,7 +16,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let worker_options = WorkerOptions::new("message-passing")
         .register_workflow::<MessagePassingWorkflow>()?
-        .task_types(WorkerTaskTypes::workflow_only())
         .build();
 
     let mut worker = Worker::new(&runtime, client, worker_options)?;

--- a/crates/sdk/examples/search_attributes/worker.rs
+++ b/crates/sdk/examples/search_attributes/worker.rs
@@ -3,7 +3,6 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::worker::WorkerTaskTypes;
 use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::SearchAttributesWorkflow;
 
@@ -17,7 +16,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let worker_options = WorkerOptions::new("search-attributes")
         .register_workflow::<SearchAttributesWorkflow>()?
-        .task_types(WorkerTaskTypes::workflow_only())
         .build();
 
     let mut worker = Worker::new(&runtime, client, worker_options)?;

--- a/crates/sdk/examples/updatable_timer/worker.rs
+++ b/crates/sdk/examples/updatable_timer/worker.rs
@@ -3,7 +3,6 @@ mod workflows;
 use temporalio_client::{
     Client, ClientOptions, Connection, envconfig::LoadClientConfigProfileOptions,
 };
-use temporalio_common::worker::WorkerTaskTypes;
 use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 use workflows::UpdatableTimerWorkflow;
 
@@ -17,7 +16,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let worker_options = WorkerOptions::new("updatable-timer")
         .register_workflow::<UpdatableTimerWorkflow>()?
-        .task_types(WorkerTaskTypes::workflow_only())
         .build();
 
     let mut worker = Worker::new(&runtime, client, worker_options)?;

--- a/crates/sdk/src/activities.rs
+++ b/crates/sdk/src/activities.rs
@@ -492,7 +492,8 @@ impl ActivityDefinitions {
         self
     }
 
-    pub(crate) fn is_empty(&self) -> bool {
+    /// Returns whether no activities are registered.
+    pub fn is_empty(&self) -> bool {
         self.activities.is_empty()
     }
 

--- a/crates/sdk/src/activities.rs
+++ b/crates/sdk/src/activities.rs
@@ -492,8 +492,7 @@ impl ActivityDefinitions {
         self
     }
 
-    /// Returns whether no activities are registered.
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.activities.is_empty()
     }
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -11,9 +11,7 @@
 //! ```no_run
 //! use std::str::FromStr;
 //! use temporalio_client::{Client, ClientOptions, Connection, ConnectionOptions, Url};
-//! use temporalio_common::worker::{
-//!     WorkerDeploymentOptions, WorkerDeploymentVersion, WorkerTaskTypes,
-//! };
+//! use temporalio_common::worker::{WorkerDeploymentOptions, WorkerDeploymentVersion};
 //! use temporalio_macros::activities;
 //! use temporalio_sdk::{
 //!     Runtime, Worker, WorkerOptions,
@@ -42,7 +40,6 @@
 //!     let client = Client::new(connection, ClientOptions::new("my_namespace").build())?;
 //!
 //!     let worker_options = WorkerOptions::new("task_queue")
-//!         .task_types(WorkerTaskTypes::activity_only())
 //!         .deployment_options(
 //!             WorkerDeploymentOptions::new(WorkerDeploymentVersion {
 //!                 deployment_name: "my_deployment".to_owned(),
@@ -165,6 +162,9 @@ use crate::runtime::{
 };
 
 /// Contains options for configuring a worker.
+///
+/// The worker polls task types according to its registered workflows and activities. At least one
+/// workflow or activity must be registered.
 #[derive(bon::Builder, Clone)]
 #[builder(start_fn = new, on(String, into), state_mod(vis = "pub"))]
 #[non_exhaustive]
@@ -244,13 +244,6 @@ pub struct WorkerOptions {
     /// If left unset, the worker uses `SimpleMaximum(5)` and becomes eligible for automatic
     /// enrollment into poller autoscaling when the namespace advertises support for it.
     pub nexus_task_poller_behavior: Option<PollerBehavior>,
-    // TODO [rust-sdk-branch]: Will go away once workflow registration can only happen in here.
-    //   Then it can be auto-determined.
-    /// Specifies which task types this worker will poll for.
-    ///
-    /// Note: At least one task type must be specified or the worker will fail validation.
-    #[builder(default = WorkerTaskTypes::all())]
-    pub task_types: WorkerTaskTypes,
     /// How long a workflow task is allowed to sit on the sticky queue before it is timed out
     /// and moved to the non-sticky queue where it may be picked up by any worker.
     #[builder(default = Duration::from_secs(10))]
@@ -539,6 +532,15 @@ impl WorkerOptions {
         namespace: String,
         connection_identity: String,
     ) -> Result<WorkerConfig, String> {
+        let workflows_registered = !self.workflows.is_empty();
+        #[cfg(feature = "wasm-workflows")]
+        let workflows_registered =
+            workflows_registered || !self.wasm_workflow_components.is_empty();
+        let activities_registered = !self.activities.is_empty();
+        if !workflows_registered && !activities_registered {
+            return Err("At least one workflow or activity must be registered".to_owned());
+        }
+
         WorkerConfig::builder()
             .namespace(namespace)
             .task_queue(self.task_queue.clone())
@@ -556,7 +558,12 @@ impl WorkerOptions {
             .maybe_workflow_task_poller_behavior(self.workflow_task_poller_behavior)
             .maybe_activity_task_poller_behavior(self.activity_task_poller_behavior)
             .maybe_nexus_task_poller_behavior(self.nexus_task_poller_behavior)
-            .task_types(self.task_types)
+            .task_types(WorkerTaskTypes {
+                enable_workflows: workflows_registered,
+                enable_local_activities: workflows_registered && activities_registered,
+                enable_remote_activities: activities_registered,
+                enable_nexus: false,
+            })
             .sticky_queue_schedule_to_start_timeout(self.sticky_queue_schedule_to_start_timeout)
             .max_heartbeat_throttle_interval(self.max_heartbeat_throttle_interval)
             .default_heartbeat_throttle_interval(self.default_heartbeat_throttle_interval)
@@ -854,56 +861,6 @@ impl Worker {
     pub fn shutdown_handle(&self) -> impl Fn() + use<> {
         let w = self.common.worker.clone();
         move || w.initiate_shutdown()
-    }
-
-    /// Registers all activities on an activity implementer.
-    pub fn register_activities<AI: ActivityImplementer>(&mut self, instance: AI) -> &mut Self {
-        self.activity_half
-            .activities
-            .register_activities::<AI>(instance);
-        self
-    }
-    /// Registers a specific activitiy.
-    pub fn register_activity<AD>(&mut self, instance: Arc<AD::Implementer>) -> &mut Self
-    where
-        AD: ActivityDefinition + ExecutableActivity,
-        AD::Input: Send + Sync,
-        AD::Output: Send + Sync,
-    {
-        self.activity_half
-            .activities
-            .register_activity::<AD>(instance);
-        self
-    }
-
-    /// Registers all workflows on a workflow implementer.
-    pub fn register_workflow<W>(&mut self) -> Result<&mut Self, WorkflowRegistrationError>
-    where
-        W: WorkflowImplementation,
-        <W::Run as WorkflowDefinition>::Input: Send,
-    {
-        self.workflow_half
-            .workflow_definitions
-            .register_workflow::<W>()?;
-        Ok(self)
-    }
-
-    /// Register a workflow with a custom factory for instance creation.
-    ///
-    /// See [WorkerOptionsBuilder::register_workflow_with_factory] for more.
-    pub fn register_workflow_with_factory<W, F>(
-        &mut self,
-        factory: F,
-    ) -> Result<&mut Self, WorkflowRegistrationError>
-    where
-        W: WorkflowImplementation,
-        <W::Run as WorkflowDefinition>::Input: Send,
-        F: Fn() -> W + Send + Sync + 'static,
-    {
-        self.workflow_half
-            .workflow_definitions
-            .register_workflow_run_with_factory::<W, F>(factory)?;
-        Ok(self)
     }
 
     /// Runs the worker. Eventually resolves after the worker has been explicitly shut down,
@@ -1711,6 +1668,49 @@ mod tests {
     }
 
     #[test]
+    fn task_types_are_derived_from_registrations() {
+        let workflow_config = WorkerOptions::new("task_q")
+            .register_workflow::<MyWorkflow>()
+            .unwrap()
+            .build()
+            .to_core_options("ns".into(), String::new())
+            .unwrap();
+        assert_eq!(workflow_config.task_types, WorkerTaskTypes::workflow_only());
+
+        let activity_config = WorkerOptions::new("task_q")
+            .register_activities(MyActivities {})
+            .build()
+            .to_core_options("ns".into(), String::new())
+            .unwrap();
+        assert_eq!(activity_config.task_types, WorkerTaskTypes::activity_only());
+
+        let combined_config = WorkerOptions::new("task_q")
+            .register_workflow::<MyWorkflow>()
+            .unwrap()
+            .register_activities(MyActivities {})
+            .build()
+            .to_core_options("ns".into(), String::new())
+            .unwrap();
+        assert_eq!(
+            combined_config.task_types,
+            WorkerTaskTypes {
+                enable_workflows: true,
+                enable_local_activities: true,
+                enable_remote_activities: true,
+                enable_nexus: false,
+            }
+        );
+
+        let empty_result = WorkerOptions::new("task_q")
+            .build()
+            .to_core_options("ns".into(), String::new());
+        assert_eq!(
+            empty_result.err().as_deref(),
+            Some("At least one workflow or activity must be registered")
+        );
+    }
+
+    #[test]
     fn workflow_interceptor_registration_replaces_previous_constructors() {
         let mut options = WorkerOptions::new("task_q").build();
         options.register_workflow_interceptors(vec![
@@ -1789,7 +1789,7 @@ mod tests {
         #[case] expected: Option<String>,
     ) {
         let opts = WorkerOptions::new("task_q")
-            .task_types(WorkerTaskTypes::activity_only())
+            .register_activities(MyActivities {})
             .maybe_client_identity_override(worker_override.map(|s| s.to_owned()))
             .build();
         let config = opts
@@ -1808,7 +1808,7 @@ mod tests {
         #[case] expected: bool,
     ) {
         let config = WorkerOptions::new("task_q")
-            .task_types(WorkerTaskTypes::activity_only())
+            .register_activities(MyActivities {})
             .maybe_disable_payload_error_limit(override_value)
             .build()
             .to_core_options("ns".into(), String::new())
@@ -1819,7 +1819,7 @@ mod tests {
     #[test]
     fn max_eager_activity_reservations_per_workflow_task_propagates() {
         let config = WorkerOptions::new("task_q")
-            .task_types(WorkerTaskTypes::activity_only())
+            .register_activities(MyActivities {})
             .max_eager_activity_reservations_per_workflow_task(7)
             .build()
             .to_core_options("ns".into(), String::new())

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1667,46 +1667,50 @@ mod tests {
         assert!(workflows.contains("OtherWorkflow"));
     }
 
+    #[rstest::rstest]
+    #[case::workflow_only(true, false, Ok(WorkerTaskTypes::workflow_only()))]
+    #[case::activity_only(false, true, Ok(WorkerTaskTypes::activity_only()))]
+    #[case::workflow_and_activity(
+        true,
+        true,
+        Ok(WorkerTaskTypes {
+            enable_workflows: true,
+            enable_local_activities: true,
+            enable_remote_activities: true,
+            enable_nexus: false,
+        })
+    )]
+    #[case::empty(
+        false,
+        false,
+        Err("At least one workflow or activity must be registered")
+    )]
     #[test]
-    fn task_types_are_derived_from_registrations() {
-        let workflow_config = WorkerOptions::new("task_q")
-            .register_workflow::<MyWorkflow>()
-            .unwrap()
-            .build()
-            .to_core_options("ns".into(), String::new())
-            .unwrap();
-        assert_eq!(workflow_config.task_types, WorkerTaskTypes::workflow_only());
+    fn task_types_are_derived_from_registrations(
+        #[case] register_workflow: bool,
+        #[case] register_activities: bool,
+        #[case] expected: Result<WorkerTaskTypes, &str>,
+    ) {
+        let options = if register_workflow {
+            WorkerOptions::new("task_q")
+                .register_workflow::<MyWorkflow>()
+                .unwrap()
+        } else {
+            WorkerOptions::new("task_q")
+        };
+        let options = if register_activities {
+            options.register_activities(MyActivities {})
+        } else {
+            options
+        };
 
-        let activity_config = WorkerOptions::new("task_q")
-            .register_activities(MyActivities {})
+        let actual = options
             .build()
             .to_core_options("ns".into(), String::new())
-            .unwrap();
-        assert_eq!(activity_config.task_types, WorkerTaskTypes::activity_only());
-
-        let combined_config = WorkerOptions::new("task_q")
-            .register_workflow::<MyWorkflow>()
-            .unwrap()
-            .register_activities(MyActivities {})
-            .build()
-            .to_core_options("ns".into(), String::new())
-            .unwrap();
+            .map(|config| config.task_types);
         assert_eq!(
-            combined_config.task_types,
-            WorkerTaskTypes {
-                enable_workflows: true,
-                enable_local_activities: true,
-                enable_remote_activities: true,
-                enable_nexus: false,
-            }
-        );
-
-        let empty_result = WorkerOptions::new("task_q")
-            .build()
-            .to_core_options("ns".into(), String::new());
-        assert_eq!(
-            empty_result.err().as_deref(),
-            Some("At least one workflow or activity must be registered")
+            actual.as_ref().map_err(String::as_str),
+            expected.as_ref().map_err(|err| *err)
         );
     }
 

--- a/crates/sdk/src/plugins.rs
+++ b/crates/sdk/src/plugins.rs
@@ -387,6 +387,18 @@ mod tests {
     use temporalio_client::ClientOptions;
     use temporalio_common::protos::temporal::api::worker::v1::PluginInfo;
 
+    #[temporalio_macros::workflow]
+    #[derive(Default)]
+    struct PluginTestWorkflow;
+
+    #[temporalio_macros::workflow_methods]
+    impl PluginTestWorkflow {
+        #[run]
+        async fn run(_ctx: &mut crate::WorkflowContext<Self>) -> crate::WorkflowResult<()> {
+            Ok(())
+        }
+    }
+
     struct RecordingCombinedPlugin {
         order: Arc<Mutex<Vec<&'static str>>>,
     }
@@ -526,6 +538,8 @@ mod tests {
             .client_plugin(SameNameClientPlugin)
             .build();
         let mut worker_options = WorkerOptions::new("queue")
+            .register_workflow::<PluginTestWorkflow>()
+            .unwrap()
             .worker_plugin(RecordingWorkerPlugin {
                 name: "same-name",
                 value: "first",


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Remove user configuration of task types and instead infer them based on the workflows/activities registered on the worker
- Remove mutating registration from `Worker` all activities/workflows must be registered at worker creation

Vast majority of the changes in this branch are moving integration tests to register workflows before worker creation.

## Why?
No need for end SDK users to need to manually toggle these bits. Match other SDKs where we infer these.

## Checklist
<!--- add/delete as needed --->

1. Closes #1196

2. How was this tested:
Existing test suite

3. Any docs updates needed?
N/A
