### PR TITLE
Scope docker_metrics_with_prometheus query to the test's task queue

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [env]
 # This temporarily overrides the version of the CLI used for integration tests, locally and in CI
-CLI_VERSION_OVERRIDE = "v1.7.4-standalone-nexus-operations"
+# CLI_VERSION_OVERRIDE = "v1.6.3-serverless"
 
 [alias]
 # Not sure why --all-features doesn't work

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [env]
 # This temporarily overrides the version of the CLI used for integration tests, locally and in CI
-# CLI_VERSION_OVERRIDE = "v1.6.3-serverless"
+CLI_VERSION_OVERRIDE = "v1.7.4-standalone-nexus-operations"
 
 [alias]
 # Not sure why --all-features doesn't work

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -960,12 +960,18 @@ async fn docker_metrics_with_prometheus(
     .await
     .unwrap();
 
+    let task_queue = starter.get_task_queue().to_string();
     eventually(
         || async {
             // Query Prometheus API for metrics
             temporalio_common::telemetry::ensure_default_crypto_provider();
             let client = reqwest::Client::new();
-            let query = format!("temporal_sdk_{}num_pollers", test_uid.clone());
+            // The task queue must be matched in the query rather than asserted on afterwards: this
+            // runtime's meter is also used by the shared-namespace worker, whose pollers report
+            // against the worker-commands control queue, and the order series come back in is not
+            // ours to choose.
+            let query =
+                format!("temporal_sdk_{test_uid}num_pollers{{task_queue=\"{task_queue}\"}}");
             let response = client
                 .get(PROMETHEUS_QUERY_API)
                 .query(&[("query", query.clone())])
@@ -981,12 +987,6 @@ async fn docker_metrics_with_prometheus(
                 }
                 assert_eq!(data[0]["metric"]["exported_job"], "temporal-core-sdk");
                 assert_eq!(data[0]["metric"]["job"], "otel-collector");
-                assert!(
-                    data[0]["metric"]["task_queue"]
-                        .as_str()
-                        .unwrap()
-                        .starts_with(test_name)
-                );
             } else {
                 bail!("Invalid Prometheus response: {response:?}");
             }


### PR DESCRIPTION
## What was changed

The Prometheus query in `docker_metrics_with_prometheus` now filters `num_pollers` on the test's
own task queue, instead of asserting on whichever series comes back first.

## Why?

On a server that advertises the `worker_commands` namespace capability, Core starts the
shared-namespace worker's control-queue worker. That worker is built with the *runtime's*
telemetry, so its Nexus poller reports `num_pollers` under the same unique metric prefix the test
relies on for isolation. Prometheus sorts by labels, which puts `poller_type=nexus_task` ahead of
the test's own series, so the assertion on `data[0]` fails — every time, not as a flake.

No CLI release bundles such a server yet, so this is latent on `main` and will bite as soon as one
does.

## Checklist

1. Closes N/A

2. How was this tested:

Deliberately three commits, so CI shows both the problem and the fix:

1. pin the integ tests on `v1.7.4-standalone-nexus-operations`, whose server does advertise the
   capability — `Docker integ tests` fails;
2. the fix — the test passes (the job then fails on a later step, which #1496
   fixes);
3. remove the pin — back on a released CLI, still green.

Also verified locally against the `docker-compose-ci.yaml` stack: `cargo integ-test docker_` is 6/6
both with and without the pin.

3. Any docs updates needed? No — test-only change, nothing user facing, so no changelog entry.