### PR TITLE
Normalize workflow's SignalWorkflowOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ relevant information.
   `RuntimeOptions::disable_environment_info` to turn the reporting off.
 * Workers now log a `[TMPRL1104]` warning when a workflow task takes longer than 5 seconds. Set
   `TEMPORAL_WORKFLOW_TASK_DURATION_WARN_SECONDS` to change the threshold.
+* `SignalWorkflowOptions::summary` attaches a single-line summary to a signal sent to another
+  workflow, which the UI and CLI display alongside the resulting history event.
 
 ### Changed
 * Cancellation errors propagated after workflow cancellation now complete the workflow as cancelled

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
@@ -12,14 +12,15 @@ use temporalio_common::protos::{
         command::v1::{Command, command},
         common::v1::Payload,
         enums::v1::{CommandType, EventType},
+        sdk::v1::UserMetadata,
     },
 };
 use temporalio_sdk_core::replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder};
 
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
-    ApplicationFailure, CancellableFuture, ChildWorkflowOptions, SyncWorkflowContext,
-    WorkflowContext, WorkflowResult,
+    ApplicationFailure, CancellableFuture, ChildWorkflowOptions, SignalWorkflowOptions,
+    SyncWorkflowContext, WorkflowContext, WorkflowResult,
 };
 use temporalio_sdk_core::test_help::MockPollCfg;
 use uuid::Uuid;
@@ -275,7 +276,9 @@ impl SignalSenderCanned {
             .signal(
                 SignalReceiver::handle_signal,
                 "hi!".into(),
-                Default::default(),
+                SignalWorkflowOptions::builder()
+                    .summary("signal summary".to_string())
+                    .build(),
             )
             .await;
         if res.is_err() {
@@ -307,10 +310,14 @@ async fn sends_signal(#[case] fails: bool) {
     mock_cfg.completion_asserts_from_expectations(|mut asserts| {
             asserts.then(move |wft| {
                 assert_matches!(wft.commands.as_slice(),
-                    [Command { attributes: Some(
+                    [cmd @ Command { attributes: Some(
                         command::Attributes::SignalExternalWorkflowExecutionCommandAttributes(attrs)),..}] => {
                         assert_eq!(attrs.signal_name, SIGNAME);
                         assert_eq!(attrs.input.as_ref().unwrap().payloads[0], "hi!".to_string().as_json_payload().unwrap());
+                        assert_eq!(cmd.user_metadata, Some(UserMetadata {
+                            summary: Some("signal summary".as_json_payload().unwrap()),
+                            details: None,
+                        }));
                     }
                 );
             }).then(move |wft| {

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -96,12 +96,12 @@ pub use temporalio_workflow::{
     CancellableFuture, CancellableFutureWithReason, ChildWorkflowCancellationType,
     ChildWorkflowOptions, ContinueAsNewOptions, ContinueAsNewVersioningBehavior,
     ExternalWorkflowHandle, LocalActivityOptions, MemoValue, NexusOperationCancellationType,
-    NexusOperationOptions, ParentClosePolicy, PatchActivationCallback, Signal, SignalData,
-    SignalWorkflowOptions, StartChildWorkflowExecutionFailedCause, StartChildWorkflowOutput,
-    StartedChildWorkflow, StartedNexusOperation, SyncWorkflowContext, TimerOptions, TimerResult,
-    VersioningIntent, WaitConditionOptions, WorkflowCancellationError, WorkflowCancellationToken,
-    WorkflowContext, WorkflowContextView, WorkflowIdReusePolicy, WorkflowRandomValue,
-    WorkflowResult, WorkflowTermination,
+    NexusOperationOptions, ParentClosePolicy, PatchActivationCallback, SignalWorkflowOptions,
+    StartChildWorkflowExecutionFailedCause, StartChildWorkflowOutput, StartedChildWorkflow,
+    StartedNexusOperation, SyncWorkflowContext, TimerOptions, TimerResult, VersioningIntent,
+    WaitConditionOptions, WorkflowCancellationError, WorkflowCancellationToken, WorkflowContext,
+    WorkflowContextView, WorkflowIdReusePolicy, WorkflowRandomValue, WorkflowResult,
+    WorkflowTermination,
 };
 #[cfg(feature = "wasm-workflows")]
 pub use workflow_wasm::WasmWorkflowComponent;

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -43,7 +43,7 @@ pub use workflow_context::{
     CancellableFuture, CancellableFutureWithReason, ChildWorkflowCancellationType,
     ChildWorkflowOptions, ContinueAsNewOptions, ContinueAsNewVersioningBehavior,
     ExternalWorkflowHandle, LocalActivityOptions, NamespacedWorkflowInfo,
-    NexusOperationCancellationType, NexusOperationOptions, ParentClosePolicy, Signal, SignalData,
+    NexusOperationCancellationType, NexusOperationOptions, ParentClosePolicy,
     SignalWorkflowOptions, StartChildWorkflowExecutionFailedCause, StartChildWorkflowOutput,
     StartedChildWorkflow, StartedNexusOperation, SyncWorkflowContext, TimerOptions,
     VersioningIntent, WaitConditionOptions, WorkflowContext, WorkflowContextView,

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -5,8 +5,8 @@ pub use options::{
     ActivityCancellationType, ActivityCloseTimeouts, ActivityOptions,
     ChildWorkflowCancellationType, ChildWorkflowOptions, ContinueAsNewOptions,
     ContinueAsNewVersioningBehavior, LocalActivityOptions, NexusOperationCancellationType,
-    NexusOperationOptions, ParentClosePolicy, Signal, SignalData, SignalWorkflowOptions,
-    TimerOptions, VersioningIntent, WaitConditionOptions, WorkflowIdReusePolicy,
+    NexusOperationOptions, ParentClosePolicy, SignalWorkflowOptions, TimerOptions,
+    VersioningIntent, WaitConditionOptions, WorkflowIdReusePolicy,
 };
 pub use temporalio_common_wasm::protos::coresdk::child_workflow::StartChildWorkflowExecutionFailedCause;
 pub use view::{NamespacedWorkflowInfo, WorkflowContextView};
@@ -86,9 +86,8 @@ use temporalio_common_wasm::{
                 CancelChildWorkflowExecution, CancelSignalWorkflow, CancelTimer,
                 ModifyWorkflowProperties, RequestCancelActivity,
                 RequestCancelExternalWorkflowExecution, RequestCancelLocalActivity,
-                RequestCancelNexusOperation, SetPatchMarker, SignalExternalWorkflowExecution,
-                UpsertWorkflowSearchAttributes, signal_external_workflow_execution,
-                workflow_command,
+                RequestCancelNexusOperation, SetPatchMarker, UpsertWorkflowSearchAttributes,
+                signal_external_workflow_execution, workflow_command,
             },
         },
         temporal::api::{
@@ -1129,19 +1128,21 @@ impl BaseWorkflowContext {
         target: SignalWorkflowTarget,
         signal: S,
         input: S::Input,
-        cancellation_token: Option<WorkflowCancellationToken>,
+        options: SignalWorkflowOptions,
     ) -> CancellableWorkflowOutboundFuture<SignalWorkflowResult> {
         let input = SignalWorkflowInput::new(
             S::name(&signal).to_string(),
             target,
             Box::new(input),
-            cancellation_token,
+            options,
         );
         let base_ctx = self.clone();
         let next = WorkflowNext::new(move |input: SignalWorkflowInput| {
-            let (signal_name, target, input, headers, cancellation_token) = input.into_parts();
-            let cancellation_token =
-                cancellation_token.unwrap_or_else(|| base_ctx.cancellation_token());
+            let (signal_name, target, input, headers, mut options) = input.into_parts();
+            let cancellation_token = options
+                .cancellation_token
+                .take()
+                .unwrap_or_else(|| base_ctx.cancellation_token());
             let input = match input.downcast::<S::Input>() {
                 Ok(input) => *input,
                 Err(_) => {
@@ -1185,8 +1186,6 @@ impl BaseWorkflowContext {
                     },
                 ),
             };
-            let mut signal = Signal::new(signal_name, payloads);
-            signal.data.headers = headers;
             let seq = base_ctx
                 .inner
                 .seq_nums
@@ -1200,19 +1199,11 @@ impl BaseWorkflowContext {
                 .inner
                 .runtime
                 .register_unblocker(PendingCommandId::SignalExternal(seq), unblocker);
-            let signal = signal.into_invocation();
-            base_ctx.inner.runtime.host.push_command(
-                workflow_command::Variant::SignalExternalWorkflowExecution(
-                    SignalExternalWorkflowExecution {
-                        seq,
-                        signal_name: signal.signal_name,
-                        args: signal.input,
-                        target: Some(target),
-                        headers: signal.headers,
-                    },
-                )
-                .into(),
-            );
+            base_ctx
+                .inner
+                .runtime
+                .host
+                .push_command(options.into_command(seq, signal_name, payloads, headers, target));
             cancellable_outbound(SignalChildFut::Running {
                 inner: cmd,
                 data_converter: base_ctx.data_converter().clone(),
@@ -3099,7 +3090,7 @@ where
             },
             signal,
             input,
-            options.cancellation_token,
+            options,
         )
     }
 }
@@ -3146,7 +3137,7 @@ impl ExternalWorkflowHandle {
             },
             signal,
             input,
-            options.cancellation_token,
+            options,
         )
     }
 

--- a/crates/workflow/src/workflow_context/options.rs
+++ b/crates/workflow/src/workflow_context/options.rs
@@ -15,12 +15,12 @@ use temporalio_common_wasm::{
             },
             common::VersioningIntent as ProtoVersioningIntent,
             nexus::NexusOperationCancellationType as ProtoNexusOperationCancellationType,
-            workflow_activation::SignalWorkflow,
             workflow_commands::{
                 ActivityCancellationType as ProtoActivityCancellationType,
                 ContinueAsNewWorkflowExecution, ScheduleActivity, ScheduleLocalActivity,
-                ScheduleNexusOperation, StartChildWorkflowExecution, StartTimer, WorkflowCommand,
-                workflow_command,
+                ScheduleNexusOperation, SignalExternalWorkflowExecution,
+                StartChildWorkflowExecution, StartTimer, WorkflowCommand,
+                signal_external_workflow_execution, workflow_command,
             },
         },
         temporal::api::{
@@ -615,66 +615,6 @@ impl ChildWorkflowOptions {
     }
 }
 
-/// Information needed to send a specific signal
-#[derive(Debug)]
-pub struct Signal {
-    /// The signal name
-    pub signal_name: String,
-    /// The data the signal carries
-    pub data: SignalData,
-}
-
-impl Signal {
-    /// Create a new signal
-    pub fn new(
-        name: impl Into<String>,
-        input: impl IntoIterator<Item = impl Into<Payload>>,
-    ) -> Self {
-        Self {
-            signal_name: name.into(),
-            data: SignalData::new(input),
-        }
-    }
-
-    pub(crate) fn into_invocation(self) -> SignalWorkflow {
-        SignalWorkflow {
-            signal_name: self.signal_name,
-            input: self.data.input,
-            identity: String::new(),
-            headers: self.data.headers,
-        }
-    }
-}
-
-/// Data contained within a signal
-#[derive(Default, Debug)]
-pub struct SignalData {
-    /// The arguments the signal will receive
-    pub input: Vec<Payload>,
-    /// Metadata attached to the signal
-    pub headers: HashMap<String, Payload>,
-}
-
-impl SignalData {
-    /// Create data for a signal
-    pub fn new(input: impl IntoIterator<Item = impl Into<Payload>>) -> Self {
-        Self {
-            input: input.into_iter().map(Into::into).collect(),
-            headers: HashMap::new(),
-        }
-    }
-
-    /// Set a header k/v pair attached to the signal
-    pub fn with_header(
-        &mut self,
-        key: impl Into<String>,
-        payload: impl Into<Payload>,
-    ) -> &mut Self {
-        self.headers.insert(key.into(), payload.into());
-        self
-    }
-}
-
 /// Options for timer
 #[derive(Debug, Clone, bon::Builder)]
 #[non_exhaustive]
@@ -734,6 +674,33 @@ pub struct WaitConditionOptions {
 pub struct SignalWorkflowOptions {
     /// Cancellation token for this signal. `None` inherits workflow cancellation.
     pub cancellation_token: Option<WorkflowCancellationToken>,
+    /// Single-line summary for this signal that will appear in UI/CLI.
+    pub summary: Option<String>,
+}
+
+impl SignalWorkflowOptions {
+    pub(crate) fn into_command(
+        self,
+        seq: u32,
+        signal_name: String,
+        args: Vec<Payload>,
+        headers: HashMap<String, Payload>,
+        target: signal_external_workflow_execution::Target,
+    ) -> WorkflowCommand {
+        command_with_metadata(
+            workflow_command::Variant::SignalExternalWorkflowExecution(
+                SignalExternalWorkflowExecution {
+                    seq,
+                    signal_name,
+                    args,
+                    target: Some(target),
+                    headers,
+                },
+            ),
+            self.summary,
+            None,
+        )
+    }
 }
 
 /// Options for Nexus Operations

--- a/crates/workflow/src/workflow_interceptors.rs
+++ b/crates/workflow/src/workflow_interceptors.rs
@@ -84,8 +84,8 @@
 use crate::{
     ActivityOptions, BaseWorkflowContext, CancellableFuture, CancellableFutureWithReason,
     ChildWorkflowOptions, ContinueAsNewOptions, ExternalWorkflowHandle, LocalActivityOptions,
-    NexusOperationOptions, StartChildWorkflowOutput, StartedChildWorkflow, StartedNexusOperation,
-    TimerOptions, WorkflowCancellationToken, WorkflowContextView,
+    NexusOperationOptions, SignalWorkflowOptions, StartChildWorkflowOutput, StartedChildWorkflow,
+    StartedNexusOperation, TimerOptions, WorkflowCancellationToken, WorkflowContextView,
     cancellation::WorkflowCancellationRegistration,
     runtime::{
         entry::WorkflowError,
@@ -1223,7 +1223,7 @@ pub struct SignalWorkflowInput {
     signal_name: String,
     target: SignalWorkflowTarget,
     decoded: DecodedInput,
-    cancellation_token: Option<WorkflowCancellationToken>,
+    options: SignalWorkflowOptions,
 }
 
 impl SignalWorkflowInput {
@@ -1231,13 +1231,13 @@ impl SignalWorkflowInput {
         signal_name: String,
         target: SignalWorkflowTarget,
         input: Box<dyn Any>,
-        cancellation_token: Option<WorkflowCancellationToken>,
+        options: SignalWorkflowOptions,
     ) -> Self {
         Self {
             signal_name,
             target,
             decoded: DecodedInput::new(Some(input), HashMap::new()),
-            cancellation_token,
+            options,
         }
     }
 
@@ -1249,7 +1249,7 @@ impl SignalWorkflowInput {
         SignalWorkflowTarget,
         Box<dyn Any>,
         HashMap<String, Payload>,
-        Option<WorkflowCancellationToken>,
+        SignalWorkflowOptions,
     ) {
         let (input, headers) = self.decoded.into_parts();
         (
@@ -1257,7 +1257,7 @@ impl SignalWorkflowInput {
             self.target,
             input.expect("signal input must exist"),
             headers,
-            self.cancellation_token,
+            self.options,
         )
     }
 
@@ -1281,14 +1281,14 @@ impl SignalWorkflowInput {
         &mut self.target
     }
 
-    /// Cancellation token for this signal. `None` inherits workflow cancellation.
-    pub fn cancellation_token(&self) -> Option<&WorkflowCancellationToken> {
-        self.cancellation_token.as_ref()
+    /// Signal options.
+    pub fn options(&self) -> &SignalWorkflowOptions {
+        &self.options
     }
 
-    /// Mutably access the signal cancellation token.
-    pub fn cancellation_token_mut(&mut self) -> &mut Option<WorkflowCancellationToken> {
-        &mut self.cancellation_token
+    /// Mutably access signal options.
+    pub fn options_mut(&mut self) -> &mut SignalWorkflowOptions {
+        &mut self.options
     }
 }
 


### PR DESCRIPTION
## What was changed

- `workflow`'s "signal external workflow" command now adheres to the same code structure as other workflow commands, i.e. `SignalWorkflowOptions` now has an `into_command(…)` in replacement of the unique and odd `into_invocation()` function.

- `SignalWorkflowOptions` now supports `summary` (i.e. part of the User Metadata feature).
- `SignalWorkflowInput` now holds the whole `SignalWorkflowOptions`, with `options()` / `options_mut()`, rather than a bare `cancellation_token`.
- The `Signal` and `SignalData` types that were used as intermediaries by the former `into_invocation()` code path have been removed. These were technically public types and could therefore be breaking changes, but there was absolutely no justification for external usage of these APIs, so no practical concern in removing them now.

## Checklist

1. How was this tested:

- Existing tests still passes.
- The existing mocked `sends_signal` test now sets a `summary` and asserts the `user_metadata` on the resulting `SignalExternalWorkflowExecution` command.

2. Any docs updates needed?

- `CHANGELOG.md` entry added.