### PR TITLE
Expose console log format through C bridge

### DIFF
--- a/crates/sdk-core-c-bridge/include/temporal-sdk-core-c-bridge.h
+++ b/crates/sdk-core-c-bridge/include/temporal-sdk-core-c-bridge.h
@@ -40,6 +40,13 @@ typedef enum TemporalCoreMetricKind {
   TemporalCoreMetricKind_UpDownCounterInteger,
 } TemporalCoreMetricKind;
 
+typedef enum TemporalCoreConsoleLogFormat {
+  TemporalCoreConsoleLogFormat_Unspecified = 0,
+  TemporalCoreConsoleLogFormat_Compact = 1,
+  TemporalCoreConsoleLogFormat_Pretty = 2,
+  TemporalCoreConsoleLogFormat_Json = 3,
+} TemporalCoreConsoleLogFormat;
+
 typedef enum TemporalCoreForwardedLogLevel {
   TemporalCoreForwardedLogLevel_Trace = 0,
   TemporalCoreForwardedLogLevel_Debug,
@@ -392,6 +399,7 @@ typedef void (*TemporalCoreForwardedLogCallback)(enum TemporalCoreForwardedLogLe
 
 typedef struct TemporalCoreLoggingOptions {
   struct TemporalCoreByteArrayRef filter;
+  enum TemporalCoreConsoleLogFormat format;
   /**
    * This callback is expected to work for the life of the runtime.
    */

--- a/crates/sdk-core-c-bridge/src/runtime.rs
+++ b/crates/sdk-core-c-bridge/src/runtime.rs
@@ -20,9 +20,10 @@ use temporalio_common::{
         Runtime as CoreEnvironmentRuntime, runtime::RuntimeType as CoreRuntimeType,
     },
     telemetry::{
-        CoreLog, CoreLogConsumer, HistogramBucketOverrides, Logger, MetricTemporality,
-        OtelCollectorOptions, PrometheusExporterOptions, TelemetryOptions as CoreTelemetryOptions,
-        build_otlp_metric_exporter, metrics::CoreMeter, start_prometheus_metric_exporter,
+        CoreLog, CoreLogConsumer, HistogramBucketOverrides, Logger, LoggerFormat,
+        MetricTemporality, OtelCollectorOptions, PrometheusExporterOptions,
+        TelemetryOptions as CoreTelemetryOptions, build_otlp_metric_exporter, metrics::CoreMeter,
+        start_prometheus_metric_exporter,
     },
 };
 use temporalio_sdk_core::{
@@ -138,8 +139,18 @@ pub struct TelemetryOptions {
 #[repr(C)]
 pub struct LoggingOptions {
     pub filter: ByteArrayRef,
+    pub format: ConsoleLogFormat,
     /// This callback is expected to work for the life of the runtime.
     pub forward_to: ForwardedLogCallback,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub enum ConsoleLogFormat {
+    Unspecified = 0,
+    Compact = 1,
+    Pretty = 2,
+    Json = 3,
 }
 
 // This has to be Option here because of https://github.com/mozilla/cbindgen/issues/326
@@ -320,7 +331,12 @@ impl Runtime {
                 } else {
                     Logger::Console {
                         filter: v.filter.to_string(),
-                        format: None,
+                        format: match v.format {
+                            ConsoleLogFormat::Unspecified => None,
+                            ConsoleLogFormat::Compact => Some(LoggerFormat::Compact),
+                            ConsoleLogFormat::Pretty => Some(LoggerFormat::Pretty),
+                            ConsoleLogFormat::Json => Some(LoggerFormat::Json),
+                        },
                     }
                 }
             });

--- a/crates/sdk-core/CHANGELOG.md
+++ b/crates/sdk-core/CHANGELOG.md
@@ -34,6 +34,7 @@ relevant information.
 ## Unreleased
 
 ### Added
+* Core-based SDKs using the C bridge can now select compact, pretty, or JSON console log output.
 * Core console logs can now be emitted as newline-delimited JSON when an SDK selects the JSON log
   format. Configured log filters continue to apply to JSON output.
 * Worker heartbeats now report the SDK runtime, hosting environments, operating system, and


### PR DESCRIPTION
## What was changed

Added an explicit console log format enum to the Core C bridge and mapped compact, pretty, and JSON values to Core's logger configuration. The generated C header exposes the new field for bridge consumers.

## Why?

Core's JSON logging support from #1485 is available to Rust callers, but C-bridge SDKs cannot select it yet. This enables the .NET SDK to expose the same console logging formats.

## Checklist

1. Closes: N/A — follow-up to #1485; #1464 was closed by that PR.
2. How was this tested:
   - `cargo lint`
   - `cargo test -p temporalio-sdk-core-c-bridge`
3. Any docs updates needed? The Core changelog and generated C header are updated.
