### PR TITLE
Only begin heartbeating once a worker has actually begun polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,8 @@ relevant information.
   Non-validation failures are reported as `WorkerRunError::Fatal` with a message and source.
 
 ### Fixed
+* Workers no longer send worker heartbeats or appear in centralized heartbeat reports before
+  `Worker::run` begins.
 * Local activity resolutions are now delivered to workflows as each activity completes instead of
   waiting for every local activity in the workflow task. This allows sequences of short local
   activities to make progress while a long-running local activity executes in parallel, while

--- a/crates/client/src/worker.rs
+++ b/crates/client/src/worker.rs
@@ -221,7 +221,7 @@ impl ClientWorkerSetImpl {
             let worker_instance_key = worker.worker_instance_key();
             let namespace = worker.namespace().to_string();
 
-            let shared_worker = match self.shared_worker.entry(namespace.clone()) {
+            let shared_worker = match self.shared_worker.entry(namespace) {
                 Occupied(o) => o.into_mut(),
                 Vacant(v) => {
                     let shared_worker = worker.new_shared_namespace_worker()?;
@@ -500,8 +500,9 @@ impl std::fmt::Debug for ClientWorkerSet {
     }
 }
 
-/// Contains a worker heartbeat callback, wrapped for mocking.
-pub type HeartbeatCallback = Arc<dyn Fn() -> WorkerHeartbeat + Send + Sync>;
+/// Contains a worker heartbeat callback, wrapped for mocking. Returns `None` until the worker has
+/// started running.
+pub type HeartbeatCallback = Arc<dyn Fn() -> Option<WorkerHeartbeat> + Send + Sync>;
 
 /// Callback invoked after a worker heartbeat has been accepted by the server.
 pub type HeartbeatSuccessCallback = Arc<dyn Fn() + Send + Sync>;
@@ -1008,7 +1009,7 @@ mod tests {
         if heartbeat_enabled {
             mock_provider
                 .expect_heartbeat_callback()
-                .returning(|| Some(Arc::new(WorkerHeartbeat::default)));
+                .returning(|| Some(Arc::new(|| Some(WorkerHeartbeat::default()))));
             mock_provider
                 .expect_heartbeat_success_callback()
                 .returning(|| None);

--- a/crates/sdk-core/CHANGELOG.md
+++ b/crates/sdk-core/CHANGELOG.md
@@ -46,6 +46,8 @@ relevant information.
   are preserved on failure; workers warn when the server does not advertise support.
 
 ### Fixed
+* Workers no longer send worker heartbeats or appear in centralized heartbeat reports before they
+  begin polling.
 * Ephemeral server processes no longer leak on failed start.
 * Local activity resolutions are now delivered to workflows as each activity completes instead of
   waiting for every local activity in the workflow task. This allows sequences of short local
@@ -53,4 +55,3 @@ relevant information.
   preserving the resolution ordering recorded in existing histories during replay.
 * Try-cancel child workflows no longer cause nondeterminism when they complete or fail after their
   cancellation was requested.
-

--- a/crates/sdk-core/src/worker/heartbeat.rs
+++ b/crates/sdk-core/src/worker/heartbeat.rs
@@ -97,14 +97,20 @@ impl SharedNamespaceWorker {
                     namespace: &str,
                     callbacks_map: &Arc<RwLock<HashMap<Uuid, WorkerCallbacks>>>,
                 ) -> bool {
-                    let mut hb_to_send = Vec::new();
                     let hb_callbacks: Vec<_> = callbacks_map
                         .read()
                         .values()
-                        .map(|cb| (cb.heartbeat.clone(), cb.heartbeat_success.clone()))
+                        .filter_map(|cb| {
+                            (cb.heartbeat)()
+                                .map(|heartbeat| (heartbeat, cb.heartbeat_success.clone()))
+                        })
                         .collect();
-                    for (heartbeat_callback, _) in &hb_callbacks {
-                        let mut heartbeat = heartbeat_callback();
+                    if hb_callbacks.is_empty() {
+                        return false;
+                    }
+                    let mut hb_to_send = Vec::with_capacity(hb_callbacks.len());
+                    for (heartbeat, _) in &hb_callbacks {
+                        let mut heartbeat = heartbeat.clone();
                         // All of these heartbeat details rely on a client. To avoid circular
                         // dependencies, this must be populated from within SharedNamespaceWorker
                         // to get info from the current client
@@ -367,6 +373,7 @@ mod tests {
         },
         time::Duration,
     };
+    use temporalio_client::worker::{SharedNamespaceWorkerTrait, WorkerCallbacks};
     use temporalio_common::{
         protos::temporal::api::{
             common::v1::Payload,
@@ -376,8 +383,8 @@ mod tests {
             },
             nexusservices::workerservice::v1::{ExecuteCommandsRequest, ExecuteCommandsResponse},
             worker::v1::{
-                CancelActivityCommand, EnvironmentInfo, WorkerCommand, worker_command,
-                worker_command_result,
+                CancelActivityCommand, EnvironmentInfo, WorkerCommand, WorkerHeartbeat,
+                worker_command, worker_command_result,
             },
             workflowservice::v1::{
                 DescribeNamespaceResponse, PollNexusTaskQueueResponse,
@@ -389,10 +396,81 @@ mod tests {
     use uuid::Uuid;
 
     #[tokio::test]
+    async fn heartbeat_only_includes_started_workers() {
+        let mut mock = mock_worker_client();
+        let started_worker_key = Uuid::new_v4();
+        let (recorded_tx, recorded_rx) = tokio::sync::oneshot::channel();
+        let recorded_tx = Mutex::new(Some(recorded_tx));
+        mock.expect_record_worker_heartbeat()
+            .times(1)
+            .returning(move |_, heartbeats| {
+                assert_eq!(heartbeats.len(), 1);
+                assert_eq!(
+                    heartbeats[0].worker_instance_key,
+                    started_worker_key.to_string()
+                );
+                if let Some(tx) = recorded_tx.lock().unwrap().take() {
+                    let _ = tx.send(());
+                }
+                Ok(RecordWorkerHeartbeatResponse {})
+            });
+        mock.expect_describe_namespace().returning(|| {
+            Ok(DescribeNamespaceResponse {
+                namespace_info: Some(NamespaceInfo {
+                    capabilities: Some(Capabilities {
+                        worker_heartbeats: true,
+                        ..Capabilities::default()
+                    }),
+                    ..NamespaceInfo::default()
+                }),
+                ..DescribeNamespaceResponse::default()
+            })
+        });
+        let client: Arc<dyn WorkerClient> = Arc::new(mock);
+        let shared_worker = super::SharedNamespaceWorker::new(
+            client,
+            "test-namespace".to_string(),
+            Duration::from_millis(100),
+            None,
+            Arc::new(temporalio_client::worker::NamespaceDescriptionSource::unresolved()),
+        )
+        .unwrap();
+        shared_worker.register_callback(
+            Uuid::new_v4(),
+            WorkerCallbacks {
+                heartbeat: Arc::new(|| None),
+                heartbeat_success: None,
+                cancel_activity: None,
+            },
+        );
+        shared_worker.register_callback(
+            started_worker_key,
+            WorkerCallbacks {
+                heartbeat: Arc::new(move || {
+                    Some(WorkerHeartbeat {
+                        worker_instance_key: started_worker_key.to_string(),
+                        ..Default::default()
+                    })
+                }),
+                heartbeat_success: None,
+                cancel_activity: None,
+            },
+        );
+
+        tokio::time::timeout(Duration::from_secs(5), recorded_rx)
+            .await
+            .expect("worker heartbeat was not recorded in time")
+            .expect("heartbeat sender was dropped");
+        shared_worker.cancel.cancel();
+    }
+
+    #[tokio::test]
     async fn worker_heartbeat_basic() {
         let mut mock = mock_worker_client();
         let heartbeat_count = Arc::new(AtomicUsize::new(0));
         let heartbeat_count_clone = heartbeat_count.clone();
+        let (third_heartbeat_tx, third_heartbeat_rx) = tokio::sync::oneshot::channel();
+        let third_heartbeat_tx = Mutex::new(Some(third_heartbeat_tx));
         mock.expect_poll_workflow_task()
             .returning(move |_namespace, _task_queue| Ok(Default::default()));
         mock.expect_poll_nexus_task()
@@ -402,6 +480,11 @@ mod tests {
                 assert_eq!(1, worker_heartbeat.len());
                 let heartbeat = worker_heartbeat[0].clone();
                 let heartbeat_index = heartbeat_count_clone.fetch_add(1, Ordering::Relaxed);
+                if heartbeat_index == 2
+                    && let Some(tx) = third_heartbeat_tx.lock().unwrap().take()
+                {
+                    let _ = tx.send(());
+                }
                 assert_eq!(heartbeat.environment.is_some(), heartbeat_index < 2);
                 let host_info = heartbeat.host_info.clone().unwrap();
                 assert_eq!("test-identity", heartbeat.worker_identity);
@@ -453,14 +536,27 @@ mod tests {
         )
         .unwrap();
 
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        let heartbeat_callback = worker
+            .client_worker_registrator
+            .heartbeat_manager
+            .as_ref()
+            .unwrap()
+            .heartbeat_callback
+            .clone();
+        assert!(heartbeat_callback().is_none());
+        worker.mark_started();
+        assert!(heartbeat_callback().is_some());
+        tokio::time::timeout(Duration::from_secs(5), third_heartbeat_rx)
+            .await
+            .expect("worker heartbeat was not recorded in time")
+            .expect("heartbeat sender was dropped");
         worker.drain_activity_poller_and_shutdown().await;
 
         assert_eq!(3, heartbeat_count.load(Ordering::Relaxed));
     }
 
     #[tokio::test]
-    async fn heartbeat_reports_auto_enroll_before_worker_validation() {
+    async fn heartbeat_reports_auto_enroll_after_worker_starts() {
         let mut mock = mock_worker_client();
         let (reported_tx, reported_rx) = tokio::sync::oneshot::channel();
         let reported_tx = Mutex::new(Some(reported_tx));
@@ -502,16 +598,17 @@ mod tests {
         )
         .unwrap();
 
+        worker.validate().await.unwrap();
+        worker.mark_started();
         let reported_autoscaling = tokio::time::timeout(Duration::from_secs(5), reported_rx)
             .await
             .expect("worker heartbeat was not recorded in time")
             .expect("heartbeat sender was dropped");
-        worker.validate().await.unwrap();
         worker.drain_activity_poller_and_shutdown().await;
 
         assert!(
             reported_autoscaling,
-            "heartbeat emitted before validation must reflect namespace auto-enrollment"
+            "heartbeat emitted after startup must reflect namespace auto-enrollment"
         );
     }
 
@@ -527,16 +624,14 @@ mod tests {
             Ok(Default::default())
         });
 
-        let (heartbeat_tx, heartbeat_rx) = tokio::sync::oneshot::channel();
-        let heartbeat_tx = Mutex::new(Some(heartbeat_tx));
+        let heartbeat_count = Arc::new(AtomicUsize::new(0));
+        let heartbeat_count_clone = heartbeat_count.clone();
         mock.expect_record_worker_heartbeat()
             .returning(move |_, _| {
-                if let Some(tx) = heartbeat_tx.lock().unwrap().take() {
-                    let _ = tx.send(());
-                }
+                heartbeat_count_clone.fetch_add(1, Ordering::Relaxed);
                 Ok(RecordWorkerHeartbeatResponse {})
             });
-        mock.expect_describe_namespace().returning(move || {
+        mock.expect_describe_namespace().returning(|| {
             Ok(DescribeNamespaceResponse {
                 namespace_info: Some(NamespaceInfo {
                     capabilities: Some(Capabilities {
@@ -550,19 +645,37 @@ mod tests {
             })
         });
 
+        let client: Arc<dyn WorkerClient> = Arc::new(mock);
         let shared_worker = super::SharedNamespaceWorker::new(
-            Arc::new(mock),
-            namespace,
+            client.clone(),
+            namespace.clone(),
             Duration::from_millis(100),
             None,
             Arc::new(temporalio_client::worker::NamespaceDescriptionSource::unresolved()),
         )
         .unwrap();
 
-        tokio::time::timeout(Duration::from_secs(5), heartbeat_rx)
+        let (callback_tx, callback_rx) = tokio::sync::oneshot::channel();
+        let callback_tx = Mutex::new(Some(callback_tx));
+        shared_worker.register_callback(
+            Uuid::new_v4(),
+            WorkerCallbacks {
+                heartbeat: Arc::new(move || {
+                    if let Some(tx) = callback_tx.lock().unwrap().take() {
+                        let _ = tx.send(());
+                    }
+                    None
+                }),
+                heartbeat_success: None,
+                cancel_activity: None,
+            },
+        );
+        tokio::time::timeout(Duration::from_secs(5), callback_rx)
             .await
-            .expect("worker heartbeat was not recorded in time")
-            .expect("heartbeat sender was dropped");
+            .expect("heartbeat callback was not invoked in time")
+            .expect("heartbeat callback sender was dropped");
+        tokio::task::yield_now().await;
+        assert_eq!(heartbeat_count.load(Ordering::Relaxed), 0);
         assert!(
             !shared_worker
                 .worker_control_task_queue_enabled
@@ -686,6 +799,7 @@ mod tests {
         )
         .unwrap();
 
+        worker.mark_started();
         let response = tokio::time::timeout(Duration::from_secs(5), completion_rx)
             .await
             .expect("nexus task was not completed in time")

--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -1144,6 +1144,15 @@ impl Worker {
         })
     }
 
+    fn mark_started(&self) {
+        if self.shutdown_token.is_cancelled() {
+            return;
+        }
+        if let Some(heartbeat_manager) = self.client_worker_registrator.heartbeat_manager.as_ref() {
+            heartbeat_manager.mark_started();
+        }
+    }
+
     /// Initiates async shutdown procedure, eventually ceases all polling of the server and shuts
     /// down this worker. [Worker::poll_workflow_activation] and [Worker::poll_activity_task] should
     /// be called until both return a `ShutDown` error to ensure that all outstanding work is
@@ -1269,6 +1278,7 @@ impl Worker {
     /// Local activities are returned first before polling the server if there are any.
     #[instrument(skip(self))]
     pub async fn poll_activity_task(&self) -> Result<ActivityTask, PollError> {
+        self.mark_started();
         loop {
             match self.activity_poll().await.transpose() {
                 Some(r) => break r,
@@ -1440,6 +1450,7 @@ impl Worker {
     /// Do not call poll concurrently. It handles polling the server concurrently internally.
     #[instrument(skip(self), fields(run_id, workflow_id, task_queue=%self.config.task_queue))]
     pub async fn poll_workflow_activation(&self) -> Result<WorkflowActivation, PollError> {
+        self.mark_started();
         match self.task_subsystems.workflows.as_ref() {
             Some(workflows) => {
                 let r = workflows.next_workflow_activation().await;
@@ -1498,6 +1509,7 @@ impl Worker {
     /// Do not call poll concurrently. It handles polling the server concurrently internally.
     #[instrument(skip(self))]
     pub async fn poll_nexus_task(&self) -> Result<NexusTask, PollError> {
+        self.mark_started();
         match self.task_subsystems.nexus_mgr.as_ref() {
             Some(mgr) => mgr.next_nexus_task().await,
             None => Err(PollError::ShutDown),
@@ -1658,7 +1670,7 @@ impl Worker {
             .client_worker_registrator
             .heartbeat_manager
             .as_ref()
-            .map(|hm| (hm.heartbeat_callback)());
+            .and_then(|hm| (hm.heartbeat_callback)());
         let handle = tokio::spawn(async move {
             match client
                 .shutdown_worker(sticky_name, task_queue, task_queue_types, heartbeat)
@@ -2272,6 +2284,7 @@ struct WorkerHeartbeatManager {
     /// Heartbeat callback
     heartbeat_callback: HeartbeatCallback,
     heartbeat_success_callback: HeartbeatSuccessCallback,
+    start_time: Arc<OnceLock<prost_types::Timestamp>>,
 }
 
 impl WorkerHeartbeatManager {
@@ -2284,10 +2297,12 @@ impl WorkerHeartbeatManager {
         capabilities: Arc<NamespaceCapabilities>,
         environment_info: Option<Arc<EnvironmentInfo>>,
     ) -> Self {
-        let start_time = Some(SystemTime::now().into());
+        let start_time = Arc::new(OnceLock::new());
+        let heartbeat_start_time = start_time.clone();
         let environment_info = Arc::new(Mutex::new(environment_info));
         let heartbeat_environment_info = environment_info.clone();
         let worker_heartbeat_callback: HeartbeatCallback = Arc::new(move || {
+            let start_time = heartbeat_start_time.get().copied()?;
             let deployment_version = config.computed_deployment_version().map(|dv| {
                 deployment::v1::WorkerDeploymentVersion {
                     deployment_name: dv.deployment_name,
@@ -2318,7 +2333,7 @@ impl WorkerHeartbeatManager {
                 deployment_version,
 
                 status: (*heartbeat_manager_metrics.status.read()) as i32,
-                start_time,
+                start_time: Some(start_time),
                 plugins,
                 drivers,
                 environment: heartbeat_environment_info.lock().as_deref().cloned(),
@@ -2431,7 +2446,7 @@ impl WorkerHeartbeatManager {
                     in_mem.local_activity_execution_failed.clone(),
                 );
             }
-            worker_heartbeat
+            Some(worker_heartbeat)
         });
         let heartbeat_success_callback: HeartbeatSuccessCallback = Arc::new(move || {
             // Take the env info because we only care about sending it one time
@@ -2443,7 +2458,12 @@ impl WorkerHeartbeatManager {
             telemetry: telemetry_instance,
             heartbeat_callback: worker_heartbeat_callback,
             heartbeat_success_callback,
+            start_time,
         }
+    }
+
+    fn mark_started(&self) {
+        let _ = self.start_time.set(SystemTime::now().into());
     }
 }
 

--- a/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
@@ -846,32 +846,77 @@ async fn worker_heartbeat_multiple_workers() {
     let mut worker_a = starter.worker().await;
 
     let mut starter_b = starter.clone_no_worker();
+    starter_b.workflow_options.workflow_id = format!("{wf_name}_b");
     let mut worker_b = starter_b.worker().await;
 
     let worker_a_key = worker_a.worker_instance_key().to_string();
     let worker_b_key = worker_b.worker_instance_key().to_string();
-    let initial_heartbeats = eventually(
+    let _ = starter
+        .start_with_worker(MultiWorkersWf::name(), &mut worker_a)
+        .await;
+    let _ = starter_b
+        .start_with_worker(MultiWorkersWf::name(), &mut worker_b)
+        .await;
+
+    let initial_heartbeats_fut = async {
+        eventually(
+            || {
+                let client = client.clone();
+                let worker_a_key = worker_a_key.clone();
+                let worker_b_key = worker_b_key.clone();
+                async move {
+                    let heartbeats = list_worker_heartbeats(&client, String::new()).await;
+                    let heartbeats: Vec<_> = heartbeats
+                        .into_iter()
+                        .filter(|heartbeat| {
+                            heartbeat.worker_instance_key == worker_a_key
+                                || heartbeat.worker_instance_key == worker_b_key
+                        })
+                        .collect();
+                    if heartbeats.len() == 2
+                        && heartbeats
+                            .iter()
+                            .all(|heartbeat| heartbeat.environment.is_some())
+                    {
+                        Ok(heartbeats)
+                    } else {
+                        Err("initial worker environments have not been recorded")
+                    }
+                }
+            },
+            Duration::from_secs(7),
+        )
+        .await
+        .unwrap()
+    };
+    let worker_a_run = worker_a.run_until_done();
+    let worker_b_run = worker_b.run_until_done();
+    let (initial_heartbeats, worker_a_result, worker_b_result) =
+        tokio::join!(initial_heartbeats_fut, worker_a_run, worker_b_run);
+    worker_a_result.unwrap();
+    worker_b_result.unwrap();
+
+    for heartbeat in &initial_heartbeats {
+        assert_worker_environment(heartbeat);
+    }
+
+    let all = eventually(
         || {
             let client = client.clone();
             let worker_a_key = worker_a_key.clone();
             let worker_b_key = worker_b_key.clone();
             async move {
                 let heartbeats = list_worker_heartbeats(&client, String::new()).await;
-                let heartbeats: Vec<_> = heartbeats
-                    .into_iter()
-                    .filter(|heartbeat| {
-                        heartbeat.worker_instance_key == worker_a_key
-                            || heartbeat.worker_instance_key == worker_b_key
+                let is_final = |worker_key: &str| {
+                    heartbeats.iter().any(|heartbeat| {
+                        heartbeat.worker_instance_key == worker_key
+                            && heartbeat.status == WorkerStatus::ShuttingDown as i32
                     })
-                    .collect();
-                if heartbeats.len() == 2
-                    && heartbeats
-                        .iter()
-                        .all(|heartbeat| heartbeat.environment.is_some())
-                {
+                };
+                if is_final(&worker_a_key) && is_final(&worker_b_key) {
                     Ok(heartbeats)
                 } else {
-                    Err("initial worker environments have not been recorded")
+                    Err("final worker heartbeats have not been recorded")
                 }
             }
         },
@@ -879,37 +924,6 @@ async fn worker_heartbeat_multiple_workers() {
     )
     .await
     .unwrap();
-    for heartbeat in &initial_heartbeats {
-        assert_worker_environment(heartbeat);
-    }
-
-    let _ = starter
-        .start_with_worker(MultiWorkersWf::name(), &mut worker_a)
-        .await;
-    worker_a.run_until_done().await.unwrap();
-
-    let _ = starter_b
-        .start_with_worker(MultiWorkersWf::name(), &mut worker_b)
-        .await;
-    worker_b.run_until_done().await.unwrap();
-
-    sleep(Duration::from_secs(2)).await;
-
-    let all = list_worker_heartbeats(&client, String::new()).await;
-    let keys: HashSet<_> = all
-        .iter()
-        .map(|hb| hb.worker_instance_key.clone())
-        .collect();
-    assert!(keys.contains(&worker_a_key));
-    assert!(keys.contains(&worker_b_key));
-    assert!(
-        all.iter()
-            .filter(|heartbeat| {
-                heartbeat.worker_instance_key == worker_a_key
-                    || heartbeat.worker_instance_key == worker_b_key
-            })
-            .all(|heartbeat| heartbeat.environment.is_none())
-    );
 
     // Verify both heartbeats contain the same shared worker_grouping_key
     let worker_grouping_keys: HashSet<_> = all


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
See title

## Why?
We were heartbeating workers who hadn't yet started running, thus making it look like they're in a running state on server when they were in fact only constructed.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-rust/issues/1428
 
2. How was this tested:
Added/updated tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
