### PR TITLE
fix(sdk): typed signal_with_start_workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ relevant information.
   client. Only affects memo values that are themselves non-`Send`/non-`Sync`, such as those
   holding an `Rc` or `RefCell`.
 
+* `Client::signal_with_start_workflow` starts a workflow and sends a typed signal atomically.
+
+### Breaking Changes :boom:
+
+* Signal-with-start is now invoked with `Client::signal_with_start_workflow`; remove uses of
+  `WorkflowStartOptions::start_signal` and `WorkflowStartSignal`.
+
 ## [0.7.0] - 2026-08-17
 
 ### Added

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -45,7 +45,11 @@ tokio = { version = "1.47", default-features = false, features = [
   "sync",
   "time",
 ] }
-tonic = { workspace = true, default-features = false, features = ["tls-native-roots", "channel", "gzip"] }
+tonic = { workspace = true, default-features = false, features = [
+  "tls-native-roots",
+  "channel",
+  "gzip",
+] }
 tokio-rustls = { version = "0.26", default-features = false }
 rustls-native-certs = { version = "0.8", optional = true }
 tower = { version = "0.5", features = ["util"] }
@@ -68,6 +72,8 @@ prost = "0.14"
 prost-types = { workspace = true }
 rstest = "0.26"
 tempfile = "3"
+temporalio-macros = { path = "../macros", version = "0.7" }
+temporalio-workflow = { path = "../workflow", version = "0.7" }
 tokio = { version = "1.47", default-features = false, features = [
   "io-util",
   "macros",
@@ -76,6 +82,7 @@ tokio = { version = "1.47", default-features = false, features = [
   "sync",
   "time",
 ] }
+trybuild = { version = "1.0", features = ["diff"] }
 
 [lints]
 workspace = true

--- a/crates/client/src/interceptors.rs
+++ b/crates/client/src/interceptors.rs
@@ -187,6 +187,106 @@ impl StartWorkflowInput {
 
 impl_with_args!(StartWorkflowInput);
 
+/// Input to [`ClientInterceptor::signal_with_start_workflow`].
+#[non_exhaustive]
+#[derive(derive_more::Debug)]
+pub struct SignalWithStartWorkflowInput {
+    /// The workflow type sent to the server.
+    pub workflow_type: String,
+    /// The signal name sent to the workflow.
+    pub signal_name: String,
+    /// Options for the workflow start.
+    pub options: WorkflowStartOptions,
+    /// Controls for the signal-with-start RPC.
+    pub rpc_options: crate::RpcOptions,
+    // These remain type-erased until after interception so interceptors can replace either value
+    // before the client's payload converter and codec run.
+    #[debug(skip)]
+    workflow_args: Box<dyn TemporalClientValue>,
+    #[debug(skip)]
+    signal_args: Box<dyn TemporalClientValue>,
+}
+
+impl SignalWithStartWorkflowInput {
+    pub(crate) fn new<W, S>(
+        workflow_type: String,
+        workflow_args: W,
+        signal_name: String,
+        signal_args: S,
+        mut options: WorkflowStartOptions,
+    ) -> Self
+    where
+        W: TemporalSerializable + Send + 'static,
+        S: TemporalSerializable + Send + 'static,
+    {
+        let rpc_options = std::mem::take(&mut options.rpc_options);
+        Self {
+            workflow_type,
+            signal_name,
+            options,
+            rpc_options,
+            workflow_args: Box::new(workflow_args),
+            signal_args: Box::new(signal_args),
+        }
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        String,
+        Box<dyn TemporalClientValue>,
+        String,
+        Box<dyn TemporalClientValue>,
+        WorkflowStartOptions,
+        crate::RpcOptions,
+    ) {
+        (
+            self.workflow_type,
+            self.workflow_args,
+            self.signal_name,
+            self.signal_args,
+            self.options,
+            self.rpc_options,
+        )
+    }
+
+    /// Attempt to access the workflow arguments as a concrete type.
+    pub fn workflow_args_ref<T: Any>(&self) -> Option<&T> {
+        self.workflow_args.as_any().downcast_ref()
+    }
+
+    /// Attempt to access the signal arguments as a concrete type.
+    pub fn signal_args_ref<T: Any>(&self) -> Option<&T> {
+        self.signal_args.as_any().downcast_ref()
+    }
+
+    /// Attempt to mutably access the workflow arguments as a concrete type.
+    pub fn workflow_args_mut<T: Any>(&mut self) -> Option<&mut T> {
+        self.workflow_args.as_any_mut().downcast_mut()
+    }
+
+    /// Attempt to mutably access the signal arguments as a concrete type.
+    pub fn signal_args_mut<T: Any>(&mut self) -> Option<&mut T> {
+        self.signal_args.as_any_mut().downcast_mut()
+    }
+
+    /// Replace the workflow arguments before serialization.
+    pub fn replace_workflow_args<T>(&mut self, args: T)
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        self.workflow_args = Box::new(args);
+    }
+
+    /// Replace the signal arguments before serialization.
+    pub fn replace_signal_args<T>(&mut self, args: T)
+    where
+        T: TemporalSerializable + Send + 'static,
+    {
+        self.signal_args = Box::new(args);
+    }
+}
+
 /// Result of a successful intercepted workflow start.
 #[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1062,6 +1162,19 @@ pub trait ClientInterceptor: Send + Sync + 'static {
         next.run(input)
     }
 
+    /// Intercept a `signal_with_start_workflow` operation.
+    fn signal_with_start_workflow<'a>(
+        &'a self,
+        input: SignalWithStartWorkflowInput,
+        next: Next<
+            'a,
+            SignalWithStartWorkflowInput,
+            BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>>,
+        >,
+    ) -> BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>> {
+        next.run(input)
+    }
+
     /// Intercept a `list_workflows_page` operation.
     fn list_workflows_page<'a>(
         &'a self,
@@ -1348,6 +1461,13 @@ interceptor_chain!(
     call_start_workflow,
     start_workflow,
     StartWorkflowInput,
+    BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>>
+);
+
+interceptor_chain!(
+    call_signal_with_start_workflow,
+    signal_with_start_workflow,
+    SignalWithStartWorkflowInput,
     BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>>
 );
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -130,18 +130,15 @@ use std::{
 };
 use temporalio_common::{
     ActivityDefinition, HasWorkflowDefinition, SignalDefinition, UntypedActivity,
-    data_converters::{
-        DataConverter, GenericPayloadConverter, PayloadConverter, SerializationContext,
-        SerializationContextData,
-    },
-    payload_visitor::{decode_payloads, encode_payloads},
+    data_converters::{DataConverter, SerializationContext, SerializationContextData},
+    payload_visitor::decode_payloads,
     protos::{
         coresdk::IntoPayloadsExt,
         grpc::health::v1::health_client::HealthClient,
         proto_ts_to_system_time,
         temporal::api::{
             cloud::cloudservice::v1::cloud_service_client::CloudServiceClient,
-            common::v1::{ActivityType, Memo as ProtoMemo, Payloads, WorkflowType},
+            common::v1::{ActivityType, Payloads, WorkflowType},
             enums::v1::{
                 ActivityIdConflictPolicy as ProtoActivityIdConflictPolicy,
                 ActivityIdReusePolicy as ProtoActivityIdReusePolicy, TaskQueueKind,
@@ -1746,35 +1743,9 @@ where
                         let workflow_id = options.workflow_id.clone();
                         let task_queue_name = options.task_queue.clone();
 
-                        let memo = match options.memo {
-                            Some(memo) => {
-                                let payload_converter = data_converter.payload_converter();
-                                let context = SerializationContext {
-                                    data: &SerializationContextData::Workflow,
-                                    converter: payload_converter,
-                                };
-                                let mut memo = ProtoMemo {
-                                    fields: memo
-                                        .iter()
-                                        .map(|(key, value)| {
-                                            payload_converter
-                                                .to_payload(&context, value)
-                                                .map(|payload| (key.to_owned(), payload))
-                                        })
-                                        .collect::<Result<_, _>>()?,
-                                };
-                                encode_payloads(
-                                    &mut memo,
-                                    data_converter.codec(),
-                                    &SerializationContextData::Workflow,
-                                )
-                                .await?;
-                                Some(memo)
-                            }
-                            None => None,
-                        };
-
                         let user_metadata = options.user_metadata();
+
+                        let memo = options.encoded_memo(&data_converter).await?;
 
                         let run_id = {
                             let mut request = StartWorkflowExecutionRequest {
@@ -1925,6 +1896,8 @@ where
 
                         let user_metadata = options.user_metadata();
 
+                        let memo = options.encoded_memo(&data_converter).await?;
+
                         let mut request = SignalWithStartWorkflowExecutionRequest {
                             namespace: client.namespace(),
                             workflow_id: workflow_id.clone(),
@@ -1959,6 +1932,7 @@ where
                                 .map(|attributes| attributes.into_proto()),
                             cron_schedule: options.cron_schedule.unwrap_or_default(),
                             retry_policy: options.retry_policy.map(Into::into),
+                            memo,
                             header: options.header,
                             user_metadata,
                             ..Default::default()
@@ -2992,40 +2966,34 @@ mod tests {
         use parking_lot::Mutex;
         use std::sync::atomic::{AtomicUsize, Ordering};
         use temporalio_common::{
-            HasWorkflowDefinition, MemoValues, SignalDefinition, WorkflowDefinition,
+            MemoValues, SignalDefinition,
             data_converters::{
                 DefaultFailureConverter, PayloadCodec, PayloadConversionError, PayloadConverter,
                 SerializationContext, SerializationContextData, TemporalDeserializable,
                 TemporalSerializable,
             },
-            protos::temporal::api::common::v1::Payload,
+            protos::temporal::api::common::v1::{Memo as ProtoMemo, Payload},
         };
+        use temporalio_macros::{workflow, workflow_methods};
+        use temporalio_workflow::{SyncWorkflowContext, WorkflowContext, WorkflowResult};
         use tonic::{Request, Response};
 
+        #[workflow]
+        #[derive(Default)]
         struct TestWorkflow;
 
-        impl WorkflowDefinition for TestWorkflow {
-            type Input = Vec<String>;
-            type Output = ();
-
-            fn name(&self) -> &str {
-                "test-workflow"
+        #[workflow_methods]
+        impl TestWorkflow {
+            #[run]
+            async fn run(
+                _ctx: &mut WorkflowContext<Self>,
+                _input: Vec<String>,
+            ) -> WorkflowResult<()> {
+                Ok(())
             }
-        }
 
-        impl HasWorkflowDefinition for TestWorkflow {
-            type Run = Self;
-        }
-
-        struct TestSignal;
-
-        impl SignalDefinition for TestSignal {
-            type Workflow = TestWorkflow;
-            type Input = Vec<String>;
-
-            fn name(&self) -> &str {
-                "test-signal"
-            }
+            #[signal]
+            fn test_signal(&mut self, _ctx: &mut SyncWorkflowContext<Self>, _input: Vec<String>) {}
         }
 
         #[derive(Default)]
@@ -3357,7 +3325,7 @@ mod tests {
         struct FailingSignal;
 
         impl SignalDefinition for FailingSignal {
-            type Workflow = TestWorkflow;
+            type Workflow = test_workflow::Run;
             type Input = FailingSignalInput;
 
             fn name(&self) -> &str {
@@ -3440,7 +3408,7 @@ mod tests {
 
             client
                 .start_workflow(
-                    TestWorkflow,
+                    TestWorkflow::run,
                     vec!["initial".to_owned()],
                     WorkflowStartOptions::new("task-queue", "workflow-id")
                         .memo(memo)
@@ -3463,12 +3431,13 @@ mod tests {
             memo.insert("memo-key", "memo-value".to_owned());
 
             client
-                .start_workflow(
-                    TestWorkflow,
+                .signal_with_start_workflow(
+                    TestWorkflow::run,
                     vec!["initial".to_owned()],
+                    TestWorkflow::test_signal,
+                    vec!["signal".to_owned()],
                     WorkflowStartOptions::new("task-queue", "workflow-id")
                         .memo(memo)
-                        .start_signal(WorkflowStartSignal::new("some-signal").build())
                         .build(),
                 )
                 .await
@@ -3487,7 +3456,7 @@ mod tests {
 
             client
                 .start_workflow(
-                    TestWorkflow,
+                    TestWorkflow::run,
                     vec!["initial".to_owned()],
                     WorkflowStartOptions::new("task-queue", "workflow-id").build(),
                 )
@@ -3519,7 +3488,7 @@ mod tests {
 
             let err = client
                 .start_workflow(
-                    TestWorkflow,
+                    TestWorkflow::run,
                     vec!["initial".to_owned()],
                     WorkflowStartOptions::new("task-queue", "workflow-id")
                         .memo(memo)
@@ -3561,7 +3530,7 @@ mod tests {
 
             let handle = client
                 .start_workflow(
-                    TestWorkflow,
+                    TestWorkflow::run,
                     vec!["initial".to_owned()],
                     WorkflowStartOptions::new("task-queue", "workflow-id").build(),
                 )
@@ -3597,7 +3566,7 @@ mod tests {
             );
             let handle = client
                 .start_workflow(
-                    TestWorkflow,
+                    TestWorkflow::run,
                     vec!["initial".to_owned()],
                     WorkflowStartOptions::new("task-queue", "ignored-workflow-id").build(),
                 )
@@ -3634,7 +3603,7 @@ mod tests {
 
             client
                 .start_workflow(
-                    TestWorkflow,
+                    TestWorkflow::run,
                     vec!["initial".to_owned()],
                     WorkflowStartOptions::new("task-queue", "workflow-id").build(),
                 )
@@ -3657,7 +3626,7 @@ mod tests {
 
             client
                 .start_workflow(
-                    TestWorkflow,
+                    TestWorkflow::run,
                     vec!["initial".to_owned()],
                     WorkflowStartOptions::new("task-queue", "workflow-id").build(),
                 )
@@ -3683,7 +3652,7 @@ mod tests {
             options.rpc_options = rpc_options.clone();
 
             client
-                .start_workflow(TestWorkflow, vec!["initial".to_owned()], options)
+                .start_workflow(TestWorkflow::run, vec!["initial".to_owned()], options)
                 .await
                 .unwrap();
 
@@ -3699,9 +3668,9 @@ mod tests {
             options.rpc_options = rpc_options;
             let handle = client
                 .signal_with_start_workflow(
-                    TestWorkflow,
+                    TestWorkflow::run,
                     vec!["initial".to_owned()],
-                    TestSignal,
+                    TestWorkflow::test_signal,
                     vec!["signal".to_owned()],
                     options,
                 )
@@ -3714,7 +3683,7 @@ mod tests {
             assert_eq!(recorded.binary_metadata.as_deref(), Some(&[0, 255][..]));
             assert_eq!(recorded.grpc_timeout.as_deref(), Some("250000u"));
             assert_eq!(recorded.retry_options, Some(RetryOptions::no_retries()));
-            assert_eq!(recorded.signal_name, "test-signal");
+            assert_eq!(recorded.signal_name, "test_signal");
             assert_eq!(recorded.signal_payloads.len(), 1);
             assert_eq!(handle.run_id(), Some("signal-server-run-id"));
         }
@@ -3728,9 +3697,9 @@ mod tests {
 
             client
                 .signal_with_start_workflow(
-                    TestWorkflow,
+                    TestWorkflow::run,
                     vec!["workflow".to_owned()],
-                    TestSignal,
+                    TestWorkflow::test_signal,
                     vec!["signal".to_owned()],
                     WorkflowStartOptions::new("task-queue", "workflow-id").build(),
                 )
@@ -3770,7 +3739,7 @@ mod tests {
 
             let result = client
                 .signal_with_start_workflow(
-                    TestWorkflow,
+                    TestWorkflow::run,
                     vec!["workflow".to_owned()],
                     FailingSignal,
                     FailingSignalInput,

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -58,9 +58,9 @@ pub use interceptors::{
     ListSchedulesPageOutput, ListWorkflowsPageInput, ListWorkflowsPageOutput, Next,
     PauseScheduleInput, PollWorkflowUpdateInput, PollWorkflowUpdateOutput, QueryWorkflowInput,
     QueryWorkflowOutput, ReportAsyncActivityCancellationInput, SendScheduleUpdateInput,
-    SignalWorkflowInput, StartWorkflowInput, StartWorkflowOutput, StartWorkflowUpdateInput,
-    StartWorkflowUpdateOutput, TemporalClientValue, TerminateWorkflowInput, TriggerScheduleInput,
-    UnpauseScheduleInput, UpdateScheduleInput,
+    SignalWithStartWorkflowInput, SignalWorkflowInput, StartWorkflowInput, StartWorkflowOutput,
+    StartWorkflowUpdateInput, StartWorkflowUpdateOutput, TemporalClientValue,
+    TerminateWorkflowInput, TriggerScheduleInput, UnpauseScheduleInput, UpdateScheduleInput,
 };
 pub use metrics::{LONG_REQUEST_LATENCY_HISTOGRAM_NAME, REQUEST_LATENCY_HISTOGRAM_NAME};
 pub use options_structs::*;
@@ -129,7 +129,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 use temporalio_common::{
-    ActivityDefinition, HasWorkflowDefinition, UntypedActivity,
+    ActivityDefinition, HasWorkflowDefinition, SignalDefinition, UntypedActivity,
     data_converters::{
         DataConverter, GenericPayloadConverter, PayloadConverter, SerializationContext,
         SerializationContextData,
@@ -141,7 +141,7 @@ use temporalio_common::{
         proto_ts_to_system_time,
         temporal::api::{
             cloud::cloudservice::v1::cloud_service_client::CloudServiceClient,
-            common::v1::{ActivityType, Memo as ProtoMemo, WorkflowType},
+            common::v1::{ActivityType, Memo as ProtoMemo, Payloads, WorkflowType},
             enums::v1::{
                 ActivityIdConflictPolicy as ProtoActivityIdConflictPolicy,
                 ActivityIdReusePolicy as ProtoActivityIdReusePolicy, TaskQueueKind,
@@ -1156,6 +1156,34 @@ impl Client {
         WorkflowClientTrait::start_workflow(self, workflow, input, options).await
     }
 
+    /// Atomically signal a workflow as it starts.
+    ///
+    /// The workflow receives the signal before its first workflow task.
+    pub async fn signal_with_start_workflow<W, S>(
+        &self,
+        workflow: W,
+        workflow_input: W::Input,
+        signal: S,
+        signal_input: S::Input,
+        options: WorkflowStartOptions,
+    ) -> Result<WorkflowHandle<Self, W>, WorkflowStartError>
+    where
+        W: HasWorkflowDefinition,
+        W::Input: Send,
+        S: SignalDefinition<Workflow = W::Run>,
+        S::Input: Send,
+    {
+        WorkflowClientTrait::signal_with_start_workflow(
+            self,
+            workflow,
+            workflow_input,
+            signal,
+            signal_input,
+            options,
+        )
+        .await
+    }
+
     /// Get a handle to an existing workflow.
     ///
     /// For untyped access, use `get_workflow_handle::<UntypedWorkflow>(...)`.
@@ -1320,6 +1348,22 @@ pub(crate) trait WorkflowClientTrait: NamespacedClient {
         Self: Sized,
         W: HasWorkflowDefinition,
         W::Input: Send;
+
+    /// Start a workflow and atomically send it a signal.
+    fn signal_with_start_workflow<W, S>(
+        &self,
+        workflow: W,
+        workflow_input: W::Input,
+        signal: S,
+        signal_input: S::Input,
+        options: WorkflowStartOptions,
+    ) -> impl Future<Output = Result<WorkflowHandle<Self, W>, WorkflowStartError>>
+    where
+        Self: Sized,
+        W: HasWorkflowDefinition,
+        W::Input: Send,
+        S: SignalDefinition<Workflow = W::Run>,
+        S::Input: Send;
 
     /// Get a handle to an existing workflow. `run_id` may be left blank to specify the most recent
     /// execution having the provided `workflow_id`.
@@ -1730,78 +1774,9 @@ where
                             None => None,
                         };
 
-                        let user_metadata = if options.static_summary.is_some()
-                            || options.static_details.is_some()
-                        {
-                            let payload_converter = PayloadConverter::default();
-                            let context = SerializationContext {
-                                data: &SerializationContextData::Workflow,
-                                converter: &payload_converter,
-                            };
-                            Some(UserMetadata {
-                                summary: options.static_summary.map(|summary| {
-                                    payload_converter.to_payload(&context, &summary).expect(
-                                        "String-to-JSON payload serialization is infallible",
-                                    )
-                                }),
-                                details: options.static_details.map(|details| {
-                                    payload_converter.to_payload(&context, &details).expect(
-                                        "String-to-JSON payload serialization is infallible",
-                                    )
-                                }),
-                            })
-                        } else {
-                            None
-                        };
+                        let user_metadata = options.user_metadata();
 
-                        let run_id = if let Some(start_signal) = options.start_signal {
-                            let mut request = SignalWithStartWorkflowExecutionRequest {
-                                namespace,
-                                workflow_id: workflow_id.clone(),
-                                workflow_type: Some(WorkflowType {
-                                    name: workflow_type,
-                                }),
-                                task_queue: Some(TaskQueue {
-                                    name: task_queue_name,
-                                    kind: TaskQueueKind::Normal as i32,
-                                    normal_name: String::new(),
-                                }),
-                                input: payloads.into_payloads(),
-                                signal_name: start_signal.signal_name,
-                                signal_input: start_signal.input,
-                                identity: client.identity(),
-                                request_id: Uuid::new_v4().to_string(),
-                                workflow_id_reuse_policy: options.id_reuse_policy as i32,
-                                workflow_id_conflict_policy: options.id_conflict_policy as i32,
-                                workflow_execution_timeout: options
-                                    .execution_timeout
-                                    .and_then(|duration| duration.try_into().ok()),
-                                workflow_run_timeout: options
-                                    .run_timeout
-                                    .and_then(|duration| duration.try_into().ok()),
-                                workflow_task_timeout: options
-                                    .task_timeout
-                                    .and_then(|duration| duration.try_into().ok()),
-                                search_attributes: options
-                                    .search_attributes
-                                    .map(|attributes| attributes.into_proto()),
-                                cron_schedule: options.cron_schedule.unwrap_or_default(),
-                                retry_policy: options.retry_policy.map(Into::into),
-                                memo,
-                                header: options.header.or(start_signal.header),
-                                user_metadata,
-                                ..Default::default()
-                            }
-                            .into_request();
-                            rpc_options.apply_to(&mut request);
-                            WorkflowService::signal_with_start_workflow_execution(
-                                &mut client,
-                                request,
-                            )
-                            .await?
-                            .into_inner()
-                            .run_id
-                        } else {
+                        let run_id = {
                             let mut request = StartWorkflowExecutionRequest {
                                 namespace,
                                 input: payloads.into_payloads(),
@@ -1862,9 +1837,141 @@ where
                                     }
                                 })?
                                 .into_inner()
-                                .run_id
+                            .run_id
                         };
 
+                        Ok(StartWorkflowOutput::new(workflow_id, run_id))
+                    })
+                }
+            }),
+        )
+        .await?;
+        let StartWorkflowOutput {
+            workflow_id,
+            run_id,
+        } = interceptor_output;
+
+        Ok(WorkflowHandle::new(
+            self.clone(),
+            WorkflowExecutionInfo {
+                namespace,
+                workflow_id,
+                run_id: Some(run_id.clone()),
+                first_execution_run_id: Some(run_id),
+            },
+        ))
+    }
+
+    async fn signal_with_start_workflow<W, S>(
+        &self,
+        workflow: W,
+        workflow_input: W::Input,
+        signal: S,
+        signal_input: S::Input,
+        options: WorkflowStartOptions,
+    ) -> Result<WorkflowHandle<Self, W>, WorkflowStartError>
+    where
+        W: HasWorkflowDefinition,
+        W::Input: Send,
+        S: SignalDefinition<Workflow = W::Run>,
+        S::Input: Send,
+    {
+        let namespace = self.namespace();
+        let interceptor_output = interceptors::call_signal_with_start_workflow(
+            self.client_interceptors(),
+            SignalWithStartWorkflowInput::new(
+                workflow.name().to_owned(),
+                workflow_input,
+                signal.name().to_owned(),
+                signal_input,
+                options,
+            ),
+            Next::new({
+                let client = (*self).clone();
+                move |input: SignalWithStartWorkflowInput| -> BoxFuture<
+                    '_,
+                    Result<StartWorkflowOutput, WorkflowStartError>,
+                > {
+                    let mut client = client;
+                    Box::pin(async move {
+                        let (
+                            workflow_type,
+                            workflow_args,
+                            signal_name,
+                            signal_args,
+                            options,
+                            rpc_options,
+                        ) = input.into_parts();
+                        let data_converter = client.data_converter().clone();
+                        let payload_converter = data_converter.payload_converter();
+                        let context = SerializationContext {
+                            data: &SerializationContextData::Workflow,
+                            converter: payload_converter,
+                        };
+                        let workflow_payloads = workflow_args.serialize_payloads(&context);
+                        let signal_payloads = signal_args.serialize_payloads(&context);
+                        drop(workflow_args);
+                        drop(signal_args);
+                        let workflow_payloads = data_converter
+                            .codec()
+                            .encode(&SerializationContextData::Workflow, workflow_payloads?)
+                            .await?;
+                        let signal_payloads = data_converter
+                            .codec()
+                            .encode(&SerializationContextData::Workflow, signal_payloads?)
+                            .await?;
+                        let workflow_id = options.workflow_id.clone();
+                        let task_queue_name = options.task_queue.clone();
+
+                        let user_metadata = options.user_metadata();
+
+                        let mut request = SignalWithStartWorkflowExecutionRequest {
+                            namespace: client.namespace(),
+                            workflow_id: workflow_id.clone(),
+                            workflow_type: Some(WorkflowType {
+                                name: workflow_type,
+                            }),
+                            task_queue: Some(TaskQueue {
+                                name: task_queue_name,
+                                kind: TaskQueueKind::Normal as i32,
+                                normal_name: String::new(),
+                            }),
+                            input: workflow_payloads.into_payloads(),
+                            signal_name,
+                            signal_input: Some(Payloads {
+                                payloads: signal_payloads,
+                            }),
+                            identity: client.identity(),
+                            request_id: Uuid::new_v4().to_string(),
+                            workflow_id_reuse_policy: options.id_reuse_policy as i32,
+                            workflow_id_conflict_policy: options.id_conflict_policy as i32,
+                            workflow_execution_timeout: options
+                                .execution_timeout
+                                .and_then(|duration| duration.try_into().ok()),
+                            workflow_run_timeout: options
+                                .run_timeout
+                                .and_then(|duration| duration.try_into().ok()),
+                            workflow_task_timeout: options
+                                .task_timeout
+                                .and_then(|duration| duration.try_into().ok()),
+                            search_attributes: options
+                                .search_attributes
+                                .map(|attributes| attributes.into_proto()),
+                            cron_schedule: options.cron_schedule.unwrap_or_default(),
+                            retry_policy: options.retry_policy.map(Into::into),
+                            header: options.header,
+                            user_metadata,
+                            ..Default::default()
+                        }
+                        .into_request();
+                        rpc_options.apply_to(&mut request);
+                        let run_id = WorkflowService::signal_with_start_workflow_execution(
+                            &mut client,
+                            request,
+                        )
+                        .await?
+                        .into_inner()
+                        .run_id;
                         Ok(StartWorkflowOutput::new(workflow_id, run_id))
                     })
                 }
@@ -2885,10 +2992,11 @@ mod tests {
         use parking_lot::Mutex;
         use std::sync::atomic::{AtomicUsize, Ordering};
         use temporalio_common::{
-            HasWorkflowDefinition, MemoValues, WorkflowDefinition,
+            HasWorkflowDefinition, MemoValues, SignalDefinition, WorkflowDefinition,
             data_converters::{
-                DefaultFailureConverter, PayloadCodec, PayloadConversionError,
-                SerializationContext, SerializationContextData, TemporalSerializable,
+                DefaultFailureConverter, PayloadCodec, PayloadConversionError, PayloadConverter,
+                SerializationContext, SerializationContextData, TemporalDeserializable,
+                TemporalSerializable,
             },
             protos::temporal::api::common::v1::Payload,
         };
@@ -2909,12 +3017,25 @@ mod tests {
             type Run = Self;
         }
 
+        struct TestSignal;
+
+        impl SignalDefinition for TestSignal {
+            type Workflow = TestWorkflow;
+            type Input = Vec<String>;
+
+            fn name(&self) -> &str {
+                "test-signal"
+            }
+        }
+
         #[derive(Default)]
         struct RecordedStart {
             calls: usize,
             workflow_type: String,
             memo: Option<ProtoMemo>,
             payloads: Vec<Payload>,
+            signal_name: String,
+            signal_payloads: Vec<Payload>,
             ascii_metadata: Option<String>,
             binary_metadata: Option<Vec<u8>>,
             grpc_timeout: Option<String>,
@@ -3042,6 +3163,8 @@ mod tests {
                 recorded.workflow_type = request.workflow_type.unwrap().name;
                 recorded.memo = request.memo;
                 recorded.payloads = request.input.unwrap_or_default().payloads;
+                recorded.signal_name = request.signal_name;
+                recorded.signal_payloads = request.signal_input.unwrap_or_default().payloads;
                 recorded.ascii_metadata = ascii_metadata;
                 recorded.binary_metadata = binary_metadata;
                 recorded.grpc_timeout = grpc_timeout;
@@ -3202,6 +3325,56 @@ mod tests {
                 let future = next.run(input);
                 assert_eq!(self.conversion_calls.load(Ordering::SeqCst), 0);
                 future
+            }
+        }
+
+        struct ReplacingSignalWithStartInterceptor;
+
+        impl ClientInterceptor for ReplacingSignalWithStartInterceptor {
+            fn signal_with_start_workflow<'a>(
+                &'a self,
+                mut input: SignalWithStartWorkflowInput,
+                next: Next<
+                    'a,
+                    SignalWithStartWorkflowInput,
+                    BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>>,
+                >,
+            ) -> BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>> {
+                assert_eq!(
+                    input.workflow_args_ref::<Vec<String>>().unwrap(),
+                    &["workflow".to_owned()]
+                );
+                assert_eq!(
+                    input.signal_args_ref::<Vec<String>>().unwrap(),
+                    &["signal".to_owned()]
+                );
+                input.replace_workflow_args(vec!["replaced-workflow".to_owned()]);
+                input.replace_signal_args(vec!["replaced-signal".to_owned()]);
+                next.run(input)
+            }
+        }
+
+        struct FailingSignal;
+
+        impl SignalDefinition for FailingSignal {
+            type Workflow = TestWorkflow;
+            type Input = FailingSignalInput;
+
+            fn name(&self) -> &str {
+                "failing-signal"
+            }
+        }
+
+        struct FailingSignalInput;
+
+        impl TemporalDeserializable for FailingSignalInput {}
+
+        impl TemporalSerializable for FailingSignalInput {
+            fn to_payloads(
+                &self,
+                _context: &SerializationContext<'_>,
+            ) -> Result<Vec<Payload>, PayloadConversionError> {
+                Err(PayloadConversionError::WrongEncoding)
             }
         }
 
@@ -3523,10 +3696,15 @@ mod tests {
             }
 
             let mut options = WorkflowStartOptions::new("task-queue", "signal-workflow-id").build();
-            options.start_signal = Some(WorkflowStartSignal::new("signal-name").build());
             options.rpc_options = rpc_options;
             let handle = client
-                .start_workflow(TestWorkflow, vec!["initial".to_owned()], options)
+                .signal_with_start_workflow(
+                    TestWorkflow,
+                    vec!["initial".to_owned()],
+                    TestSignal,
+                    vec!["signal".to_owned()],
+                    options,
+                )
                 .await
                 .unwrap();
 
@@ -3536,7 +3714,75 @@ mod tests {
             assert_eq!(recorded.binary_metadata.as_deref(), Some(&[0, 255][..]));
             assert_eq!(recorded.grpc_timeout.as_deref(), Some("250000u"));
             assert_eq!(recorded.retry_options, Some(RetryOptions::no_retries()));
+            assert_eq!(recorded.signal_name, "test-signal");
+            assert_eq!(recorded.signal_payloads.len(), 1);
             assert_eq!(handle.run_id(), Some("signal-server-run-id"));
+        }
+
+        #[tokio::test]
+        async fn signal_with_start_interceptor_can_replace_both_argument_sets() {
+            let (client, recorded) = mock_client(
+                vec![Arc::new(ReplacingSignalWithStartInterceptor)],
+                Arc::new(AtomicUsize::new(0)),
+            );
+
+            client
+                .signal_with_start_workflow(
+                    TestWorkflow,
+                    vec!["workflow".to_owned()],
+                    TestSignal,
+                    vec!["signal".to_owned()],
+                    WorkflowStartOptions::new("task-queue", "workflow-id").build(),
+                )
+                .await
+                .unwrap();
+
+            let data_converter = DataConverter::default();
+            let (workflow_payloads, signal_payloads) = {
+                let recorded = recorded.lock();
+                (recorded.payloads.clone(), recorded.signal_payloads.clone())
+            };
+            assert_eq!(
+                data_converter
+                    .from_payloads::<Vec<String>>(
+                        &SerializationContextData::Workflow,
+                        workflow_payloads,
+                    )
+                    .await
+                    .unwrap(),
+                vec!["replaced-workflow".to_owned()]
+            );
+            assert_eq!(
+                data_converter
+                    .from_payloads::<Vec<String>>(
+                        &SerializationContextData::Workflow,
+                        signal_payloads,
+                    )
+                    .await
+                    .unwrap(),
+                vec!["replaced-signal".to_owned()]
+            );
+        }
+
+        #[tokio::test]
+        async fn signal_with_start_payload_conversion_failure_does_not_call_service() {
+            let (client, recorded) = mock_client(Vec::new(), Arc::new(AtomicUsize::new(0)));
+
+            let result = client
+                .signal_with_start_workflow(
+                    TestWorkflow,
+                    vec!["workflow".to_owned()],
+                    FailingSignal,
+                    FailingSignalInput,
+                    WorkflowStartOptions::new("task-queue", "workflow-id").build(),
+                )
+                .await;
+
+            assert!(matches!(
+                result,
+                Err(WorkflowStartError::PayloadConversion(_))
+            ));
+            assert_eq!(recorded.lock().calls, 0);
         }
 
         #[test]
@@ -3617,7 +3863,7 @@ mod tests {
         use futures_util::{FutureExt, StreamExt};
         use std::sync::atomic::{AtomicUsize, Ordering};
         use temporalio_common::{
-            data_converters::DefaultFailureConverter,
+            data_converters::{DefaultFailureConverter, PayloadConverter},
             protos::temporal::api::common::v1::{
                 Memo as ProtoMemo, Payload, WorkflowExecution as ProtoWorkflowExecution,
             },

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -7,13 +7,14 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use temporalio_common::{
     ActivityCloseTimeouts, MemoValues, RetryPolicy,
     data_converters::{
-        DataConverter, GenericPayloadConverter, PayloadConverter, SerializationContext,
-        SerializationContextData,
+        DataConverter, GenericPayloadConverter, PayloadConversionError, PayloadConverter,
+        SerializationContext, SerializationContextData,
     },
+    payload_visitor::encode_payloads,
     protos::temporal::api::{
         common::{
             self,
-            v1::{Header, Payloads},
+            v1::{Header, Memo as ProtoMemo, Payloads},
         },
         enums::v1::{
             ActivityIdConflictPolicy as ProtoActivityIdConflictPolicy,
@@ -456,6 +457,38 @@ pub struct WorkflowStartOptions {
 }
 
 impl WorkflowStartOptions {
+    pub(crate) async fn encoded_memo(
+        &self,
+        data_converter: &DataConverter,
+    ) -> Result<Option<ProtoMemo>, PayloadConversionError> {
+        let Some(memo) = &self.memo else {
+            return Ok(None);
+        };
+
+        let payload_converter = data_converter.payload_converter();
+        let context = SerializationContext {
+            data: &SerializationContextData::Workflow,
+            converter: payload_converter,
+        };
+        let mut memo = ProtoMemo {
+            fields: memo
+                .iter()
+                .map(|(key, value)| {
+                    payload_converter
+                        .to_payload(&context, value)
+                        .map(|payload| (key.to_owned(), payload))
+                })
+                .collect::<Result<_, _>>()?,
+        };
+        encode_payloads(
+            &mut memo,
+            data_converter.codec(),
+            &SerializationContextData::Workflow,
+        )
+        .await?;
+        Ok(Some(memo))
+    }
+
     pub(crate) fn user_metadata(&self) -> Option<UserMetadata> {
         (self.static_summary.is_some() || self.static_details.is_some()).then(|| {
             let payload_converter = PayloadConverter::default();

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -6,7 +6,10 @@ use http::Uri;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use temporalio_common::{
     ActivityCloseTimeouts, MemoValues, RetryPolicy,
-    data_converters::DataConverter,
+    data_converters::{
+        DataConverter, GenericPayloadConverter, PayloadConverter, SerializationContext,
+        SerializationContextData,
+    },
     protos::temporal::api::{
         common::{
             self,
@@ -19,6 +22,7 @@ use temporalio_common::{
             WorkflowIdReusePolicy,
         },
         replication::v1::ClusterReplicationConfig,
+        sdk::v1::UserMetadata,
         workflowservice::v1::RegisterNamespaceRequest,
     },
     search_attributes::SearchAttributes,
@@ -421,10 +425,6 @@ pub struct WorkflowStartOptions {
     #[builder(into)]
     pub retry_policy: Option<RetryPolicy>,
 
-    /// If set, send a signal to the workflow atomically with start.
-    /// The workflow will receive this signal before its first task.
-    pub start_signal: Option<WorkflowStartSignal>,
-
     /// Links to associate with the workflow. Ex: References to a nexus operation.
     #[builder(default)]
     pub links: Vec<common::v1::Link>,
@@ -455,19 +455,28 @@ pub struct WorkflowStartOptions {
     pub rpc_options: RpcOptions,
 }
 
-/// A signal to send atomically when starting a workflow.
-/// Use with `WorkflowStartOptions::start_signal` to achieve signal-with-start behavior.
-#[derive(Debug, Clone, bon::Builder)]
-#[builder(start_fn = new, on(String, into))]
-#[non_exhaustive]
-pub struct WorkflowStartSignal {
-    /// Name of the signal to send.
-    #[builder(start_fn)]
-    pub signal_name: String,
-    /// Payload for the signal.
-    pub input: Option<Payloads>,
-    /// Headers for the signal.
-    pub header: Option<Header>,
+impl WorkflowStartOptions {
+    pub(crate) fn user_metadata(&self) -> Option<UserMetadata> {
+        (self.static_summary.is_some() || self.static_details.is_some()).then(|| {
+            let payload_converter = PayloadConverter::default();
+            let context = SerializationContext {
+                data: &SerializationContextData::Workflow,
+                converter: &payload_converter,
+            };
+            UserMetadata {
+                summary: self.static_summary.as_ref().map(|summary| {
+                    payload_converter
+                        .to_payload(&context, summary)
+                        .expect("String-to-JSON payload serialization is infallible")
+                }),
+                details: self.static_details.as_ref().map(|details| {
+                    payload_converter
+                        .to_payload(&context, details)
+                        .expect("String-to-JSON payload serialization is infallible")
+                }),
+            }
+        })
+    }
 }
 
 pub use temporalio_common::Priority;

--- a/crates/client/tests/typed_signal_with_start.rs
+++ b/crates/client/tests/typed_signal_with_start.rs
@@ -1,0 +1,5 @@
+#[test]
+fn typed_signal_with_start_build_tests() {
+    let tests = trybuild::TestCases::new();
+    tests.compile_fail("tests/typed_signal_with_start/*_fail.rs");
+}

--- a/crates/client/tests/typed_signal_with_start/mismatched_signal_fail.rs
+++ b/crates/client/tests/typed_signal_with_start/mismatched_signal_fail.rs
@@ -1,0 +1,45 @@
+use temporalio_client::{Client, WorkflowStartOptions};
+use temporalio_macros::{workflow, workflow_methods};
+use temporalio_workflow::{SyncWorkflowContext, WorkflowContext, WorkflowResult};
+
+#[workflow]
+#[derive(Default)]
+struct FirstWorkflow;
+
+#[workflow_methods]
+impl FirstWorkflow {
+    #[run]
+    async fn run(_ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+        Ok(())
+    }
+
+    #[signal]
+    fn first_signal(&mut self, _ctx: &mut SyncWorkflowContext<Self>, _input: String) {}
+}
+
+#[workflow]
+#[derive(Default)]
+struct SecondWorkflow;
+
+#[workflow_methods]
+impl SecondWorkflow {
+    #[run]
+    async fn run(_ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+        Ok(())
+    }
+
+    #[signal]
+    fn second_signal(&mut self, _ctx: &mut SyncWorkflowContext<Self>, _input: String) {}
+}
+
+fn mismatched_signal(client: &Client) {
+    let _ = client.signal_with_start_workflow(
+        FirstWorkflow::run,
+        (),
+        SecondWorkflow::second_signal,
+        "signal".to_owned(),
+        WorkflowStartOptions::new("task-queue", "workflow-id").build(),
+    );
+}
+
+fn main() {}

--- a/crates/client/tests/typed_signal_with_start/mismatched_signal_fail.stderr
+++ b/crates/client/tests/typed_signal_with_start/mismatched_signal_fail.stderr
@@ -1,0 +1,34 @@
+error[E0271]: type mismatch resolving `<SecondSignal as SignalDefinition>::Workflow == Run`
+  --> tests/typed_signal_with_start/mismatched_signal_fail.rs:39:9
+   |
+36 |     let _ = client.signal_with_start_workflow(
+   |                    -------------------------- required by a bound introduced by this call
+...
+39 |         SecondWorkflow::second_signal,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<SecondSignal as SignalDefinition>::Workflow == Run`
+   |
+note: expected this to be `first_workflow::Run`
+  --> tests/typed_signal_with_start/mismatched_signal_fail.rs:24:1
+   |
+24 | #[workflow_methods]
+   | ^^^^^^^^^^^^^^^^^^^
+   = note: `second_workflow::Run` and `first_workflow::Run` have similar names, but are actually distinct types
+note: `second_workflow::Run` is defined in module `crate::second_workflow` of the current crate
+  --> tests/typed_signal_with_start/mismatched_signal_fail.rs:24:1
+   |
+24 | #[workflow_methods]
+   | ^^^^^^^^^^^^^^^^^^^
+note: `first_workflow::Run` is defined in module `crate::first_workflow` of the current crate
+  --> tests/typed_signal_with_start/mismatched_signal_fail.rs:9:1
+   |
+ 9 | #[workflow_methods]
+   | ^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `temporalio_client::Client::signal_with_start_workflow`
+  --> src/lib.rs
+   |
+   |     pub async fn signal_with_start_workflow<W, S>(
+   |                  -------------------------- required by a bound in this associated function
+...
+   |         S: SignalDefinition<Workflow = W::Run>,
+   |                             ^^^^^^^^^^^^^^^^^ required by this bound in `Client::signal_with_start_workflow`
+   = note: this error originates in the attribute macro `workflow_methods` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
@@ -1,9 +1,13 @@
 use crate::common::{ActivationAssertionsInterceptor, CoreWfStarter};
-use std::collections::HashMap;
-use temporalio_client::{WorkflowStartOptions, WorkflowStartSignal};
+use futures::future::BoxFuture;
+use std::{collections::HashMap, sync::Arc};
+use temporalio_client::{
+    ClientInterceptor, Next, SignalWithStartWorkflowInput, StartWorkflowOutput,
+    WorkflowStartOptions, errors::WorkflowStartError,
+};
 use temporalio_common::protos::{
     coresdk::{
-        AsJsonPayloadExt, IntoPayloadsExt,
+        AsJsonPayloadExt,
         workflow_activation::{
             ResolveSignalExternalWorkflow, WorkflowActivationJob, workflow_activation_job,
         },
@@ -21,6 +25,10 @@ use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
     ApplicationFailure, CancellableFuture, ChildWorkflowOptions, SignalWorkflowOptions,
     SyncWorkflowContext, WorkflowContext, WorkflowResult,
+    workflow_interceptors::{
+        HandleSignalInput, HandleSignalResult, WorkflowInterceptor, WorkflowInterceptorConstructor,
+        WorkflowInterceptorContext, WorkflowInterceptorFuture, WorkflowNext,
+    },
 };
 use temporalio_sdk_core::test_help::MockPollCfg;
 use uuid::Uuid;
@@ -114,14 +122,49 @@ impl SignalWithCreateWfReceiver {
     }
 
     #[signal(name = "signame")]
-    fn handle_signal(&mut self, ctx: &mut SyncWorkflowContext<Self>, input: String) {
+    fn handle_signal(&mut self, _ctx: &mut SyncWorkflowContext<Self>, input: String) {
         assert_eq!(input, "tada");
-        let headers = ctx.headers();
+        self.received = true;
+    }
+}
+
+struct SignalWithStartHeaderClientInterceptor;
+
+impl ClientInterceptor for SignalWithStartHeaderClientInterceptor {
+    fn signal_with_start_workflow<'a>(
+        &'a self,
+        mut input: SignalWithStartWorkflowInput,
+        next: Next<
+            'a,
+            SignalWithStartWorkflowInput,
+            BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>>,
+        >,
+    ) -> BoxFuture<'a, Result<StartWorkflowOutput, WorkflowStartError>> {
+        input.options.header =
+            Some(HashMap::from([("tupac".to_string(), Payload::from("shakur"))]).into());
+        next.run(input)
+    }
+}
+
+struct SignalHeaderWorkflowInterceptor;
+
+impl WorkflowInterceptor for SignalHeaderWorkflowInterceptor {
+    fn handle_signal<'a>(
+        &'a self,
+        _ctx: WorkflowInterceptorContext,
+        input: HandleSignalInput,
+        next: WorkflowNext<
+            'a,
+            HandleSignalInput,
+            WorkflowInterceptorFuture<'a, HandleSignalResult>,
+        >,
+    ) -> WorkflowInterceptorFuture<'a, HandleSignalResult> {
+        assert_eq!(input.name(), SIGNAME);
         assert_eq!(
-            *headers.get("tupac").expect("tupac header exists"),
+            *input.headers().get("tupac").expect("tupac header exists"),
             b"shakur".into()
         );
-        self.received = true;
+        next.run(input)
     }
 }
 
@@ -164,22 +207,27 @@ async fn sends_signal_with_create_wf() {
     starter
         .sdk_config
         .register_workflow::<SignalWithCreateWfReceiver>()
-        .unwrap();
+        .unwrap()
+        .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(|_| {
+            SignalHeaderWorkflowInterceptor
+        })]);
     let mut worker = starter.worker().await;
 
-    let client = starter.get_core_client().await;
-    let mut header: HashMap<String, Payload> = HashMap::new();
-    header.insert("tupac".into(), "shakur".into());
+    let mut client = starter.get_core_client().await;
+    client
+        .options_mut()
+        .client_interceptors
+        .push(Arc::new(SignalWithStartHeaderClientInterceptor));
     let task_queue = worker.inner_mut().task_queue().to_string();
-    let start_signal = WorkflowStartSignal::new(SIGNAME)
-        .maybe_input(vec!["tada".to_string().as_json_payload().unwrap()].into_payloads())
-        .maybe_header(Some(header.into()))
-        .build();
-    let options = WorkflowStartOptions::new(task_queue, "sends_signal_with_create_wf")
-        .start_signal(start_signal)
-        .build();
+    let options = WorkflowStartOptions::new(task_queue, "sends_signal_with_create_wf").build();
     let handle = client
-        .start_workflow(SignalWithCreateWfReceiver::run, (), options)
+        .signal_with_start_workflow(
+            SignalWithCreateWfReceiver::run,
+            (),
+            SignalWithCreateWfReceiver::handle_signal,
+            "tada".to_string(),
+            options,
+        )
         .await
         .expect("request succeeds.qed");
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Remove `start_signal` from workflow options and `WorkflowStartSignal` which was only used there.
- Add a `signal_with_start_workflow` instead of taking an optional signal as part of `WorkflowStartOptions`
- New `signal_with_start_workflow` client interceptor hook

## Why?
We were not providing any type safety around ensuring signals sent during workflow start were valid for the workflow type *or* that the input type matched the signal definition.

I went with a different method instead of an optional signal for a few reasons:
- Bon support for [generics is currently experimental](https://bon-rs.com/reference/builder/top-level/generics)
- If we did make `WorkflowStartOption` generic over signals, we would still need a way to capture "no signal" at the type level. This is possibly, with some `WorkflowStartOption<S = NoSignal>` and adding another trait we implement for all `SignalDefinition` and this new `NoSignal` type. Was unsure this extra type work was worth keeping the single method.
- We will be introducing `update_with_start` and `execute_update_with_start` soon, which are necessarily different methods due to the return type. Feels okay to have signal/update with start have some symmetry as opposed to one being part of start options and one being an explicit arguments.

## Checklist
<!--- add/delete as needed --->

1. Closes #1506 

2. How was this tested:
- Some additional client unit tests around payload conversion
- Integration test ensuring that headers set from client interceptor is visible on the workflow signal handler interceptor
- trybuild test to verify you can't use incorrect signals against a workflow

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
