### PR TITLE
fix(sdk): payload conversion causes wft failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ relevant information.
   `WorkerInterceptor::with_workflow_replay_worker`.
 
 ### Breaking Changes :boom:
+* `anyhow::Error` no longer converts directly into `WorkflowTermination`. Wrap an error in
+  `ApplicationFailure` to explicitly fail the Workflow Execution.
 * Removed `InterceptorWithNext`. Register worker interceptors as an ordered vector instead.
 * `Worker::run` now returns `WorkerRunError` instead of `anyhow::Error`.
   Non-validation failures are reported as `WorkerRunError::Fatal` with a message and source.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,8 @@ relevant information.
   Non-validation failures are reported as `WorkerRunError::Fatal` with a message and source.
 
 ### Fixed
+* Unhandled workflow payload conversion errors now fail the Workflow Task so it can retry instead
+  of failing the Workflow Execution. Workflows may still explicitly handle these errors.
 * Local activity resolutions are now delivered to workflows as each activity completes instead of
   waiting for every local activity in the workflow task. This allows sequences of short local
   activities to make progress while a long-running local activity executes in parallel, while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ relevant information.
 ### Breaking Changes :boom:
 * `anyhow::Error` no longer converts directly into `WorkflowTermination`. Wrap an error in
   `ApplicationFailure` to explicitly fail the Workflow Execution.
+* `OutgoingWorkflowError` now has a dedicated `PayloadConversion` variant. Converting activity,
+  child-workflow, and signal errors lifts their payload-conversion variants into it.
+  `OutgoingError`, `OutgoingActivityError`, and `OutgoingWorkflowError` are now non-exhaustive;
+  downstream matches must include a wildcard arm.
 * Removed `InterceptorWithNext`. Register worker interceptors as an ordered vector instead.
 * `Worker::run` now returns `WorkerRunError` instead of `anyhow::Error`.
   Non-validation failures are reported as `WorkerRunError::Fatal` with a message and source.

--- a/crates/common-wasm/src/data_converters/failure_converter.rs
+++ b/crates/common-wasm/src/data_converters/failure_converter.rs
@@ -178,6 +178,9 @@ impl FailureConverter for DefaultFailureConverter {
             OutgoingError::Workflow(OutgoingWorkflowError::Application(app)) => {
                 app.encode_failure(payload_converter, context)
             }
+            OutgoingError::Workflow(OutgoingWorkflowError::PayloadConversion(err)) => {
+                Ok(encode_generic_application_failure(&err))
+            }
             OutgoingError::Workflow(OutgoingWorkflowError::ActivityExecution(activity)) => {
                 activity.encode_failure(payload_converter, context)
             }

--- a/crates/common-wasm/src/error.rs
+++ b/crates/common-wasm/src/error.rs
@@ -408,6 +408,7 @@ impl From<PayloadConversionError> for ApplicationFailure {
 
 /// A typed outbound error surface used before encoding to a Temporal failure proto.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum OutgoingError {
     /// An error produced while completing an activity.
     #[error(transparent)]
@@ -419,6 +420,7 @@ pub enum OutgoingError {
 
 /// A typed outbound activity error.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum OutgoingActivityError {
     /// An activity application failure.
     #[error(transparent)]
@@ -433,10 +435,14 @@ pub enum OutgoingActivityError {
 
 /// A typed outbound workflow failure.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum OutgoingWorkflowError {
     /// A workflow application failure.
     #[error(transparent)]
     Application(#[from] Box<ApplicationFailure>),
+    /// A workflow payload conversion failure.
+    #[error(transparent)]
+    PayloadConversion(#[from] PayloadConversionError),
     /// A workflow failure sourced from an activity execution.
     #[error(transparent)]
     ActivityExecution(#[from] Box<ActivityExecutionError>),
@@ -457,6 +463,7 @@ impl OutgoingWorkflowError {
     pub fn as_cancelled(&self) -> Option<&CancelledError> {
         match self {
             Self::Application(err) => err.as_cancelled(),
+            Self::PayloadConversion(_) => None,
             Self::ActivityExecution(err) => err.as_cancelled(),
             Self::ChildWorkflowExecution(err) => err.as_cancelled(),
             Self::ChildWorkflowStart(err) => err.as_cancelled(),
@@ -471,12 +478,6 @@ impl From<anyhow::Error> for OutgoingWorkflowError {
     }
 }
 
-impl From<PayloadConversionError> for OutgoingWorkflowError {
-    fn from(value: PayloadConversionError) -> Self {
-        Self::Application(Box::new(value.into()))
-    }
-}
-
 impl From<ApplicationFailure> for OutgoingWorkflowError {
     fn from(value: ApplicationFailure) -> Self {
         Self::Application(Box::new(value))
@@ -485,25 +486,37 @@ impl From<ApplicationFailure> for OutgoingWorkflowError {
 
 impl From<ActivityExecutionError> for OutgoingWorkflowError {
     fn from(value: ActivityExecutionError) -> Self {
-        Self::ActivityExecution(Box::new(value))
+        match value {
+            ActivityExecutionError::Serialization(err) => Self::PayloadConversion(err),
+            other => Self::ActivityExecution(Box::new(other)),
+        }
     }
 }
 
 impl From<ChildWorkflowExecutionError> for OutgoingWorkflowError {
     fn from(value: ChildWorkflowExecutionError) -> Self {
-        Self::ChildWorkflowExecution(Box::new(value))
+        match value {
+            ChildWorkflowExecutionError::Serialization(err) => Self::PayloadConversion(err),
+            other => Self::ChildWorkflowExecution(Box::new(other)),
+        }
     }
 }
 
 impl From<ChildWorkflowStartError> for OutgoingWorkflowError {
     fn from(value: ChildWorkflowStartError) -> Self {
-        Self::ChildWorkflowStart(Box::new(value))
+        match value {
+            ChildWorkflowStartError::Serialization(err) => Self::PayloadConversion(err),
+            other => Self::ChildWorkflowStart(Box::new(other)),
+        }
     }
 }
 
 impl From<WorkflowSignalError> for OutgoingWorkflowError {
     fn from(value: WorkflowSignalError) -> Self {
-        Self::WorkflowSignal(Box::new(value))
+        match value {
+            WorkflowSignalError::Serialization(err) => Self::PayloadConversion(err),
+            other => Self::WorkflowSignal(Box::new(other)),
+        }
     }
 }
 
@@ -1416,13 +1429,13 @@ mod tests {
     }
 
     #[test]
-    fn payload_conversion_errors_default_to_application_outgoing_errors() {
+    fn payload_conversion_errors_use_dedicated_outgoing_variant() {
         let outgoing: OutgoingWorkflowError =
             PayloadConversionError::EncodingError(anyhow::anyhow!("encode boom").into()).into();
 
-        let OutgoingWorkflowError::Application(app) = outgoing else {
-            panic!("payload conversion errors should default to application failures");
+        let OutgoingWorkflowError::PayloadConversion(err) = outgoing else {
+            panic!("expected a payload conversion failure");
         };
-        assert_eq!(app.to_string(), "Encoding error: encode boom");
+        assert_eq!(err.to_string(), "Encoding error: encode boom");
     }
 }

--- a/crates/sdk-core/tests/common/workflows.rs
+++ b/crates/sdk-core/tests/common/workflows.rs
@@ -30,15 +30,13 @@ impl LaProblemWorkflow {
                 .timer_backoff_threshold(Duration::from_secs(1))
                 .build(),
         )
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+        .await?;
         ctx.execute_activity(
             StdActivities::delay,
             Duration::from_secs(15),
             ActivityOptions::start_to_close_timeout(Duration::from_secs(20)),
         )
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+        .await?;
         Ok(())
     }
 }

--- a/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
@@ -30,8 +30,8 @@ use temporalio_common::{
 };
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityOptions, CancellableFuture, MemoValue, SyncWorkflowContext, WorkflowContext,
-    WorkflowContextView, WorkflowResult,
+    ActivityOptions, ApplicationFailure, CancellableFuture, MemoValue, SyncWorkflowContext,
+    WorkflowContext, WorkflowContextView, WorkflowResult,
     activities::{ActivityContext, ActivityError},
 };
 
@@ -296,7 +296,7 @@ struct WorkflowFailureFallbackWorkflow;
 impl WorkflowFailureFallbackWorkflow {
     #[run]
     async fn run(_ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
-        Err(anyhow::anyhow!(WORKFLOW_FAILURE_MESSAGE).into())
+        Err(ApplicationFailure::new(WORKFLOW_FAILURE_MESSAGE).into())
     }
 }
 

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -92,6 +92,7 @@ use tonic::IntoRequest;
 use url::Url;
 
 pub(crate) async fn get_text(endpoint: String) -> String {
+    temporalio_common::telemetry::ensure_default_crypto_provider();
     reqwest::get(endpoint).await.unwrap().text().await.unwrap()
 }
 
@@ -962,6 +963,7 @@ async fn docker_metrics_with_prometheus(
     eventually(
         || async {
             // Query Prometheus API for metrics
+            temporalio_common::telemetry::ensure_default_crypto_provider();
             let client = reqwest::Client::new();
             let query = format!("temporal_sdk_{}num_pollers", test_uid.clone());
             let response = client
@@ -1526,6 +1528,7 @@ async fn test_prometheus_endpoint_integration() {
     up_down_counter.adds(-2);
 
     let url = format!("http://{addr}/metrics");
+    temporalio_common::telemetry::ensure_default_crypto_provider();
     let response = tokio::time::timeout(Duration::from_secs(10), reqwest::get(&url))
         .await
         .expect("Request timed out")
@@ -1576,6 +1579,7 @@ async fn test_prometheus_metric_format_consistency() {
     activity_histogram.record(Duration::from_millis(150), &attrs);
 
     let url = format!("http://{addr}/metrics");
+    temporalio_common::telemetry::ensure_default_crypto_provider();
     let response = tokio::time::timeout(Duration::from_secs(10), reqwest::get(&url))
         .await
         .expect("Request timed out")

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -59,7 +59,6 @@ use temporalio_common::{
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
     ActivityOptions, LocalActivityOptions, WorkerOptions, WorkflowContext, WorkflowResult,
-    WorkflowTermination,
     activities::{ActivityContext, ActivityError},
     interceptors::WorkerInterceptor,
 };
@@ -433,8 +432,7 @@ async fn oversize_activity_result_fails_retryably_then_completes() {
                     })
                     .build(),
             )
-            .await
-            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            .await?;
             Ok(())
         }
     }
@@ -518,8 +516,7 @@ async fn oversize_activity_heartbeat_fails_retryably_then_completes() {
                     })
                     .build(),
             )
-            .await
-            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            .await?;
             Ok(())
         }
     }
@@ -657,8 +654,7 @@ async fn disabled_error_limit_lets_server_hard_fail() {
                     })
                     .build(),
             )
-            .await
-            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            .await?;
             Ok(())
         }
     }

--- a/crates/sdk-core/tests/integ_tests/workflow_replayer_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_replayer_tests.rs
@@ -14,8 +14,8 @@ use temporalio_client::{
 use temporalio_common::protos::temporal::api::enums::v1::EventType;
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
-    ActivityOptions, SimplePlugin, WorkerPlugin, WorkerRunError, WorkflowContext,
-    WorkflowContextView, WorkflowDefinitions, WorkflowResult,
+    ActivityOptions, ApplicationFailure, SimplePlugin, WorkerPlugin, WorkerRunError,
+    WorkflowContext, WorkflowContextView, WorkflowDefinitions, WorkflowResult,
     activities::{ActivityContext, ActivityError},
     interceptors::{Next, RunWorkerInput, WithWorkflowReplayWorkerInput, WorkerInterceptor},
     workflow_replayer::{
@@ -76,7 +76,7 @@ impl SayHelloWorkflow {
             ctx.wait_condition(|_| false).await?;
         }
         if input.should_error {
-            return Err(anyhow::anyhow!("Intentional workflow failure").into());
+            return Err(ApplicationFailure::new("Intentional workflow failure").into());
         }
         if input.should_fail_task {
             panic!("Intentional workflow task failure");

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -226,6 +226,76 @@ impl MultiArgActivityWorkflow {
     }
 }
 
+static FAIL_ACTIVITY_INPUT_SERIALIZATION_ONCE: AtomicBool = AtomicBool::new(true);
+
+#[derive(serde::Deserialize)]
+struct FailOnceActivityInput;
+
+impl serde::Serialize for FailOnceActivityInput {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if FAIL_ACTIVITY_INPUT_SERIALIZATION_ONCE.swap(false, Ordering::SeqCst) {
+            return Err(serde::ser::Error::custom(
+                "intentional activity input serialization failure",
+            ));
+        }
+        serializer.serialize_unit_struct("FailOnceActivityInput")
+    }
+}
+
+struct PayloadConversionActivities;
+
+#[activities]
+impl PayloadConversionActivities {
+    #[activity]
+    async fn fail_once_input(
+        _ctx: ActivityContext,
+        _input: FailOnceActivityInput,
+    ) -> Result<(), ActivityError> {
+        Ok(())
+    }
+}
+
+#[workflow]
+#[derive(Default)]
+struct PropagatedActivityInputConversionFailureWorkflow;
+
+#[workflow_methods]
+impl PropagatedActivityInputConversionFailureWorkflow {
+    #[run]
+    async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+        ctx.execute_activity(
+            PayloadConversionActivities::fail_once_input,
+            FailOnceActivityInput,
+            ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
+        )
+        .await?;
+        Ok(())
+    }
+}
+
+#[workflow]
+#[derive(Default)]
+struct CaughtActivityInputConversionFailureWorkflow;
+
+#[workflow_methods]
+impl CaughtActivityInputConversionFailureWorkflow {
+    #[run]
+    async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+        let result = ctx
+            .execute_activity(
+                PayloadConversionActivities::fail_once_input,
+                FailOnceActivityInput,
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
+            )
+            .await;
+        match result {
+            Err(ActivityExecutionError::Serialization(_error)) => (),
+            other => panic!("expected a serialization error, got {other:?}"),
+        }
+        Ok(())
+    }
+}
+
 #[tokio::test]
 async fn multi_arg_activity() {
     let wf_name = MultiArgActivityWorkflow::name();
@@ -250,6 +320,66 @@ async fn multi_arg_activity() {
     worker.run_until_done().await.unwrap();
     let r = handle.get_result(Default::default()).await.unwrap();
     assert_eq!(r, "hello world");
+}
+
+#[tokio::test]
+async fn propagated_activity_input_conversion_failure_fails_workflow_task() {
+    FAIL_ACTIVITY_INPUT_SERIALIZATION_ONCE.store(true, Ordering::SeqCst);
+    let wf_name = PropagatedActivityInputConversionFailureWorkflow::name();
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter
+        .sdk_config
+        .register_activities(PayloadConversionActivities);
+    starter
+        .sdk_config
+        .register_workflow::<PropagatedActivityInputConversionFailureWorkflow>()
+        .unwrap();
+    let mut worker = starter.worker().await;
+
+    let task_queue = starter.get_task_queue().to_owned();
+    let handle = worker
+        .submit_workflow(
+            PropagatedActivityInputConversionFailureWorkflow::run,
+            (),
+            WorkflowStartOptions::new(task_queue, wf_name.to_owned()).build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+    handle.get_result(Default::default()).await.unwrap();
+
+    let history = handle.fetch_history(Default::default()).await.unwrap();
+    assert_eq!(
+        history
+            .events()
+            .iter()
+            .filter(|event| event.event_type() == EventType::WorkflowTaskFailed)
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn activity_input_conversion_failure_can_be_caught() {
+    let wf_name = CaughtActivityInputConversionFailureWorkflow::name();
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter
+        .sdk_config
+        .register_workflow::<CaughtActivityInputConversionFailureWorkflow>()
+        .unwrap();
+    let mut worker = starter.worker().await;
+
+    let task_queue = starter.get_task_queue().to_owned();
+    let handle = worker
+        .submit_workflow(
+            CaughtActivityInputConversionFailureWorkflow::run,
+            (),
+            WorkflowStartOptions::new(task_queue, wf_name.to_owned()).build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+    handle.get_result(Default::default()).await.unwrap();
 }
 
 #[tokio::test]

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -42,6 +42,7 @@ use temporalio_common::{
             common::v1::{ActivityType, Payload, RetryPolicy},
             enums::v1::{CommandType, EventType, RetryState as ProtoRetryState},
             failure::v1::{ActivityFailureInfo, Failure, failure::FailureInfo},
+            history::v1::history_event::Attributes::WorkflowTaskFailedEventAttributes,
             sdk::v1::UserMetadata,
         },
     },
@@ -349,13 +350,25 @@ async fn propagated_activity_input_conversion_failure_fails_workflow_task() {
     handle.get_result(Default::default()).await.unwrap();
 
     let history = handle.fetch_history(Default::default()).await.unwrap();
-    assert_eq!(
-        history
-            .events()
-            .iter()
-            .filter(|event| event.event_type() == EventType::WorkflowTaskFailed)
-            .count(),
-        1
+    let workflow_task_failures: Vec<_> = history
+        .events()
+        .iter()
+        .filter(|event| event.event_type() == EventType::WorkflowTaskFailed)
+        .collect();
+    assert_eq!(workflow_task_failures.len(), 1);
+    let Some(WorkflowTaskFailedEventAttributes(attributes)) =
+        workflow_task_failures[0].attributes.as_ref()
+    else {
+        panic!("expected workflow task failed attributes");
+    };
+    let failure = attributes
+        .failure
+        .as_ref()
+        .expect("workflow task failure should include a failure");
+    assert!(
+        failure
+            .message
+            .contains("intentional activity input serialization failure")
     );
 }
 

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_external.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_external.rs
@@ -5,7 +5,7 @@ use temporalio_common::protos::{
     temporal::api::enums::v1::{CommandType, EventType},
 };
 use temporalio_macros::{workflow, workflow_methods};
-use temporalio_sdk::{WorkflowContext, WorkflowResult};
+use temporalio_sdk::{ApplicationFailure, WorkflowContext, WorkflowResult};
 use temporalio_sdk_core::{
     replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder},
     test_help::MockPollCfg,
@@ -104,7 +104,7 @@ impl CancelSenderCanned {
         let handle = ctx.external_workflow("fake_wid", Some("fake_rid".into()));
         let res = handle.cancel(None).await;
         if res.is_err() {
-            Err(anyhow::anyhow!("Cancel fail!").into())
+            Err(ApplicationFailure::new("Cancel fail!").into())
         } else {
             Ok(())
         }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -1,5 +1,4 @@
 use crate::common::{CoreWfStarter, WorkflowHandleExt};
-use anyhow::anyhow;
 use assert_matches::assert_matches;
 use std::{sync::Arc, time::Duration};
 use temporalio_client::{WorkflowCancelOptions, WorkflowStartOptions};
@@ -33,9 +32,9 @@ use temporalio_common::{
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
-    CancellableFuture, ChildWorkflowCancellationType, ChildWorkflowExecutionError,
-    ChildWorkflowOptions, ChildWorkflowStartError, ParentClosePolicy, SyncWorkflowContext,
-    WorkflowContext, WorkflowResult, WorkflowSignalError, WorkflowTermination,
+    ApplicationFailure, CancellableFuture, ChildWorkflowCancellationType,
+    ChildWorkflowExecutionError, ChildWorkflowOptions, ChildWorkflowStartError, ParentClosePolicy,
+    SyncWorkflowContext, WorkflowContext, WorkflowResult, WorkflowSignalError, WorkflowTermination,
 };
 use temporalio_sdk_core::{
     replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, canned_histories},
@@ -918,7 +917,9 @@ impl ParentWf {
         if let Expectation::StartFailure = expectation {
             match start_res {
                 Err(ChildWorkflowStartError::StartFailed { .. }) => return Ok(()),
-                _ => return Err(anyhow!("Expected start failure").into()),
+                _ => {
+                    return Err(ApplicationFailure::new("Expected start failure").into());
+                }
             }
         }
         let started = start_res?;
@@ -932,7 +933,7 @@ impl ParentWf {
                 assert_eq!(failure.workflow_type(), Some("child"));
                 Ok(())
             }
-            _ => Err(anyhow!("Unexpected child WF status").into()),
+            _ => Err(ApplicationFailure::new("Unexpected child WF status").into()),
         }
     }
 }
@@ -1034,7 +1035,7 @@ impl CancelBeforeSendWf {
         start.cancel();
         match start.await {
             Err(ChildWorkflowStartError::Cancelled(_)) => Ok(()),
-            _ => Err(anyhow!("Unexpected start status").into()),
+            _ => Err(ApplicationFailure::new("Unexpected start status").into()),
         }
     }
 }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use temporalio_client::WorkflowStartOptions;
 use temporalio_common::{
-    UntypedWorkflow,
+    UntypedActivity, UntypedWorkflow,
     data_converters::RawValue,
     protos::{
         coresdk::{AsJsonPayloadExt, FromJsonPayloadExt},
@@ -342,8 +342,12 @@ impl ActivityIdOrTypeChangeWf {
                 )
                 .await?;
             } else {
-                ctx.execute_local_activity(StdActivities::no_op, (), Default::default())
-                    .await?;
+                ctx.execute_local_activity(
+                    UntypedActivity::new("not the activity type"),
+                    RawValue::empty(),
+                    Default::default(),
+                )
+                .await?;
             }
         } else if id_change {
             ctx.execute_activity(
@@ -356,8 +360,8 @@ impl ActivityIdOrTypeChangeWf {
             .await?;
         } else {
             ctx.execute_activity(
-                StdActivities::no_op,
-                (),
+                UntypedActivity::new("not the activity type"),
+                RawValue::empty(),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(5)),
             )
             .await?;

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/nexus.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/nexus.rs
@@ -2,7 +2,6 @@ use crate::{
     common::{CoreWfStarter, WorkflowHandleExt, rand_6_chars},
     integ_tests::mk_nexus_endpoint,
 };
-use anyhow::anyhow;
 use assert_matches::assert_matches;
 use std::{
     sync::{
@@ -43,9 +42,9 @@ use temporalio_common::{
 };
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
-    CancellableFuture, NexusOperationCancellationType, NexusOperationOptions, SyncWorkflowContext,
-    WaitConditionOptions, WorkflowCancellationToken, WorkflowContext, WorkflowContextView,
-    WorkflowResult, WorkflowTermination,
+    ApplicationFailure, CancellableFuture, NexusOperationCancellationType, NexusOperationOptions,
+    SyncWorkflowContext, WaitConditionOptions, WorkflowCancellationToken, WorkflowContext,
+    WorkflowContextView, WorkflowResult, WorkflowTermination,
 };
 use temporalio_sdk_core::PollError;
 use tokio::{
@@ -304,7 +303,7 @@ impl AsyncCompleter {
                 ctx.cancelled().await;
                 Err(WorkflowTermination::Cancelled)
             }
-            _ => Err(anyhow!("broken").into()),
+            _ => Err(ApplicationFailure::new("broken").into()),
         }
     }
 }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
@@ -18,7 +18,8 @@ use temporalio_sdk_core::replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder};
 
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
-    CancellableFuture, ChildWorkflowOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
+    ApplicationFailure, CancellableFuture, ChildWorkflowOptions, SyncWorkflowContext,
+    WorkflowContext, WorkflowResult,
 };
 use temporalio_sdk_core::test_help::MockPollCfg;
 use uuid::Uuid;
@@ -278,7 +279,7 @@ impl SignalSenderCanned {
             )
             .await;
         if res.is_err() {
-            Err(anyhow::anyhow!("Signal fail!").into())
+            Err(ApplicationFailure::new("Signal fail!").into())
         } else {
             Ok(())
         }

--- a/crates/sdk-core/tests/shared_tests/mod.rs
+++ b/crates/sdk-core/tests/shared_tests/mod.rs
@@ -41,7 +41,7 @@ use temporalio_common::{
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
     ActivityOptions, CancellableFuture, SyncWorkflowContext, WorkflowContext, WorkflowResult,
-    WorkflowTermination, activities::ActivityContext,
+    activities::ActivityContext,
 };
 use tokio::{
     net::TcpListener,
@@ -304,8 +304,7 @@ impl ShutdownTimerActivityLoopWf {
                 (),
                 ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),
             )
-            .await
-            .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            .await?;
         }
     }
 }
@@ -472,9 +471,7 @@ pub(crate) async fn activity_cancel_delivered_without_heartbeat(disable_eager: b
             // through the worker commands path.
             ctx.wait_condition(|s| s.act_started).await?;
             act_fut.cancel();
-            act_fut
-                .await
-                .map_err(|e| WorkflowTermination::from(anyhow::Error::from(e)))?;
+            act_fut.await?;
             Ok(())
         }
 

--- a/crates/sdk/src/workflow_future.rs
+++ b/crates/sdk/src/workflow_future.rs
@@ -10,6 +10,7 @@ use std::{
 };
 use temporalio_common::{
     data_converters::DataConverter,
+    error::ApplicationFailure,
     protos::{
         coresdk::{
             workflow_activation::{
@@ -646,10 +647,11 @@ impl Future for WorkflowFuture {
                     Poll::Ready(a) => match a {
                         Some(act) => act,
                         None => {
-                            return Poll::Ready(Err(anyhow!(
-                                "Workflow future's activation channel was lost!"
-                            )
-                            .into()));
+                            return Poll::Ready(Err(WorkflowTermination::failed_application(
+                                ApplicationFailure::new(
+                                    "Workflow future's activation channel was lost!",
+                                ),
+                            )));
                         }
                     },
                     Poll::Pending => return Poll::Pending,

--- a/crates/workflow/Cargo.toml
+++ b/crates/workflow/Cargo.toml
@@ -39,5 +39,8 @@ version = "0.6"
 path = "../macros"
 version = "0.6"
 
+[dev-dependencies]
+rstest = "0.26"
+
 [lints]
 workspace = true

--- a/crates/workflow/src/runtime/instance.rs
+++ b/crates/workflow/src/runtime/instance.rs
@@ -10,8 +10,8 @@ use crate::{
         types::{
             ActivationJobResult, ActivationResult, MAIN_ROUTINE_ID, MainRoutineCompletion,
             QueryResponse, RoutineCompletion, RoutineId, RoutineKind, RoutinePendingState,
-            RoutinePollResult, StartedRoutine, UpdateRoutineCompletion, UpdateRoutineKind,
-            WorkflowActivation, WorkflowFailure,
+            RoutinePollResult, StartedRoutine, TaskFailure, TerminalOutcome,
+            UpdateRoutineCompletion, UpdateRoutineKind, WorkflowActivation, WorkflowFailure,
         },
     },
     workflow_interceptors::{
@@ -759,32 +759,37 @@ where
     fn terminal_outcome_from_result(
         &self,
         result: ExecuteWorkflowResult,
-    ) -> crate::runtime::types::TerminalOutcome {
+    ) -> Result<TerminalOutcome, TaskFailure> {
         let result = result.and_then(|result| {
             serialize_workflow_output(result.as_ref(), self.ctx.payload_converter())
                 .map_err(WorkflowTermination::from)
         });
         match result {
-            Ok(result) => crate::runtime::types::TerminalOutcome::Completed(result),
-            Err(WorkflowTermination::ContinueAsNew(req)) => {
-                crate::runtime::types::TerminalOutcome::ContinueAsNew(req)
-            }
-            Err(WorkflowTermination::Cancelled) => {
-                crate::runtime::types::TerminalOutcome::Cancelled
-            }
+            Ok(result) => Ok(TerminalOutcome::Completed(result)),
+            Err(WorkflowTermination::ContinueAsNew(req)) => Ok(TerminalOutcome::ContinueAsNew(req)),
+            Err(WorkflowTermination::Cancelled) => Ok(TerminalOutcome::Cancelled),
             Err(WorkflowTermination::Evicted) => {
                 panic!("workflow instances must not explicitly return eviction")
+            }
+            Err(WorkflowTermination::Failed(OutgoingWorkflowError::PayloadConversion(err))) => {
+                Err(TaskFailure {
+                    failure: Box::new(Failure {
+                        message: format!("Workflow payload conversion failed: {err}"),
+                        ..Default::default()
+                    }),
+                    force_cause: None,
+                })
             }
             Err(WorkflowTermination::Failed(err)) => {
                 if self.base_ctx.cancellation_token().is_cancelled() && err.as_cancelled().is_some()
                 {
-                    return crate::runtime::types::TerminalOutcome::Cancelled;
+                    return Ok(TerminalOutcome::Cancelled);
                 }
                 let failure = self.base_ctx.data_converter().to_failure(
                     &SerializationContextData::Workflow,
                     temporalio_common_wasm::error::OutgoingError::Workflow(err),
                 );
-                crate::runtime::types::TerminalOutcome::Failed(Box::new(failure))
+                Ok(TerminalOutcome::Failed(Box::new(failure)))
             }
         }
     }
@@ -854,13 +859,17 @@ where
                 RoutinePollState::Ready {
                     result,
                     made_progress,
-                } => RoutinePollResult {
-                    completion: Some(RoutineCompletion::Main(MainRoutineCompletion::Terminal(
-                        Box::new(self.terminal_outcome_from_result(result)),
-                    ))),
-                    made_progress,
-                    pending_state: None,
-                },
+                } => {
+                    let completion = match self.terminal_outcome_from_result(result) {
+                        Ok(outcome) => MainRoutineCompletion::Terminal(Box::new(outcome)),
+                        Err(failure) => MainRoutineCompletion::TaskFailed(failure),
+                    };
+                    RoutinePollResult {
+                        completion: Some(RoutineCompletion::Main(completion)),
+                        made_progress,
+                        pending_state: None,
+                    }
+                }
                 RoutinePollState::ForcedFailure {
                     failure,
                     made_progress,

--- a/crates/workflow/src/runtime/model.rs
+++ b/crates/workflow/src/runtime/model.rs
@@ -254,57 +254,33 @@ impl From<ApplicationFailure> for WorkflowTermination {
     }
 }
 
-fn fail_workflow_task_on_payload_conversion(error: PayloadConversionError) -> ! {
-    panic!("Workflow payload conversion failed: {error}")
-}
-
 impl From<PayloadConversionError> for WorkflowTermination {
     fn from(value: PayloadConversionError) -> Self {
-        fail_workflow_task_on_payload_conversion(value)
+        Self::Failed(value.into())
     }
 }
 
 impl From<ActivityExecutionError> for WorkflowTermination {
     fn from(value: ActivityExecutionError) -> Self {
-        match value {
-            ActivityExecutionError::Serialization(err) => {
-                fail_workflow_task_on_payload_conversion(err)
-            }
-            other => Self::Failed(other.into()),
-        }
+        Self::Failed(value.into())
     }
 }
 
 impl From<ChildWorkflowExecutionError> for WorkflowTermination {
     fn from(value: ChildWorkflowExecutionError) -> Self {
-        match value {
-            ChildWorkflowExecutionError::Serialization(err) => {
-                fail_workflow_task_on_payload_conversion(err)
-            }
-            other => Self::Failed(other.into()),
-        }
+        Self::Failed(value.into())
     }
 }
 
 impl From<WorkflowSignalError> for WorkflowTermination {
     fn from(value: WorkflowSignalError) -> Self {
-        match value {
-            WorkflowSignalError::Serialization(err) => {
-                fail_workflow_task_on_payload_conversion(err)
-            }
-            other => Self::Failed(other.into()),
-        }
+        Self::Failed(value.into())
     }
 }
 
 impl From<ChildWorkflowStartError> for WorkflowTermination {
     fn from(value: ChildWorkflowStartError) -> Self {
-        match value {
-            ChildWorkflowStartError::Serialization(err) => {
-                fail_workflow_task_on_payload_conversion(err)
-            }
-            other => Self::Failed(other.into()),
-        }
+        Self::Failed(value.into())
     }
 }
 
@@ -312,6 +288,7 @@ impl From<ChildWorkflowStartError> for WorkflowTermination {
 mod tests {
     use super::*;
     use rstest::rstest;
+    use temporalio_common_wasm::error::OutgoingWorkflowError;
 
     fn conversion_error() -> PayloadConversionError {
         PayloadConversionError::EncodingError(std::io::Error::other("test conversion error").into())
@@ -323,14 +300,25 @@ mod tests {
     #[case::child_start(ChildWorkflowStartError::Serialization(conversion_error()))]
     #[case::child_execution(ChildWorkflowExecutionError::Serialization(conversion_error()))]
     #[case::signal(WorkflowSignalError::Serialization(conversion_error()))]
-    #[should_panic(
-        expected = "Workflow payload conversion failed: Encoding error: test conversion error"
-    )]
-    fn conversion_error_panics_when_converted_to_workflow_termination<
-        T: Into<WorkflowTermination>,
-    >(
+    fn conversion_error_is_preserved_in_workflow_termination<T: Into<WorkflowTermination>>(
         #[case] error: T,
     ) {
-        let _: WorkflowTermination = error.into();
+        let termination = error.into();
+        let WorkflowTermination::Failed(OutgoingWorkflowError::PayloadConversion(err)) =
+            termination
+        else {
+            panic!("expected a payload conversion failure");
+        };
+        assert_eq!(err.to_string(), "Encoding error: test conversion error");
+    }
+
+    #[test]
+    fn explicitly_wrapped_conversion_error_remains_an_application_failure() {
+        let termination = WorkflowTermination::from(ApplicationFailure::new(conversion_error()));
+
+        assert!(matches!(
+            termination,
+            WorkflowTermination::Failed(OutgoingWorkflowError::Application(_))
+        ));
     }
 }

--- a/crates/workflow/src/runtime/model.rs
+++ b/crates/workflow/src/runtime/model.rs
@@ -214,8 +214,7 @@ pub type WorkflowResult<T> = Result<T, WorkflowTermination>;
 
 /// Represents ways a workflow can terminate without producing a normal result.
 ///
-/// Payload conversion errors returned by workflow operations may be handled at the operation
-/// boundary. Propagating one directly into `WorkflowTermination`, such as with `?`, will fail
+/// Payload conversion errors returned by workflow operations propagated directly into `WorkflowTermination`, such as with `?`, will fail
 /// the current Workflow Task so it can be retried.
 ///
 /// Wrap an error in an [`ApplicationFailure`] to explicitly fail the Workflow Execution.

--- a/crates/workflow/src/runtime/model.rs
+++ b/crates/workflow/src/runtime/model.rs
@@ -215,9 +215,10 @@ pub type WorkflowResult<T> = Result<T, WorkflowTermination>;
 /// Represents ways a workflow can terminate without producing a normal result.
 ///
 /// Payload conversion errors returned by workflow operations may be handled at the operation
-/// boundary. Propagating one directly into `WorkflowTermination`, such as with `?` will fail
-/// the current Workflow Task so it can be retried. Wrapping the conversion error in another
-/// error type instead produces the normal failure behavior for that wrapper.
+/// boundary. Propagating one directly into `WorkflowTermination`, such as with `?`, will fail
+/// the current Workflow Task so it can be retried.
+///
+/// Wrap an error in an [`ApplicationFailure`] to explicitly fail the Workflow Execution.
 #[derive(Debug, thiserror::Error)]
 pub enum WorkflowTermination {
     #[error("Workflow cancelled")]
@@ -241,12 +242,6 @@ impl WorkflowTermination {
     }
 }
 
-impl From<anyhow::Error> for WorkflowTermination {
-    fn from(err: anyhow::Error) -> Self {
-        Self::Failed(err.into())
-    }
-}
-
 impl From<WorkflowCancellationError> for WorkflowTermination {
     fn from(_value: WorkflowCancellationError) -> Self {
         Self::Cancelled
@@ -266,19 +261,6 @@ fn fail_workflow_task_on_payload_conversion(error: PayloadConversionError) -> ! 
 impl From<PayloadConversionError> for WorkflowTermination {
     fn from(value: PayloadConversionError) -> Self {
         fail_workflow_task_on_payload_conversion(value)
-    }
-}
-
-impl From<crate::runtime::entry::WorkflowError> for WorkflowTermination {
-    fn from(value: crate::runtime::entry::WorkflowError) -> Self {
-        match value {
-            crate::runtime::entry::WorkflowError::PayloadConversion(err) => Self::from(err),
-            crate::runtime::entry::WorkflowError::Execution(err) => Self::Failed(
-                temporalio_common_wasm::error::OutgoingWorkflowError::Application(Box::new(
-                    ApplicationFailure::new(err),
-                )),
-            ),
-        }
     }
 }
 
@@ -329,7 +311,6 @@ impl From<ChildWorkflowStartError> for WorkflowTermination {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime::entry::WorkflowError;
     use rstest::rstest;
 
     fn conversion_error() -> PayloadConversionError {
@@ -338,7 +319,6 @@ mod tests {
 
     #[rstest]
     #[case::payload(conversion_error())]
-    #[case::workflow(WorkflowError::PayloadConversion(conversion_error()))]
     #[case::activity(ActivityExecutionError::Serialization(conversion_error()))]
     #[case::child_start(ChildWorkflowStartError::Serialization(conversion_error()))]
     #[case::child_execution(ChildWorkflowExecutionError::Serialization(conversion_error()))]

--- a/crates/workflow/src/runtime/model.rs
+++ b/crates/workflow/src/runtime/model.rs
@@ -9,9 +9,10 @@ use crate::{
 };
 use temporalio_common_wasm::{
     WorkflowDefinition,
+    data_converters::PayloadConversionError,
     error::{
         ActivityExecutionError, ApplicationFailure, ChildWorkflowExecutionError,
-        WorkflowSignalError,
+        ChildWorkflowStartError, WorkflowSignalError,
     },
     protos::{
         coresdk::{
@@ -212,6 +213,11 @@ impl CancellableID {
 pub type WorkflowResult<T> = Result<T, WorkflowTermination>;
 
 /// Represents ways a workflow can terminate without producing a normal result.
+///
+/// Payload conversion errors returned by workflow operations may be handled at the operation
+/// boundary. Propagating one directly into `WorkflowTermination`, such as with `?` will fail
+/// the current Workflow Task so it can be retried. Wrapping the conversion error in another
+/// error type instead produces the normal failure behavior for that wrapper.
 #[derive(Debug, thiserror::Error)]
 pub enum WorkflowTermination {
     #[error("Workflow cancelled")]
@@ -253,9 +259,13 @@ impl From<ApplicationFailure> for WorkflowTermination {
     }
 }
 
-impl From<temporalio_common_wasm::data_converters::PayloadConversionError> for WorkflowTermination {
-    fn from(value: temporalio_common_wasm::data_converters::PayloadConversionError) -> Self {
-        Self::Failed(value.into())
+fn fail_workflow_task_on_payload_conversion(error: PayloadConversionError) -> ! {
+    panic!("Workflow payload conversion failed: {error}")
+}
+
+impl From<PayloadConversionError> for WorkflowTermination {
+    fn from(value: PayloadConversionError) -> Self {
+        fail_workflow_task_on_payload_conversion(value)
     }
 }
 
@@ -274,24 +284,73 @@ impl From<crate::runtime::entry::WorkflowError> for WorkflowTermination {
 
 impl From<ActivityExecutionError> for WorkflowTermination {
     fn from(value: ActivityExecutionError) -> Self {
-        Self::Failed(value.into())
+        match value {
+            ActivityExecutionError::Serialization(err) => {
+                fail_workflow_task_on_payload_conversion(err)
+            }
+            other => Self::Failed(other.into()),
+        }
     }
 }
 
 impl From<ChildWorkflowExecutionError> for WorkflowTermination {
     fn from(value: ChildWorkflowExecutionError) -> Self {
-        Self::Failed(value.into())
+        match value {
+            ChildWorkflowExecutionError::Serialization(err) => {
+                fail_workflow_task_on_payload_conversion(err)
+            }
+            other => Self::Failed(other.into()),
+        }
     }
 }
 
 impl From<WorkflowSignalError> for WorkflowTermination {
     fn from(value: WorkflowSignalError) -> Self {
-        Self::Failed(value.into())
+        match value {
+            WorkflowSignalError::Serialization(err) => {
+                fail_workflow_task_on_payload_conversion(err)
+            }
+            other => Self::Failed(other.into()),
+        }
     }
 }
 
-impl From<temporalio_common_wasm::error::ChildWorkflowStartError> for WorkflowTermination {
-    fn from(value: temporalio_common_wasm::error::ChildWorkflowStartError) -> Self {
-        Self::Failed(value.into())
+impl From<ChildWorkflowStartError> for WorkflowTermination {
+    fn from(value: ChildWorkflowStartError) -> Self {
+        match value {
+            ChildWorkflowStartError::Serialization(err) => {
+                fail_workflow_task_on_payload_conversion(err)
+            }
+            other => Self::Failed(other.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::entry::WorkflowError;
+    use rstest::rstest;
+
+    fn conversion_error() -> PayloadConversionError {
+        PayloadConversionError::EncodingError(std::io::Error::other("test conversion error").into())
+    }
+
+    #[rstest]
+    #[case::payload(conversion_error())]
+    #[case::workflow(WorkflowError::PayloadConversion(conversion_error()))]
+    #[case::activity(ActivityExecutionError::Serialization(conversion_error()))]
+    #[case::child_start(ChildWorkflowStartError::Serialization(conversion_error()))]
+    #[case::child_execution(ChildWorkflowExecutionError::Serialization(conversion_error()))]
+    #[case::signal(WorkflowSignalError::Serialization(conversion_error()))]
+    #[should_panic(
+        expected = "Workflow payload conversion failed: Encoding error: test conversion error"
+    )]
+    fn conversion_error_panics_when_converted_to_workflow_termination<
+        T: Into<WorkflowTermination>,
+    >(
+        #[case] error: T,
+    ) {
+        let _: WorkflowTermination = error.into();
     }
 }

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -4197,7 +4197,10 @@ mod tests {
     }
 
     #[test]
-    fn continue_as_new_reports_serialization_errors() {
+    #[should_panic(
+        expected = "Workflow payload conversion failed: Encoding error: serialization failure"
+    )]
+    fn continue_as_new_panics_on_input_serialization_errors() {
         #[derive(Debug)]
         struct FailingInput;
 
@@ -4259,38 +4262,24 @@ mod tests {
         );
         let ctx = WorkflowContext::from_base(base, Rc::new(RefCell::new(FailingWorkflow)));
 
-        let err = ctx
-            .continue_as_new(FailingInput, ContinueAsNewOptions::default())
-            .expect_err("serialization errors should be surfaced");
-
-        let WorkflowTermination::Failed(err) = err else {
-            panic!("expected failed termination, got {err:?}");
-        };
-        assert_eq!(err.to_string(), "Encoding error: serialization failure");
+        let _ = ctx.continue_as_new(FailingInput, ContinueAsNewOptions::default());
     }
 
     #[test]
-    fn continue_as_new_reports_memo_serialization_errors() {
+    #[should_panic(
+        expected = "Workflow payload conversion failed: Encoding error: memo serialization failure"
+    )]
+    fn continue_as_new_panics_on_memo_serialization_errors() {
         let ctx = test_context();
         let mut memo = MemoValues::new();
         memo.insert("invalid", FailingMemoValue);
 
-        let err = ctx
-            .continue_as_new(
-                7,
-                ContinueAsNewOptions {
-                    memo: Some(memo),
-                    ..Default::default()
-                },
-            )
-            .expect_err("memo serialization errors should be surfaced");
-
-        let WorkflowTermination::Failed(err) = err else {
-            panic!("expected failed termination, got {err:?}");
-        };
-        assert_eq!(
-            err.to_string(),
-            "Encoding error: memo serialization failure"
+        let _ = ctx.continue_as_new(
+            7,
+            ContinueAsNewOptions {
+                memo: Some(memo),
+                ..Default::default()
+            },
         );
     }
 

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -3215,6 +3215,7 @@ mod tests {
     use temporalio_common_wasm::{
         RetryPolicy,
         data_converters::{TemporalDeserializable, TemporalSerializable},
+        error::OutgoingWorkflowError,
         protos::{
             coresdk::{
                 AsJsonPayloadExt, FromJsonPayloadExt,
@@ -4197,10 +4198,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "Workflow payload conversion failed: Encoding error: serialization failure"
-    )]
-    fn continue_as_new_panics_on_input_serialization_errors() {
+    fn continue_as_new_preserves_input_serialization_errors() {
         #[derive(Debug)]
         struct FailingInput;
 
@@ -4262,24 +4260,40 @@ mod tests {
         );
         let ctx = WorkflowContext::from_base(base, Rc::new(RefCell::new(FailingWorkflow)));
 
-        let _ = ctx.continue_as_new(FailingInput, ContinueAsNewOptions::default());
+        let termination = ctx
+            .continue_as_new(FailingInput, ContinueAsNewOptions::default())
+            .expect_err("input serialization should fail");
+        let WorkflowTermination::Failed(OutgoingWorkflowError::PayloadConversion(err)) =
+            termination
+        else {
+            panic!("expected a payload conversion failure");
+        };
+        assert_eq!(err.to_string(), "Encoding error: serialization failure");
     }
 
     #[test]
-    #[should_panic(
-        expected = "Workflow payload conversion failed: Encoding error: memo serialization failure"
-    )]
-    fn continue_as_new_panics_on_memo_serialization_errors() {
+    fn continue_as_new_preserves_memo_serialization_errors() {
         let ctx = test_context();
         let mut memo = MemoValues::new();
         memo.insert("invalid", FailingMemoValue);
 
-        let _ = ctx.continue_as_new(
-            7,
-            ContinueAsNewOptions {
-                memo: Some(memo),
-                ..Default::default()
-            },
+        let termination = ctx
+            .continue_as_new(
+                7,
+                ContinueAsNewOptions {
+                    memo: Some(memo),
+                    ..Default::default()
+                },
+            )
+            .expect_err("memo serialization should fail");
+        let WorkflowTermination::Failed(OutgoingWorkflowError::PayloadConversion(err)) =
+            termination
+        else {
+            panic!("expected a payload conversion failure");
+        };
+        assert_eq!(
+            err.to_string(),
+            "Encoding error: memo serialization failure"
         );
     }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Payload conversion errors now result in failing the WFT. Previously a naive `?` usage would fail the workflow.
- Remove `anyhow` conversion to `WorkflowTermination`, ensures that there is explicit `ApplicationFailure` wrapping if failing the workflow is desired.
- In order to better support the first change we added a new variant to outgoing workflow error. All outgoing error types that have a payload conversion failure map to this variant directly.
- Small fixup to ensure crypto provider is hooked up for some reqwest usage in our tests.

## Why?
Match all other SDKs, payload conversion errors should result in a task being retried, not the workflow itself failed.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Added integration test to verify these fail the WFT and will result in the task being retried.

3. Any docs updates needed?
N/A
