### PR TITLE
Fix integ test failure for activity cancellation against Server v1.32.0-158.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [env]
 # This temporarily overrides the version of the CLI used for integration tests, locally and in CI
-CLI_VERSION_OVERRIDE = "v1.7.4-standalone-nexus-operations"
+# CLI_VERSION_OVERRIDE = "v1.6.3-serverless"
 
 [alias]
 # Not sure why --all-features doesn't work

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [env]
 # This temporarily overrides the version of the CLI used for integration tests, locally and in CI
-# CLI_VERSION_OVERRIDE = "v1.6.3-serverless"
+CLI_VERSION_OVERRIDE = "v1.7.4-standalone-nexus-operations"
 
 [alias]
 # Not sure why --all-features doesn't work

--- a/crates/sdk-core/tests/common/mod.rs
+++ b/crates/sdk-core/tests/common/mod.rs
@@ -1263,6 +1263,8 @@ pub(crate) fn integ_dev_server_config(
             "--dynamic-config-value".to_owned(),
             "frontend.workerCommandsEnabled=true".to_owned(),
             "--dynamic-config-value".to_owned(),
+            "system.enableCancelActivityWorkerCommand=true".to_owned(),
+            "--dynamic-config-value".to_owned(),
             "matching.rps=12000".to_owned(),
             "--search-attribute".to_string(),
             format!("{SEARCH_ATTR_TXT}=Text"),

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -1,7 +1,8 @@
 use crate::{
     common::{
-        ActivationAssertionsInterceptor, CoreWfStarter, INTEG_CLIENT_IDENTITY,
-        activity_functions::StdActivities, init_core_and_create_wf,
+        ActivationAssertionsInterceptor, CLI_VERSION_OVERRIDE_ENV_VAR, CoreWfStarter,
+        INTEG_CLIENT_IDENTITY, activity_functions::StdActivities, init_core_and_create_wf,
+        init_integ_telem,
     },
     shared_tests,
 };
@@ -9,6 +10,7 @@ use anyhow::anyhow;
 use assert_matches::assert_matches;
 use futures_util::FutureExt;
 use std::{
+    env,
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
@@ -66,6 +68,7 @@ use temporalio_sdk_core::{
     },
 };
 use tokio::{join, sync::Semaphore, time::sleep};
+use tracing::warn;
 
 #[workflow]
 #[derive(Default)]
@@ -2407,5 +2410,25 @@ async fn immediate_activity_cancelation() {
 #[case::eager(false)]
 #[tokio::test]
 async fn activity_cancel_delivered_without_heartbeat(#[case] disable_eager: bool) {
+    // Cancellation of activities through Worker Commands was added in Server v1.32.0-158.0,
+    // but the case for eager activities was initially broken. It got fixed in
+    // temporalio/temporal#10634, which was released in Server v1.32.0-159.0.
+    //
+    // At this time, there is no release of the Temporal CLI that bundles Server
+    // v1.32.0-159.0. We're pinned on CLI "v1.7.4-standalone-nexus-operations" which
+    // bundles Server v1.32.0-158.0, and therefore has the broken support for eager
+    // activity cancellation. That results in the eager activity cancelation test
+    // failing in CI and local tests against the CLI Dev Server.
+    //
+    // FIXME: Remove once we're pinned on a CLI that bundles Server >v1.32.0-159.0.
+    const CLI_WITHOUT_EAGER_CANCEL_FIX: &str = "v1.7.4-standalone-nexus-operations";
+    if !disable_eager
+        && env::var(CLI_VERSION_OVERRIDE_ENV_VAR).is_ok_and(|v| v == CLI_WITHOUT_EAGER_CANCEL_FIX)
+    {
+        // The skip message would go unlogged as no telemetry has been initialized yet.
+        init_integ_telem();
+        warn!("Skipping test: eager activity cancel requires server >= v1.32.0-159.0");
+        return;
+    }
     shared_tests::activity_cancel_delivered_without_heartbeat(disable_eager).await
 }


### PR DESCRIPTION
## What was changed

- The integ dev server now sets `system.enableCancelActivityWorkerCommand=true`.
- The eager case of `activity_cancel_delivered_without_heartbeat` is skipped while the integ tests
  are pinned on `v1.7.4-standalone-nexus-operations`.

## Why?

`system.enableCancelActivityWorkerCommand` defaults to false and is what gates dispatching activity
cancellation to workers, so without it the test cannot exercise the path it is named after.

With it on, the eager case then fails against the pinned CLI, which bundles Server v1.32.0-158.0 —
the version where eager activity cancellation was still broken. That was fixed by
temporalio/temporal#10634 and released in v1.32.0-159.0, which no CLI release bundles yet, hence the
skip and the FIXME to drop it once one does.

## Checklist

1. Closes N/A

2. How was this tested:

Three commits, so CI shows both the problem and the fix: pin the integ tests on
`v1.7.4-standalone-nexus-operations`, which fails the test; then the fix; then remove the pin.

3. Any docs updates needed? No — test-only change, nothing user facing, so no changelog entry.