### PR TITLE
Updating Temporal API Protos

### DIFF
--- a/crates/protos/protos/api_upstream/openapi/openapiv2.json
+++ b/crates/protos/protos/api_upstream/openapi/openapiv2.json
@@ -12020,6 +12020,10 @@
         "requestId": {
           "type": "string",
           "description": "Used to de-dupe reset requests."
+        },
+        "resetHeartbeat": {
+          "type": "boolean",
+          "description": "Reset persisted heartbeat details.\nReset always resets the attempt counter. Passing this flag causes reset to additionally\ndiscard any persisted heartbeat details."
         }
       }
     },

--- a/crates/protos/protos/api_upstream/openapi/openapiv3.yaml
+++ b/crates/protos/protos/api_upstream/openapi/openapiv3.yaml
@@ -15529,6 +15529,12 @@ components:
         requestId:
           type: string
           description: Used to de-dupe reset requests.
+        resetHeartbeat:
+          type: boolean
+          description: |-
+            Reset persisted heartbeat details.
+             Reset always resets the attempt counter. Passing this flag causes reset to additionally
+             discard any persisted heartbeat details.
     ResetActivityExecutionResponse:
       type: object
       properties: {}

--- a/crates/protos/protos/api_upstream/temporal/api/workflowservice/v1/request_response.proto
+++ b/crates/protos/protos/api_upstream/temporal/api/workflowservice/v1/request_response.proto
@@ -2420,6 +2420,12 @@ message ResetActivityExecutionRequest {
 
     // Used to de-dupe reset requests.
     string request_id = 10;
+
+    // Reset persisted heartbeat details.
+    // Reset always resets the attempt counter. Passing this flag causes reset to additionally
+    // discard any persisted heartbeat details.
+    bool reset_heartbeat = 11;
+
 }
 
 // Deprecated. Use `ResetActivityExecutionRequest`.


### PR DESCRIPTION
## What was changed
Sync `api_upstream` to `temporalio/api@3ebdff4` to include:

- api#848 — Add `reset_heartbeat` field to `ResetActivityExecutionRequest`