### PR TITLE
Expose cancel details on workflow cancel & propagate them in Rust SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ relevant information.
 ### Added
 * Support for running Standalone Activities in Rust SDK Worker.
 * Client methods for starting and managing execution of Standalone Activities. 
+* `WorkflowTermination::cancelled_with_details` for recording structured details when a Workflow
+  Execution completes as cancelled.
 * `LoggerFormat` for selecting compact, pretty, or JSON Core console log output. Configured log
   filters continue to apply to JSON output.
 * `RpcOptions::builder()` for constructing per-call RPC options.
@@ -69,6 +71,8 @@ relevant information.
   `WorkerInterceptor::with_workflow_replay_worker`.
 
 ### Breaking Changes :boom:
+* `WorkflowTermination::Cancelled` now has an optional `details` field. Use
+  `WorkflowTermination::cancelled()` to construct a cancellation without details.
 * Changes to `ActivityInfo`: instead of `workflow_namespace`, `workflow_execution` and `run_id`,
   there is now `namespace`, `workflow_id`, `workflow_run_id` and `activity_run_id`. 
   Also, `workflow_type` is now `Option<String>`.

--- a/crates/protos/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
+++ b/crates/protos/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
@@ -231,7 +231,9 @@ message ContinueAsNewWorkflowExecution {
 
 // Indicate a workflow has completed as cancelled. Generally sent as a response to an activation
 // containing a cancellation job.
-message CancelWorkflowExecution {}
+message CancelWorkflowExecution {
+    temporal.api.common.v1.Payloads details = 1;
+}
 
 // A request to set/check if a certain patch is present or not
 message SetPatchMarker {

--- a/crates/protos/src/protos/mod.rs
+++ b/crates/protos/src/protos/mod.rs
@@ -2021,9 +2021,9 @@ pub mod temporal {
                     }
 
                     impl From<workflow_commands::CancelWorkflowExecution> for command::Attributes {
-                        fn from(_c: workflow_commands::CancelWorkflowExecution) -> Self {
+                        fn from(c: workflow_commands::CancelWorkflowExecution) -> Self {
                             Self::CancelWorkflowExecutionCommandAttributes(
-                                CancelWorkflowExecutionCommandAttributes { details: None },
+                                CancelWorkflowExecutionCommandAttributes { details: c.details },
                             )
                         }
                     }

--- a/crates/sdk-core/CHANGELOG.md
+++ b/crates/sdk-core/CHANGELOG.md
@@ -36,6 +36,8 @@ relevant information.
 ### Added
 * Core console logs can now be emitted as newline-delimited JSON when an SDK selects the JSON log
   format. Configured log filters continue to apply to JSON output.
+* Workflow completion-as-cancelled commands can now carry details for recording on the terminal
+  history event.
 * Worker heartbeats now report the SDK runtime, hosting environments, operating system, and
   architecture once per worker, retrying until the first successful delivery. Runtime options can
   disable the reporting.

--- a/crates/sdk-core/src/core_tests/workflow_cancels.rs
+++ b/crates/sdk-core/src/core_tests/workflow_cancels.rs
@@ -117,7 +117,7 @@ async fn immediate_cancel() {
                 workflow_activation_job::Variant::InitializeWorkflow(_),
                 workflow_activation_job::Variant::CancelWorkflow(_)
             ),
-            vec![CancelWorkflowExecution {}.into()],
+            vec![CancelWorkflowExecution::default().into()],
         )],
     )
     .await;

--- a/crates/sdk-core/src/worker/workflow/managed_run.rs
+++ b/crates/sdk-core/src/worker/workflow/managed_run.rs
@@ -1910,7 +1910,9 @@ mod tests {
         }
 
         pub(crate) fn cancel() -> WFCommand {
-            WFCommand::new(WFCommandVariant::CancelWorkflow(CancelWorkflowExecution {}))
+            WFCommand::new(WFCommandVariant::CancelWorkflow(
+                CancelWorkflowExecution::default(),
+            ))
         }
 
         pub(crate) fn query_response() -> WFCommand {

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -580,7 +580,7 @@ async fn query_of_closed_workflow_doesnt_tick_terminal_metric(
             failure: Some(Failure::application_failure("I'm ded".to_string(), false)),
         }.into(),
         ContinueAsNewWorkflowExecution::default().into(),
-        CancelWorkflowExecution { }.into()
+        CancelWorkflowExecution::default().into()
     )]
     completion: workflow_command::Variant,
 ) {

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_wf.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_wf.rs
@@ -38,6 +38,67 @@ impl CancelledWf {
     }
 }
 
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+struct CancellationDetails {
+    reason: String,
+}
+
+#[workflow]
+#[derive(Default)]
+struct CancelledWithDetailsWf;
+
+#[workflow_methods]
+impl CancelledWithDetailsWf {
+    #[run]
+    async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+        ctx.cancelled().await;
+        Err(WorkflowTermination::cancelled_with_details(
+            CancellationDetails {
+                reason: "contract expired".to_owned(),
+            },
+        ))
+    }
+}
+
+#[tokio::test]
+async fn workflow_cancellation_records_details() {
+    let wf_name = "workflow_cancellation_records_details";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter
+        .sdk_config
+        .register_workflow::<CancelledWithDetailsWf>()
+        .unwrap();
+    let mut worker = starter.worker().await;
+    let task_queue = starter.get_task_queue().to_owned();
+    let wf_handle = worker
+        .submit_workflow(
+            CancelledWithDetailsWf::run,
+            (),
+            WorkflowStartOptions::new(task_queue, wf_name).build(),
+        )
+        .await
+        .unwrap();
+
+    let (cancel_result, worker_result) = tokio::join!(
+        wf_handle.cancel(WorkflowCancelOptions::default()),
+        worker.run_until_done()
+    );
+    cancel_result.unwrap();
+    worker_result.unwrap();
+
+    let Err(WorkflowGetResultError::Cancelled { details }) =
+        wf_handle.get_result(Default::default()).await
+    else {
+        panic!("workflow should complete as cancelled");
+    };
+    assert_eq!(
+        details.deserialize::<CancellationDetails>().unwrap(),
+        CancellationDetails {
+            reason: "contract expired".to_owned(),
+        }
+    );
+}
+
 #[tokio::test]
 async fn cancel_during_timer() {
     let wf_name = "cancel_during_timer";
@@ -155,11 +216,86 @@ impl CancellationPropagationActivities {
         let mut heartbeat = tokio::time::interval(Duration::from_millis(100));
         loop {
             tokio::select! {
-                _ = ctx.cancelled() => return Err(ActivityError::cancelled()),
+                _ = ctx.cancelled() => return Err(ActivityError::cancelled_with_details(
+                    CancellationDetails {
+                        reason: "operation cancelled".to_owned(),
+                    },
+                )),
                 _ = heartbeat.tick() => ctx.record_heartbeat(()).await?,
             }
         }
     }
+}
+
+#[workflow]
+#[derive(Default)]
+struct FailedCancellationDetailsWf;
+
+#[workflow_methods]
+impl FailedCancellationDetailsWf {
+    #[run]
+    async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+        let err = ctx
+            .execute_activity(
+                CancellationPropagationActivities::wait_for_cancellation,
+                (),
+                ActivityOptions::with_start_to_close_timeout(Duration::from_secs(30))
+                    .heartbeat_timeout(Duration::from_secs(1))
+                    .cancellation_type(ActivityCancellationType::WaitCancellationCompleted)
+                    .build(),
+            )
+            .await
+            .expect_err("activity should be cancelled");
+        Err(err.into())
+    }
+}
+
+#[tokio::test]
+async fn workflow_failed_cancellation_propagates_details() {
+    let wf_name = "workflow_failed_cancellation_propagates_details";
+    let mut starter = CoreWfStarter::new(wf_name);
+    let started = Arc::new(Semaphore::new(0));
+    starter
+        .sdk_config
+        .register_activities(CancellationPropagationActivities {
+            started: started.clone(),
+        });
+    starter
+        .sdk_config
+        .register_workflow::<FailedCancellationDetailsWf>()
+        .unwrap();
+    let mut worker = starter.worker().await;
+    let task_queue = starter.get_task_queue().to_owned();
+    let wf_handle = worker
+        .submit_workflow(
+            FailedCancellationDetailsWf::run,
+            (),
+            WorkflowStartOptions::new(task_queue, wf_name).build(),
+        )
+        .await
+        .unwrap();
+
+    let canceller = async {
+        let _started = started.acquire().await.unwrap();
+        wf_handle
+            .cancel(WorkflowCancelOptions::default())
+            .await
+            .unwrap();
+    };
+    let (_, worker_result) = tokio::join!(canceller, worker.run_until_done());
+    worker_result.unwrap();
+
+    let Err(WorkflowGetResultError::Cancelled { details }) =
+        wf_handle.get_result(Default::default()).await
+    else {
+        panic!("workflow should complete as cancelled");
+    };
+    assert_eq!(
+        details.deserialize::<CancellationDetails>().unwrap(),
+        CancellationDetails {
+            reason: "operation cancelled".to_owned(),
+        }
+    );
 }
 
 #[workflow]
@@ -173,7 +309,7 @@ impl CancellationPropagationChild {
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         ctx.state(|wf| wf.started.add_permits(1));
         ctx.cancelled().await;
-        Err(WorkflowTermination::Cancelled)
+        Err(WorkflowTermination::cancelled())
     }
 
     #[signal]
@@ -304,9 +440,16 @@ async fn workflow_cancellation_propagates_to_operations() {
     let (_, worker_result) = tokio::join!(canceller, worker.run_until_done());
     worker_result.unwrap();
 
-    assert_matches!(
-        wf_handle.get_result(Default::default()).await,
-        Err(WorkflowGetResultError::Cancelled { .. })
+    let Err(WorkflowGetResultError::Cancelled { details }) =
+        wf_handle.get_result(Default::default()).await
+    else {
+        panic!("workflow should complete as cancelled");
+    };
+    assert_eq!(
+        details.deserialize::<CancellationDetails>().unwrap(),
+        CancellationDetails {
+            reason: "operation cancelled".to_owned(),
+        }
     );
 }
 
@@ -319,7 +462,7 @@ impl WfWithTimer {
     #[run(name = DEFAULT_WORKFLOW_TYPE)]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         ctx.timer(Duration::from_millis(500)).await;
-        Err(WorkflowTermination::Cancelled)
+        Err(WorkflowTermination::cancelled())
     }
 }
 

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -146,7 +146,7 @@ impl AbandonedChildBugReproChild {
     #[run(name = "child_wf")]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         ctx.cancelled().await;
-        Err(WorkflowTermination::Cancelled)
+        Err(WorkflowTermination::cancelled())
     }
 }
 
@@ -567,7 +567,7 @@ impl GrandchildCancelled {
     #[run(name = "grandchild_wf")]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         ctx.cancelled().await;
-        Err(WorkflowTermination::Cancelled)
+        Err(WorkflowTermination::cancelled())
     }
 }
 
@@ -1100,7 +1100,7 @@ async fn cancel_child_before_started_event() {
                 reason: "parent cancelled".to_string(),
             }
             .into(),
-            CancelWorkflowExecution {}.into(),
+            CancelWorkflowExecution::default().into(),
         ],
     ))
     .await
@@ -1110,7 +1110,7 @@ async fn cancel_child_before_started_event() {
     let act = core.poll_workflow_activation().await.unwrap();
     core.complete_workflow_activation(WorkflowActivationCompletion::from_cmd(
         act.run_id,
-        CancelWorkflowExecution {}.into(),
+        CancelWorkflowExecution::default().into(),
     ))
     .await
     .unwrap();
@@ -1149,7 +1149,7 @@ impl CancelChildBeforeStartedCannedWf {
         };
         assert!(cancelled.raw_details().is_none());
         assert!(cancelled.cause().is_none());
-        Err(WorkflowTermination::Cancelled)
+        Err(WorkflowTermination::cancelled())
     }
 }
 
@@ -1189,7 +1189,7 @@ impl CancelChildBeforeStartedParent {
         // Wait for parent cancellation
         ctx.cancelled().await;
         started.cancel();
-        Err(WorkflowTermination::Cancelled)
+        Err(WorkflowTermination::cancelled())
     }
 }
 
@@ -1344,7 +1344,7 @@ impl UnserializableSignalChild {
     #[run]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         ctx.cancelled().await;
-        Err(WorkflowTermination::Cancelled)
+        Err(WorkflowTermination::cancelled())
     }
 
     #[signal]

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/nexus.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/nexus.rs
@@ -301,7 +301,7 @@ impl AsyncCompleter {
             Outcome::Succeed => Ok("completed async".to_string()),
             Outcome::Cancel | Outcome::CancelAfterRecordedBeforeStarted => {
                 ctx.cancelled().await;
-                Err(WorkflowTermination::Cancelled)
+                Err(WorkflowTermination::cancelled())
             }
             _ => Err(ApplicationFailure::new("broken").into()),
         }
@@ -629,7 +629,7 @@ impl NexusRootCancellationWf {
             result.status,
             Some(nexus_operation_result::Status::Cancelled(_))
         );
-        Err(WorkflowTermination::Cancelled)
+        Err(WorkflowTermination::cancelled())
     }
 }
 
@@ -936,7 +936,7 @@ impl AsyncCompleterWf {
         }
 
         ctx.state(|wf| wf.handler_exited_tx.send(true).unwrap());
-        Err(WorkflowTermination::Cancelled)
+        Err(WorkflowTermination::cancelled())
     }
 
     #[signal(name = "proceed-to-exit")]

--- a/crates/sdk/src/workflow_future.rs
+++ b/crates/sdk/src/workflow_future.rs
@@ -584,10 +584,10 @@ impl WorkflowFuture {
                                     ),
                                 );
                             }
-                            TerminalOutcome::Cancelled => {
+                            TerminalOutcome::Cancelled(details) => {
                                 self.host.push_command_variant(
                                     workflow_command::Variant::CancelWorkflowExecution(
-                                        CancelWorkflowExecution {},
+                                        CancelWorkflowExecution { details },
                                     ),
                                 );
                             }

--- a/crates/sdk/src/workflow_wasm.rs
+++ b/crates/sdk/src/workflow_wasm.rs
@@ -341,7 +341,9 @@ impl WorkflowInstance for WasmWorkflowInstance {
                                 wit_types::TerminalOutcome::Failed(failure) => {
                                     TerminalOutcome::Failed(convert_failure(failure))
                                 }
-                                wit_types::TerminalOutcome::Cancelled => TerminalOutcome::Cancelled,
+                                wit_types::TerminalOutcome::Cancelled(details) => {
+                                    TerminalOutcome::Cancelled(details.map(decode_proto))
+                                }
                                 wit_types::TerminalOutcome::ContinueAsNew(req) => {
                                     TerminalOutcome::ContinueAsNew(Box::new(decode_proto(req)))
                                 }

--- a/crates/workflow/src/component.rs
+++ b/crates/workflow/src/component.rs
@@ -154,8 +154,10 @@ impl wit_guest::GuestWorkflowInstance for ExportedWorkflowInstance {
                                     TerminalOutcome::Failed(failure) => {
                                         wit_types::TerminalOutcome::Failed(failure.encode_to_vec())
                                     }
-                                    TerminalOutcome::Cancelled => {
-                                        wit_types::TerminalOutcome::Cancelled
+                                    TerminalOutcome::Cancelled(details) => {
+                                        wit_types::TerminalOutcome::Cancelled(
+                                            details.map(|details| details.encode_to_vec()),
+                                        )
                                     }
                                     TerminalOutcome::ContinueAsNew(req) => {
                                         wit_types::TerminalOutcome::ContinueAsNew(

--- a/crates/workflow/src/runtime/instance.rs
+++ b/crates/workflow/src/runtime/instance.rs
@@ -19,7 +19,7 @@ use crate::{
         HandleSignalInput, HandleSignalResult, HandleUpdateInput, HandleUpdateResult,
         InitializeWorkflowInput, InitializeWorkflowOutput, SyncWorkflowInterceptorContext,
         ValidateUpdateInput, ValidateUpdateResult, WorkflowInterceptor, WorkflowInterceptorContext,
-        WorkflowInterceptorFuture, WorkflowNext, serialize_workflow_output,
+        WorkflowInterceptorFuture, WorkflowNext, WorkflowOutputValue, serialize_workflow_output,
         wrong_workflow_input_type,
     },
 };
@@ -767,7 +767,26 @@ where
         match result {
             Ok(result) => Ok(TerminalOutcome::Completed(result)),
             Err(WorkflowTermination::ContinueAsNew(req)) => Ok(TerminalOutcome::ContinueAsNew(req)),
-            Err(WorkflowTermination::Cancelled) => Ok(TerminalOutcome::Cancelled),
+            Err(WorkflowTermination::Cancelled { details }) => {
+                let details = details
+                    .map(|details| {
+                        (&*details as &dyn WorkflowOutputValue)
+                            .serialize_payloads(&SerializationContext {
+                                data: &SerializationContextData::Workflow,
+                                converter: self.ctx.payload_converter(),
+                            })
+                            .map(|payloads| Payloads { payloads })
+                    })
+                    .transpose()
+                    .map_err(|err| TaskFailure {
+                        failure: Box::new(Failure {
+                            message: format!("Workflow payload conversion failed: {err}"),
+                            ..Default::default()
+                        }),
+                        force_cause: None,
+                    })?;
+                Ok(TerminalOutcome::Cancelled(details))
+            }
             Err(WorkflowTermination::Evicted) => {
                 panic!("workflow instances must not explicitly return eviction")
             }
@@ -781,9 +800,13 @@ where
                 })
             }
             Err(WorkflowTermination::Failed(err)) => {
-                if self.base_ctx.cancellation_token().is_cancelled() && err.as_cancelled().is_some()
+                if self.base_ctx.cancellation_token().is_cancelled()
+                    && let Some(cancelled) = err.as_cancelled()
                 {
-                    return Ok(TerminalOutcome::Cancelled);
+                    let details = cancelled.raw_details().map(|payloads| Payloads {
+                        payloads: payloads.to_vec(),
+                    });
+                    return Ok(TerminalOutcome::Cancelled(details));
                 }
                 let failure = self.base_ctx.data_converter().to_failure(
                     &SerializationContextData::Workflow,

--- a/crates/workflow/src/runtime/model.rs
+++ b/crates/workflow/src/runtime/model.rs
@@ -6,10 +6,11 @@ use crate::{
     workflow_context::{
         ChildWfCommon, NexusUnblockData, PendingChildWorkflow, StartedNexusOperation,
     },
+    workflow_interceptors::WorkflowOutputValue,
 };
 use temporalio_common_wasm::{
     WorkflowDefinition,
-    data_converters::PayloadConversionError,
+    data_converters::{PayloadConversionError, TemporalSerializable},
     error::{
         ActivityExecutionError, ApplicationFailure, ChildWorkflowExecutionError,
         ChildWorkflowStartError, WorkflowSignalError,
@@ -218,10 +219,14 @@ pub type WorkflowResult<T> = Result<T, WorkflowTermination>;
 /// the current Workflow Task so it can be retried.
 ///
 /// Wrap an error in an [`ApplicationFailure`] to explicitly fail the Workflow Execution.
-#[derive(Debug, thiserror::Error)]
+#[derive(derive_more::Debug, thiserror::Error)]
 pub enum WorkflowTermination {
     #[error("Workflow cancelled")]
-    Cancelled,
+    Cancelled {
+        /// Optional cancellation details.
+        #[debug(skip)]
+        details: Option<Box<dyn WorkflowOutputValue + Send + Sync>>,
+    },
     #[error("Workflow evicted from cache")]
     Evicted,
     #[error("Continue as new")]
@@ -231,6 +236,22 @@ pub enum WorkflowTermination {
 }
 
 impl WorkflowTermination {
+    /// Construct a cancelled workflow termination without details.
+    pub fn cancelled() -> Self {
+        Self::Cancelled { details: None }
+    }
+
+    /// Construct a cancelled workflow termination with details that will be converted using the
+    /// active payload converter.
+    pub fn cancelled_with_details<T>(details: T) -> Self
+    where
+        T: TemporalSerializable + Send + Sync + 'static,
+    {
+        Self::Cancelled {
+            details: Some(Box::new(details)),
+        }
+    }
+
     pub fn continue_as_new(can: ContinueAsNewRequest) -> Self {
         Self::ContinueAsNew(Box::new(can))
     }
@@ -243,7 +264,7 @@ impl WorkflowTermination {
 
 impl From<WorkflowCancellationError> for WorkflowTermination {
     fn from(_value: WorkflowCancellationError) -> Self {
-        Self::Cancelled
+        Self::cancelled()
     }
 }
 

--- a/crates/workflow/src/runtime/types.rs
+++ b/crates/workflow/src/runtime/types.rs
@@ -7,7 +7,10 @@ use temporalio_common_wasm::protos::{
         workflow_activation::{InitializeWorkflow, WorkflowActivation as CoreWorkflowActivation},
         workflow_commands::ContinueAsNewWorkflowExecution,
     },
-    temporal::api::{common::v1::Payload, failure::v1::Failure},
+    temporal::api::{
+        common::v1::{Payload, Payloads},
+        failure::v1::Failure,
+    },
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -89,7 +92,7 @@ pub struct TaskFailure {
 pub enum TerminalOutcome {
     Completed(Payload),
     Failed(WorkflowFailure),
-    Cancelled,
+    Cancelled(Option<Payloads>),
     ContinueAsNew(Box<ContinueAsNewRequest>),
 }
 

--- a/crates/workflow/src/workflow_interceptors.rs
+++ b/crates/workflow/src/workflow_interceptors.rs
@@ -132,6 +132,11 @@ mod workflow_output_value {
             &self,
             context: &SerializationContext<'_>,
         ) -> Result<Payload, PayloadConversionError>;
+
+        fn to_workflow_payloads(
+            &self,
+            context: &SerializationContext<'_>,
+        ) -> Result<Vec<Payload>, PayloadConversionError>;
     }
 
     impl<T> Sealed for T
@@ -143,6 +148,13 @@ mod workflow_output_value {
             context: &SerializationContext<'_>,
         ) -> Result<Payload, PayloadConversionError> {
             context.converter.to_payload(context, self)
+        }
+
+        fn to_workflow_payloads(
+            &self,
+            context: &SerializationContext<'_>,
+        ) -> Result<Vec<Payload>, PayloadConversionError> {
+            context.converter.to_payloads(context, self)
         }
     }
 }
@@ -173,6 +185,13 @@ impl dyn WorkflowOutputValue {
         context: &SerializationContext<'_>,
     ) -> Result<Payload, PayloadConversionError> {
         self.to_workflow_payload(context)
+    }
+
+    pub(crate) fn serialize_payloads(
+        &self,
+        context: &SerializationContext<'_>,
+    ) -> Result<Vec<Payload>, PayloadConversionError> {
+        self.to_workflow_payloads(context)
     }
 }
 

--- a/crates/workflow/wit/types.wit
+++ b/crates/workflow/wit/types.wit
@@ -76,7 +76,7 @@ record task-failure {
 variant terminal-outcome {
   completed(payload),
   failed(failure),
-  cancelled,
+  cancelled(option<list<u8>>),
   continue-as-new(continue-as-new-request),
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
See title

## Why?
This is fully supported on the backed but was never exposed in Core

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/sdk-rust/issues/1463
2. How was this tested:
Added tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
