### PR TITLE
Workflow Task Chunking: v2

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -44,6 +44,7 @@ jobs:
           - os: windows-latest
             timeoutMinutes: 30
           - os: ubuntu-latest
+            useWftChunkingV2: "true"
           - os: ubuntu-arm
             runsOn: ubuntu-24.04-arm64-2-core
             timeoutMinutes: 30
@@ -68,6 +69,8 @@ jobs:
           script: |
             core.exportVariable('RUSTFLAGS', '-Csymbol-mangling-version=v0');
       - run: cargo test -- --include-ignored --nocapture
+        env:
+          TEMPORAL_USE_WFT_CHUNKING_V2: ${{ matrix.useWftChunkingV2 || 'false' }}
       - name: Find test executable for cgroup tests
         id: find-cgroup-test
         if: runner.os == 'Linux' && runner.arch == 'X64'
@@ -131,6 +134,7 @@ jobs:
         include:
           - os: windows-latest
           - os: ubuntu-latest
+            useWftChunkingV2: "true"
           - os: ubuntu-arm
             runsOn: ubuntu-24.04-arm64-2-core
           - os: macos-arm
@@ -154,6 +158,8 @@ jobs:
           script: |
             core.exportVariable('RUSTFLAGS', '-Csymbol-mangling-version=v0');
       - run: cargo integ-test
+        env:
+          TEMPORAL_USE_WFT_CHUNKING_V2: ${{ matrix.useWftChunkingV2 || 'false' }}
 
   wasm-workflow-tests:
     name: WASM workflow tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@ relevant information.
 * Signal-with-start is now invoked with `Client::signal_with_start_workflow`; remove uses of
   `WorkflowStartOptions::start_signal` and `WorkflowStartSignal`.
 
+### Fixed
+
+* Added opt-in Workflow Task chunking v2 to prevent replay boundary divergence around Updates,
+  heartbeat tasks, and paginated history. Deploy reader support before enabling
+  `TEMPORAL_USE_WFT_CHUNKING_V2`; runs whose first successful Workflow Task is already complete
+  remain on v1 and can adopt v2 via Continue-As-New.
+
 ## [0.7.0] - 2026-08-17
 
 ### Added

--- a/arch_docs/workflow_task_chunking.md
+++ b/arch_docs/workflow_task_chunking.md
@@ -1,51 +1,75 @@
 # Workflow Task Chunking
 
-One source of complexity in Core is the chunking of history into "logical" Workflow Tasks.
+## Logical Workflow Tasks
 
-Workflow tasks (WFTs) always take the following form in event history:
+In history, a physical Workflow Task (WFT) is framed by `WorkflowTaskScheduled`,
+`WorkflowTaskStarted`, and `WorkflowTaskCompleted`; inbound events precede it and commands follow.
 
-* \[Preceding Events\] (optional)
-* WFT Scheduled
-* WFT Started
-* WFT Completed
-* \[Commands\] (optional)
+The worker processes history from a different alignment: the completion and commands of the
+previous physical WFT, then new inbound events, then the scheduled/started pair for the current
+WFT. Core calls each such processing unit a logical Workflow Task (LWFT).
 
-In the typical case, the "logical" WFT consists of all the commands from the last workflow task,
-any events generated in the interrim, and the scheduled/started preamble. So:
+Some physical WFTs need not become separate LWFTs. A failed or timed-out attempt committed no
+workflow decision and can be folded into its retry. An otherwise empty WFT, such as a heartbeat
+while a local activity is running, can be swallowed when doing so changes nothing observable by
+workflow code. Chunking is the algorithm that determines when this is safe.
 
-* WFT Completed
-* \[Commands\] (optional)
-* \[Events\] (optional)
-* WFT Scheduled
-* WFT Started
+## Chunking versions
 
-Commands and events are both "optional" in the sense that:
+Core retains the original v1 chunker because changing how an existing history is grouped can
+change activation jobs or workflow time and cause nondeterminism. v1 uses a small look-ahead
+heuristic to identify empty heartbeat WFTs.
 
-Workflow code, after being woken up, might not do anything, and thus generate no new commands
+That heuristic is ambiguous around Updates. A live worker first receives an Update as a protocol
+message on the current WFT, but replay sees a later `WorkflowExecutionUpdateAccepted` event. The
+acceptance may follow other command events, such as `MarkerRecorded`, so a decision based only on
+the immediately available events can differ between live execution, full replay, and paginated
+replay.
 
-There may be no events for more nuanced reasons:
+The v2 chunker makes the required evidence explicit:
 
-1. The workflow might have been running a long-running local activity. In such cases, the workflow
-   must "workflow task heartbeat" in order to avoid timing out the workflow task. This means
-   completing the WFT with no commands while the LA is ongoing.
-2. The workflow might have received an update, which does not come as an event in history, but
-   rather as a "protocol message" attached to the task.
-3. Server can forcibly generate a new WFT with some obscure APIs
+* An event that can cause workflow code to run prevents the surrounding WFT from being treated as
+  an empty heartbeat.
+* A pending speculative Update keeps the current live WFT separate.
+* On replay, the complete command batch following the successor `WorkflowTaskCompleted` is scanned
+  for `WorkflowExecutionUpdateAccepted`; it need not be the first command event.
+* If a page ends before the command batch or next boundary is complete, the chunker requests more
+  history instead of making a provisional decision.
 
-Core does not consider such empty WFT sequences as worthy of waking lang (on replay - as a new
-task, they always will), since nothing meaningful has happened. Thus, they are grouped together
-as part of a "logical" WFT with the last WFT that had any real work in it.
+Rejected Updates leave no acceptance event. Their validator activation may therefore be absent on
+replay; validators cannot mutate workflow state or emit commands, so that difference is safe.
 
-## Possible issues as of this writing (5/25)
+## Selecting a version
 
-The "new WFT force-issued by server" case would, currently, not cause a wakeup on replay for the
-reasons discussed above. In some obscure edge cases (inspecting workflow clock) this could cause
-NDE.
+The first successful `WorkflowTaskCompleted` event is the only version-selection point for a
+workflow run. Its `sdk_metadata.core_used_flags` determines the rule for the complete history:
 
-### Possible solutions
+* `WftChunkingV2` present: use v2 from the beginning of the run.
+* `WftChunkingV2` absent: use v1 for the lifetime of the run.
 
-* Core can attach a flag on WFT completes in order to be explicit that that WFT may be skipped on
-  replay. IE: During WFT heartbeating for LAs.
-* We could legislate that server should never send empty WFTs. Seemingly the only case of this
-  is
-  the [obscure api](https://github.com/temporalio/temporal/blob/d189737aa2ed1b07c221abb9fbdd28ecf68f0492/proto/internal/temporal/server/api/adminservice/v1/service.proto#L151)
+Failed and timed-out attempts do not select a version. If `WftChunkingV2` first appears after a
+flagless first completion, it has no effect and the run remains on v1. When a partial history does
+not include the selection point and Core has not already latched the version for that run, it must
+fetch history from event 1 before chunking.
+
+The flag in durable history is authoritative. Worker configuration and an attempted completion do
+not select a version because the completion may fail or lose a race.
+
+## Rollout
+
+The v2 reader ships before its writer is enabled. The writer is disabled by default and is opted
+in with `TEMPORAL_USE_WFT_CHUNKING_V2=true` (or `1`). Writing requires a server that advertises SDK
+metadata support and persists `WorkflowTaskCompleted.sdk_metadata.core_used_flags`; without that
+capability, Core must leave the run on v1.
+
+Rollout is reader before writer: first deploy a reader-capable release to every active, standby,
+and rollback worker with the writer disabled; enable the writer only after those versions are the
+minimum supported worker version.
+
+Older workers can silently apply v1 to a flagged history, so they are not safe rollback targets
+after any run adopts v2. Disabling the writer later does not make such workers safe readers.
+
+Runs whose first successful completion is already flagless remain on v1. A long-running workflow
+can adopt v2 by using Continue-As-New, which creates a new run with a new first completion.
+
+This uses existing SDK metadata and does not change the Temporal API or history representation.

--- a/crates/sdk-core/CHANGELOG.md
+++ b/crates/sdk-core/CHANGELOG.md
@@ -51,6 +51,11 @@ relevant information.
   are preserved on failure; workers warn when the server does not advertise support.
 
 ### Fixed
+* Added opt-in Workflow Task chunking v2 to prevent replay boundary divergence around Updates and
+  heartbeat tasks. The writer is disabled by default, is enabled with
+  `TEMPORAL_USE_WFT_CHUNKING_V2`, requires server SDK metadata support, and must be enabled only
+  after every active, standby, and rollback worker has the v2 reader. Runs whose first successful
+  Workflow Task is already complete remain on v1.
 * Workers now warn when autoscaling task polling encounters errors continuously for one minute.
   Repeated warnings use exponential backoff up to 15-minute intervals and stop after polling
   recovers.

--- a/crates/sdk-core/src/core_tests/workflow_tasks.rs
+++ b/crates/sdk-core/src/core_tests/workflow_tasks.rs
@@ -1,6 +1,6 @@
 use crate::{
     PollError, PollWorkflowOptions, Worker, advance_fut,
-    internal_flags::CoreInternalFlags,
+    internal_flags::{CoreInternalFlags, use_wft_chunking_v2_opt_in},
     job_assert,
     replay::{TestHistoryBuilder, canned_histories, default_act_sched, default_wes_attribs},
     test_help::{
@@ -2609,15 +2609,19 @@ async fn core_internal_flags() {
         mock_worker_client(),
     );
     mh.completion_mock_fn = Some(Box::new(move |c| {
+        let mut expected: HashSet<_> = CoreInternalFlags::all_cumulative_default_enabled()
+            .map(|f| f as u32)
+            .collect();
+        if use_wft_chunking_v2_opt_in() {
+            expected.insert(CoreInternalFlags::WftChunkingV2 as u32);
+        }
         assert_eq!(
             c.sdk_metadata
                 .core_used_flags
                 .iter()
                 .copied()
                 .collect::<HashSet<_>>(),
-            CoreInternalFlags::all_except_too_high()
-                .map(|f| f as u32)
-                .collect()
+            expected
         );
         Ok(Default::default())
     }));
@@ -2628,6 +2632,47 @@ async fn core_internal_flags() {
     let act = core.poll_workflow_activation().await.unwrap();
     core.complete_execution(&act.run_id).await;
     core.shutdown().await;
+}
+
+#[tokio::test]
+async fn unknown_first_completion_flag_fails_polled_task() {
+    let mut t = TestHistoryBuilder::default();
+    t.add_by_type(EventType::WorkflowExecutionStarted);
+    t.add_full_wf_task();
+    t.add_workflow_task_scheduled_and_started();
+    t.modify_event(4, |event| {
+        let Some(history_event::Attributes::WorkflowTaskCompletedEventAttributes(attrs)) =
+            event.attributes.as_mut()
+        else {
+            panic!("event 4 must be WorkflowTaskCompleted");
+        };
+        attrs
+            .sdk_metadata
+            .get_or_insert_default()
+            .core_used_flags
+            .push(1_000_000);
+    });
+    let mut mh = MockPollCfg::from_resp_batches(
+        "unknown-chunker",
+        t,
+        [ResponseType::AllHistory, ResponseType::AllHistory],
+        mock_worker_client(),
+    );
+    mh.num_expected_completions = Some(TimesRange::from(0));
+    mh.num_expected_fails = 2;
+    mh.expect_fail_wft_matcher = Box::new(|_, cause, failure| {
+        *cause == WorkflowTaskFailedCause::NonDeterministicError
+            && failure.as_ref().is_some_and(|failure| {
+                failure.message.contains("1000000") && failure.message.contains("event 4")
+            })
+    });
+    let worker = mock_worker(build_mock_pollers(mh));
+
+    assert_matches!(
+        worker.poll_workflow_activation().await,
+        Err(PollError::ShutDown)
+    );
+    worker.shutdown().await;
 }
 
 #[tokio::test]

--- a/crates/sdk-core/src/core_tests/workflow_tasks.rs
+++ b/crates/sdk-core/src/core_tests/workflow_tasks.rs
@@ -15,6 +15,7 @@ use crate::{
         PollerBehavior, SlotMarkUsedContext, SlotReleaseContext, SlotReservationContext,
         SlotSupplier, SlotSupplierPermit, TunerBuilder, WorkflowSlotKind,
         client::mocks::{mock_manual_worker_client, mock_worker_client},
+        parse_wft_chunking_v2_opt_in,
     },
 };
 use futures_util::{FutureExt, stream};
@@ -2612,10 +2613,11 @@ async fn core_internal_flags() {
         let mut expected: HashSet<_> = CoreInternalFlags::all_cumulative_default_enabled()
             .map(|f| f as u32)
             .collect();
-        if std::env::var("TEMPORAL_USE_WFT_CHUNKING_V2")
-            .ok()
-            .is_some_and(|value| matches!(value.to_ascii_lowercase().as_str(), "true" | "1"))
-        {
+        if parse_wft_chunking_v2_opt_in(
+            std::env::var("TEMPORAL_USE_WFT_CHUNKING_V2")
+                .ok()
+                .as_deref(),
+        ) {
             expected.insert(CoreInternalFlags::WftChunkingV2 as u32);
         }
         assert_eq!(

--- a/crates/sdk-core/src/core_tests/workflow_tasks.rs
+++ b/crates/sdk-core/src/core_tests/workflow_tasks.rs
@@ -1,6 +1,6 @@
 use crate::{
     PollError, PollWorkflowOptions, Worker, advance_fut,
-    internal_flags::{CoreInternalFlags, use_wft_chunking_v2_opt_in},
+    internal_flags::CoreInternalFlags,
     job_assert,
     replay::{TestHistoryBuilder, canned_histories, default_act_sched, default_wes_attribs},
     test_help::{
@@ -2612,7 +2612,10 @@ async fn core_internal_flags() {
         let mut expected: HashSet<_> = CoreInternalFlags::all_cumulative_default_enabled()
             .map(|f| f as u32)
             .collect();
-        if use_wft_chunking_v2_opt_in() {
+        if std::env::var("TEMPORAL_USE_WFT_CHUNKING_V2")
+            .ok()
+            .is_some_and(|value| matches!(value.to_ascii_lowercase().as_str(), "true" | "1"))
+        {
             expected.insert(CoreInternalFlags::WftChunkingV2 as u32);
         }
         assert_eq!(

--- a/crates/sdk-core/src/internal_flags.rs
+++ b/crates/sdk-core/src/internal_flags.rs
@@ -1,10 +1,7 @@
 //! Utilities for and tracking of internal versions which alter history in incompatible ways
 //! so that we can use older code paths for workflows executed on older core versions.
 
-use std::{
-    collections::{BTreeSet, HashSet},
-    sync::OnceLock,
-};
+use std::collections::{BTreeSet, HashSet};
 use temporalio_common::protos::temporal::api::{
     history::v1::WorkflowTaskCompletedEventAttributes, sdk::v1::WorkflowTaskCompletedMetadata,
     workflowservice::v1::get_system_info_response,
@@ -62,13 +59,10 @@ impl InternalFlags {
         server_capabilities: &get_system_info_response::Capabilities,
         sdk_name: String,
         sdk_version: String,
-        record_first_wft_flags: bool,
+        record_wft_chunking_v2: bool,
     ) -> Self {
         let mut core_since_last_complete = HashSet::new();
-        if server_capabilities.sdk_metadata
-            && record_first_wft_flags
-            && use_wft_chunking_v2_opt_in()
-        {
+        if server_capabilities.sdk_metadata && record_wft_chunking_v2 {
             core_since_last_complete.insert(CoreInternalFlags::WftChunkingV2);
         }
         Self {
@@ -223,19 +217,6 @@ impl CoreInternalFlags {
     }
 }
 
-const USE_WFT_CHUNKING_V2_ENV_VAR: &str = "TEMPORAL_USE_WFT_CHUNKING_V2";
-
-fn parse_wft_chunking_v2_opt_in(value: Option<&str>) -> bool {
-    value.is_some_and(|value| matches!(value.to_ascii_lowercase().as_str(), "true" | "1"))
-}
-
-pub(crate) fn use_wft_chunking_v2_opt_in() -> bool {
-    static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| {
-        parse_wft_chunking_v2_opt_in(std::env::var(USE_WFT_CHUNKING_V2_ENV_VAR).ok().as_deref())
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -302,16 +283,6 @@ mod tests {
     }
 
     #[test]
-    fn chunking_v2_opt_in_requires_explicit_truthy_value() {
-        for value in [Some("true"), Some("TRUE"), Some("1")] {
-            assert!(parse_wft_chunking_v2_opt_in(value));
-        }
-        for value in [None, Some(""), Some("false"), Some("0"), Some("yes")] {
-            assert!(!parse_wft_chunking_v2_opt_in(value));
-        }
-    }
-
-    #[test]
     fn chunking_v2_stays_staged_until_first_completion_is_observed() {
         let mut flags = InternalFlags::new(
             &Capabilities {
@@ -320,11 +291,8 @@ mod tests {
             },
             "name".to_string(),
             "ver".to_string(),
-            false,
+            true,
         );
-        flags
-            .core_since_last_complete
-            .insert(CoreInternalFlags::WftChunkingV2);
 
         assert_eq!(
             flags.gather_for_wft_complete().core_used_flags,

--- a/crates/sdk-core/src/internal_flags.rs
+++ b/crates/sdk-core/src/internal_flags.rs
@@ -1,7 +1,10 @@
 //! Utilities for and tracking of internal versions which alter history in incompatible ways
 //! so that we can use older code paths for workflows executed on older core versions.
 
-use std::collections::{BTreeSet, HashSet};
+use std::{
+    collections::{BTreeSet, HashSet},
+    sync::OnceLock,
+};
 use temporalio_common::protos::temporal::api::{
     history::v1::WorkflowTaskCompletedEventAttributes, sdk::v1::WorkflowTaskCompletedMetadata,
     workflowservice::v1::get_system_info_response,
@@ -33,6 +36,10 @@ pub enum CoreInternalFlags {
     /// if in the sequence delivered by lang they came after a terminal command.
     /// See <https://github.com/temporalio/features/issues/481>.
     MoveTerminalCommands = 3,
+    /// Selects the second-generation workflow-task history chunker for this run. This flag is
+    /// valid only on the run's first successful workflow-task completion, because changing
+    /// chunkers after workflow code has already executed would reinterpret earlier activations.
+    WftChunkingV2 = 4,
     /// We received a value higher than this code can understand.
     TooHigh = u32::MAX,
 }
@@ -55,12 +62,20 @@ impl InternalFlags {
         server_capabilities: &get_system_info_response::Capabilities,
         sdk_name: String,
         sdk_version: String,
+        record_first_wft_flags: bool,
     ) -> Self {
+        let mut core_since_last_complete = HashSet::new();
+        if server_capabilities.sdk_metadata
+            && record_first_wft_flags
+            && use_wft_chunking_v2_opt_in()
+        {
+            core_since_last_complete.insert(CoreInternalFlags::WftChunkingV2);
+        }
         Self {
             can_write_sdk_metadata: server_capabilities.sdk_metadata,
             core: Default::default(),
             lang: Default::default(),
-            core_since_last_complete: Default::default(),
+            core_since_last_complete,
             lang_since_last_complete: Default::default(),
             last_sdk_name: "".to_string(),
             last_sdk_version: "".to_string(),
@@ -70,6 +85,11 @@ impl InternalFlags {
     }
 
     pub(crate) fn add_from_complete(&mut self, e: &WorkflowTaskCompletedEventAttributes) {
+        // The first durable successful completion decides the run's chunker. Keep offering a
+        // staged flag across failed/ambiguous completion RPCs, but never move it to a later WFT if
+        // another worker wins the first completion without it.
+        self.core_since_last_complete
+            .remove(&CoreInternalFlags::WftChunkingV2);
         if let Some(metadata) = e.sdk_metadata.as_ref() {
             self.core.extend(
                 metadata
@@ -108,12 +128,12 @@ impl InternalFlags {
         }
     }
 
-    /// Writes all known core flags to the set which should be recorded in the current WFT if not
-    /// already known. Must only be called if not replaying.
+    /// Stages the cumulative, default-enabled flags. The first-WFT-only chunker flag is staged
+    /// separately at construction because it must never move to a later completion.
     pub(crate) fn write_all_known(&mut self) {
         if self.can_write_sdk_metadata {
             self.core_since_last_complete
-                .extend(CoreInternalFlags::all_except_too_high());
+                .extend(CoreInternalFlags::all_cumulative_default_enabled());
         }
     }
 
@@ -136,7 +156,14 @@ impl InternalFlags {
             .filter(|f| !self.lang.contains(f))
             .copied()
             .collect();
-        self.core.extend(self.core_since_last_complete.iter());
+        // Unlike ordinary capability flags, merely attempting to write the chunker flag cannot
+        // select it: the completion may fail or lose a race. It becomes observed only when read
+        // back through `add_from_complete`.
+        self.core.extend(
+            self.core_since_last_complete
+                .iter()
+                .filter(|flag| **flag != CoreInternalFlags::WftChunkingV2),
+        );
         self.lang.extend(self.lang_since_last_complete.iter());
         let sdk_name = if self.last_sdk_name != self.sdk_name {
             self.sdk_name.clone()
@@ -170,19 +197,43 @@ impl InternalFlags {
 }
 
 impl CoreInternalFlags {
-    fn from_u32(v: u32) -> Self {
+    pub(crate) fn from_u32(v: u32) -> Self {
         match v {
             1 => Self::IdAndTypeDeterminismChecks,
             2 => Self::UpsertSearchAttributeOnPatch,
             3 => Self::MoveTerminalCommands,
+            4 => Self::WftChunkingV2,
             _ => Self::TooHigh,
         }
     }
 
+    pub(crate) fn all_cumulative_default_enabled() -> impl Iterator<Item = CoreInternalFlags> {
+        [
+            Self::IdAndTypeDeterminismChecks,
+            Self::UpsertSearchAttributeOnPatch,
+            Self::MoveTerminalCommands,
+        ]
+        .into_iter()
+    }
+
+    #[cfg(test)]
     pub(crate) fn all_except_too_high() -> impl Iterator<Item = CoreInternalFlags> {
         enum_iterator::all::<CoreInternalFlags>()
             .filter(|f| !matches!(f, CoreInternalFlags::TooHigh))
     }
+}
+
+const USE_WFT_CHUNKING_V2_ENV_VAR: &str = "TEMPORAL_USE_WFT_CHUNKING_V2";
+
+fn parse_wft_chunking_v2_opt_in(value: Option<&str>) -> bool {
+    value.is_some_and(|value| matches!(value.to_ascii_lowercase().as_str(), "true" | "1"))
+}
+
+pub(crate) fn use_wft_chunking_v2_opt_in() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        parse_wft_chunking_v2_opt_in(std::env::var(USE_WFT_CHUNKING_V2_ENV_VAR).ok().as_deref())
+    })
 }
 
 #[cfg(test)]
@@ -192,7 +243,12 @@ mod tests {
 
     impl Default for InternalFlags {
         fn default() -> Self {
-            Self::new(&Capabilities::default(), "".to_string(), "".to_string())
+            Self::new(
+                &Capabilities::default(),
+                "".to_string(),
+                "".to_string(),
+                false,
+            )
         }
     }
 
@@ -202,6 +258,7 @@ mod tests {
             &Capabilities::default(),
             "name".to_string(),
             "ver".to_string(),
+            false,
         );
         f.add_from_complete(&WorkflowTaskCompletedEventAttributes {
             sdk_metadata: Some(WorkflowTaskCompletedMetadata {
@@ -223,6 +280,7 @@ mod tests {
             &Capabilities::default(),
             "name".to_string(),
             "ver".to_string(),
+            false,
         );
         f.add_lang_used([1]);
 
@@ -244,6 +302,44 @@ mod tests {
     }
 
     #[test]
+    fn chunking_v2_opt_in_requires_explicit_truthy_value() {
+        for value in [Some("true"), Some("TRUE"), Some("1")] {
+            assert!(parse_wft_chunking_v2_opt_in(value));
+        }
+        for value in [None, Some(""), Some("false"), Some("0"), Some("yes")] {
+            assert!(!parse_wft_chunking_v2_opt_in(value));
+        }
+    }
+
+    #[test]
+    fn chunking_v2_stays_staged_until_first_completion_is_observed() {
+        let mut flags = InternalFlags::new(
+            &Capabilities {
+                sdk_metadata: true,
+                ..Default::default()
+            },
+            "name".to_string(),
+            "ver".to_string(),
+            false,
+        );
+        flags
+            .core_since_last_complete
+            .insert(CoreInternalFlags::WftChunkingV2);
+
+        assert_eq!(
+            flags.gather_for_wft_complete().core_used_flags,
+            vec![CoreInternalFlags::WftChunkingV2 as u32]
+        );
+        assert_eq!(
+            flags.gather_for_wft_complete().core_used_flags,
+            vec![CoreInternalFlags::WftChunkingV2 as u32]
+        );
+
+        flags.add_from_complete(&WorkflowTaskCompletedEventAttributes::default());
+        assert!(flags.gather_for_wft_complete().core_used_flags.is_empty());
+    }
+
+    #[test]
     fn only_writes_new_flags_and_sdk_info() {
         let mut f = InternalFlags::new(
             &Capabilities {
@@ -252,6 +348,7 @@ mod tests {
             },
             "name".to_string(),
             "ver".to_string(),
+            false,
         );
         f.add_lang_used([1]);
         f.try_use(CoreInternalFlags::IdAndTypeDeterminismChecks, true);

--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -42,6 +42,8 @@ pub(crate) use wft_poller::WFTPollerShared;
 
 #[allow(unreachable_pub)] // re-exported in test_help::integ_helpers
 pub use workflow::LEGACY_QUERY_ID;
+#[cfg(test)]
+pub(crate) use workflow::parse_wft_chunking_v2_opt_in;
 
 use crate::{
     ActivityHeartbeat,

--- a/crates/sdk-core/src/worker/workflow/history_update.rs
+++ b/crates/sdk-core/src/worker/workflow/history_update.rs
@@ -1,4 +1,5 @@
 use crate::{
+    internal_flags::CoreInternalFlags,
     protosext::ValidPollWFTQResponse,
     worker::{
         client::WorkerClient,
@@ -7,14 +8,15 @@ use crate::{
 };
 use futures_util::{FutureExt, Stream, TryFutureExt, future::BoxFuture};
 use itertools::Itertools;
+use parking_lot::Mutex;
 use std::{
-    collections::VecDeque,
+    collections::{HashMap, VecDeque},
     fmt::Debug,
     future::Future,
     mem,
     mem::transmute,
     pin::Pin,
-    sync::{Arc, LazyLock},
+    sync::{Arc, LazyLock, Weak},
     task::{Context, Poll},
 };
 use temporalio_common::protos::temporal::api::{
@@ -30,6 +32,23 @@ static EMPTY_FETCH_ERR: LazyLock<tonic::Status> =
 static EMPTY_TASK_ERR: LazyLock<tonic::Status> = LazyLock::new(|| {
     tonic::Status::unknown("Received an empty workflow task with no queries or history")
 });
+// A server RPC may use the same tonic code, so only errors marked locally are nondeterminism.
+const INCOMPATIBLE_HISTORY_STATUS_KEY: &str = "temporal-incompatible-history";
+
+pub(crate) fn is_incompatible_history_status(status: &tonic::Status) -> bool {
+    status
+        .metadata()
+        .contains_key(INCOMPATIBLE_HISTORY_STATUS_KEY)
+}
+
+fn incompatible_history_status(message: String) -> tonic::Status {
+    let mut status = tonic::Status::failed_precondition(message);
+    status.metadata_mut().insert(
+        INCOMPATIBLE_HISTORY_STATUS_KEY,
+        tonic::metadata::MetadataValue::from_static("true"),
+    );
+    status
+}
 
 /// Represents one or more complete WFT sequences. History events are expected to be consumed from
 /// it and applied to the state machines via [HistoryUpdate::take_next_wft_sequence]
@@ -46,6 +65,8 @@ pub(crate) struct HistoryUpdate {
     /// additional updates should be made.
     has_last_wft: bool,
     wft_count: usize,
+    has_pending_speculative_updates: bool,
+    use_chunking_v2: bool,
 }
 
 impl Debug for HistoryUpdate {
@@ -79,6 +100,75 @@ pub(crate) enum NextWFT {
     NeedFetch,
 }
 
+/// Immutable, run-wide chunker choice. Only the first successful WFT completion can move this
+/// from `Unknown`; failed attempts do not select a version, and later metadata cannot change it.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum WFTChunkingVersion {
+    #[default]
+    Unknown,
+    V1,
+    V2,
+}
+
+type WFTChunkingVersionLatch = Arc<Mutex<WFTChunkingVersion>>;
+
+/// Keeps the one-time version choice available while a run is cached. Dead entries are pruned on
+/// lookup so the registry does not retain completed run IDs.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct WFTChunkingVersionRegistry {
+    inner: Arc<Mutex<WFTChunkingVersionRegistryInner>>,
+}
+
+#[derive(Debug, Default)]
+struct WFTChunkingVersionRegistryInner {
+    versions: HashMap<String, Weak<Mutex<WFTChunkingVersion>>>,
+    lookups_since_prune: usize,
+}
+
+impl WFTChunkingVersionRegistry {
+    fn get_or_create(&self, run_id: &str) -> WFTChunkingVersionLatch {
+        let mut inner = self.inner.lock();
+        inner.lookups_since_prune += 1;
+        // Most entries are live for the cache lifetime, so scanning the entire registry on every
+        // poll would make task intake quadratic in cache size. Periodic pruning bounds stale IDs
+        // while keeping the ordinary lookup constant-time.
+        if inner.lookups_since_prune >= 1024 {
+            inner
+                .versions
+                .retain(|_, version| version.strong_count() > 0);
+            inner.lookups_since_prune = 0;
+        }
+        if let Some(version) = inner.versions.get(run_id).and_then(Weak::upgrade) {
+            return version;
+        }
+        let version = Arc::new(Mutex::new(WFTChunkingVersion::Unknown));
+        inner
+            .versions
+            .insert(run_id.to_string(), Arc::downgrade(&version));
+        version
+    }
+
+    /// Avoids an event-1 fetch on the next sticky task after this worker successfully records the
+    /// first completion. An ambiguous response must not call this; history remains authoritative.
+    pub(crate) fn record_successful_completion(&self, run_id: &str, used_v2: bool) {
+        let version = {
+            let inner = self.inner.lock();
+            inner.versions.get(run_id).and_then(Weak::upgrade)
+        };
+        let Some(version) = version else {
+            return;
+        };
+        let mut version = version.lock();
+        if *version == WFTChunkingVersion::Unknown {
+            *version = if used_v2 {
+                WFTChunkingVersion::V2
+            } else {
+                WFTChunkingVersion::V1
+            };
+        }
+    }
+}
+
 #[derive(derive_more::Debug)]
 #[debug("HistoryPaginator(run_id: {run_id})")]
 pub(crate) struct HistoryPaginator {
@@ -94,6 +184,12 @@ pub(crate) struct HistoryPaginator {
     /// These are events that should be returned once pagination has finished. This only happens
     /// during cache misses, where we got a partial task but need to fetch history from the start.
     final_events: Vec<HistoryEvent>,
+    has_pending_speculative_updates: bool,
+    use_chunking_v2: bool,
+    chunking_version: WFTChunkingVersionLatch,
+    can_select_chunking_version: bool,
+    should_record_first_wft_flags: bool,
+    requires_full_history_for_chunking_version: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -123,6 +219,7 @@ impl HistoryPaginator {
     pub(super) async fn from_poll(
         wft: ValidPollWFTQResponse,
         client: Arc<dyn WorkerClient>,
+        chunking_versions: WFTChunkingVersionRegistry,
     ) -> Result<(Self, PreparedWFT), tonic::Status> {
         let empty_hist = wft.history.events.is_empty();
         let npt = if empty_hist {
@@ -130,7 +227,8 @@ impl HistoryPaginator {
         } else {
             wft.next_page_token.into()
         };
-        let mut paginator = HistoryPaginator::new(
+        let has_pending_speculative_updates = !wft.messages.is_empty();
+        let mut paginator = HistoryPaginator::new_with_registry(
             wft.history,
             wft.previous_started_event_id,
             wft.started_event_id,
@@ -138,11 +236,24 @@ impl HistoryPaginator {
             wft.workflow_execution.run_id.clone(),
             npt,
             client,
+            has_pending_speculative_updates,
+            Some(chunking_versions),
         );
         if empty_hist && wft.legacy_query.is_none() && wft.query_requests.is_empty() {
             return Err(EMPTY_TASK_ERR.clone());
         }
-        let update = if empty_hist {
+        let update = if paginator.requires_full_history_for_chunking_version {
+            // Preserve the suffix verbatim until event 1 establishes the immutable version.
+            HistoryUpdate {
+                events: mem::take(&mut paginator.final_events),
+                previous_wft_started_id: wft.previous_started_event_id,
+                wft_started_id: wft.started_event_id,
+                has_last_wft: false,
+                wft_count: 0,
+                has_pending_speculative_updates,
+                use_chunking_v2: false,
+            }
+        } else if empty_hist {
             HistoryUpdate::from_events(
                 [],
                 wft.previous_started_event_id,
@@ -170,6 +281,8 @@ impl HistoryPaginator {
         mut req: Box<CacheMissFetchReq>,
         client: Arc<dyn WorkerClient>,
     ) -> Result<PermittedWFT, tonic::Status> {
+        let chunking_version = req.original_wft.paginator.chunking_version.clone();
+        let use_chunking_v2 = *chunking_version.lock() == WFTChunkingVersion::V2;
         let mut paginator = Self {
             wf_id: req.original_wft.work.execution.workflow_id.clone(),
             run_id: req.original_wft.work.execution.run_id.clone(),
@@ -183,6 +296,12 @@ impl HistoryPaginator {
             event_queue: Default::default(),
             next_page_token: NextPageToken::FetchFromStart,
             final_events: req.original_wft.work.update.events,
+            has_pending_speculative_updates: !req.original_wft.work.messages.is_empty(),
+            use_chunking_v2,
+            chunking_version,
+            can_select_chunking_version: true,
+            should_record_first_wft_flags: false,
+            requires_full_history_for_chunking_version: false,
         };
         let first_update = paginator.extract_next_update().await?;
         req.original_wft.work.update = first_update;
@@ -190,6 +309,7 @@ impl HistoryPaginator {
         Ok(req.original_wft)
     }
 
+    #[cfg(test)]
     fn new(
         initial_history: History,
         previous_wft_started_id: i64,
@@ -199,7 +319,49 @@ impl HistoryPaginator {
         next_page_token: impl Into<NextPageToken>,
         client: Arc<dyn WorkerClient>,
     ) -> Self {
-        let next_page_token = next_page_token.into();
+        Self::new_with_registry(
+            initial_history,
+            previous_wft_started_id,
+            wft_started_event_id,
+            wf_id,
+            run_id,
+            next_page_token,
+            client,
+            false,
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_with_registry(
+        initial_history: History,
+        previous_wft_started_id: i64,
+        wft_started_event_id: i64,
+        wf_id: String,
+        run_id: String,
+        next_page_token: impl Into<NextPageToken>,
+        client: Arc<dyn WorkerClient>,
+        has_pending_speculative_updates: bool,
+        chunking_versions: Option<WFTChunkingVersionRegistry>,
+    ) -> Self {
+        let mut next_page_token = next_page_token.into();
+        let chunking_version = chunking_versions.map_or_else(
+            || Arc::new(Mutex::new(WFTChunkingVersion::Unknown)),
+            |versions| versions.get_or_create(&run_id),
+        );
+        let starts_at_beginning = initial_history
+            .events
+            .first()
+            .is_some_and(|event| event.event_id == 1);
+        let version = *chunking_version.lock();
+        let requires_full_history_for_chunking_version = version == WFTChunkingVersion::Unknown
+            && !starts_at_beginning
+            && !matches!(next_page_token, NextPageToken::FetchFromStart);
+        if requires_full_history_for_chunking_version {
+            next_page_token = NextPageToken::FetchFromStart;
+        }
+        let can_select_chunking_version =
+            starts_at_beginning || matches!(next_page_token, NextPageToken::FetchFromStart);
         let (event_queue, final_events) =
             if matches!(next_page_token, NextPageToken::FetchFromStart) {
                 (VecDeque::new(), initial_history.events)
@@ -216,7 +378,72 @@ impl HistoryPaginator {
             previous_wft_started_id,
             wft_started_event_id,
             id_of_last_event_in_last_extracted_update: None,
+            has_pending_speculative_updates,
+            use_chunking_v2: version == WFTChunkingVersion::V2,
+            chunking_version,
+            can_select_chunking_version,
+            should_record_first_wft_flags: false,
+            requires_full_history_for_chunking_version,
         }
+    }
+
+    /// Mutates the shared selector only from an authoritative prefix beginning at event 1. Until
+    /// the first successful completion or end of history is visible, no page may be chunked: a v2
+    /// flag on a later page applies to the entire run.
+    fn discover_chunking_version(
+        &mut self,
+        events: &VecDeque<HistoryEvent>,
+        at_end: bool,
+    ) -> Result<(), tonic::Status> {
+        if !self.can_select_chunking_version {
+            self.use_chunking_v2 = *self.chunking_version.lock() == WFTChunkingVersion::V2;
+            return Ok(());
+        }
+        let first_completion = events.iter().find_map(|event| match &event.attributes {
+            Some(Attributes::WorkflowTaskCompletedEventAttributes(attrs)) => {
+                Some((event.event_id, attrs))
+            }
+            _ => None,
+        });
+        if let Some((event_id, completion)) = first_completion {
+            if let Some(flag) = completion
+                .sdk_metadata
+                .iter()
+                .flat_map(|metadata| &metadata.core_used_flags)
+                .find(|flag| CoreInternalFlags::from_u32(**flag) == CoreInternalFlags::TooHigh)
+            {
+                return Err(incompatible_history_status(format!(
+                    "Workflow history has unknown Core flag {flag} on first Workflow Task completion event {event_id}"
+                )));
+            }
+            let selected = if completion.sdk_metadata.as_ref().is_some_and(|metadata| {
+                metadata
+                    .core_used_flags
+                    .contains(&(CoreInternalFlags::WftChunkingV2 as u32))
+            }) {
+                WFTChunkingVersion::V2
+            } else {
+                WFTChunkingVersion::V1
+            };
+            let mut shared = self.chunking_version.lock();
+            if *shared == WFTChunkingVersion::Unknown {
+                *shared = selected;
+            }
+            self.use_chunking_v2 = *shared == WFTChunkingVersion::V2;
+            self.can_select_chunking_version = false;
+        } else if at_end {
+            self.should_record_first_wft_flags = true;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn should_record_first_wft_flags(&self) -> bool {
+        self.should_record_first_wft_flags
+            && *self.chunking_version.lock() == WFTChunkingVersion::Unknown
+    }
+
+    pub(crate) fn requires_full_history_for_chunking_version(&self) -> bool {
+        self.requires_full_history_for_chunking_version
     }
 
     /// Return at least the next two WFT sequences (as determined by the passed-in ID) as a
@@ -232,6 +459,16 @@ impl HistoryPaginator {
         loop {
             let no_next_page = !self.get_next_page().await?;
             let current_events = mem::take(&mut self.event_queue);
+            self.discover_chunking_version(&current_events, no_next_page)?;
+            if !no_next_page
+                && self.can_select_chunking_version
+                && *self.chunking_version.lock() == WFTChunkingVersion::Unknown
+            {
+                // V2 applies from event 1, so no replay boundary may escape before the first
+                // successful completion has selected the run's immutable version.
+                self.event_queue = current_events;
+                continue;
+            }
             let seen_enough_events = current_events
                 .back()
                 .map(|e| e.event_id)
@@ -256,11 +493,13 @@ impl HistoryPaginator {
             if current_events.is_empty() && no_next_page && already_sent_update_with_enough_events {
                 // We must return an empty update which also says is contains the final WFT so we
                 // know we're done with replay.
-                return Ok(HistoryUpdate::from_events(
+                return Ok(HistoryUpdate::from_events_with_options(
                     [],
                     self.previous_wft_started_id,
                     self.wft_started_event_id,
                     true,
+                    self.has_pending_speculative_updates,
+                    self.use_chunking_v2,
                 )
                 .0);
             }
@@ -282,19 +521,25 @@ impl HistoryPaginator {
             // We only *really* have the last WFT if the events go all the way up to at least the
             // WFT started event id. Otherwise we somehow still have partial history.
             let no_more = matches!(self.next_page_token, NextPageToken::Done) && seen_enough_events;
-            let (update, extra) = HistoryUpdate::from_events(
+            let (update, extra) = HistoryUpdate::from_events_with_options(
                 current_events,
                 self.previous_wft_started_id,
                 self.wft_started_event_id,
                 no_more,
+                self.has_pending_speculative_updates,
+                self.use_chunking_v2,
             );
 
             // If there are potentially more events and we haven't extracted two WFTs yet, keep
             // trying.
             if !matches!(self.next_page_token, NextPageToken::Done) && update.wft_count < 2 {
-                // Unwrap the update and stuff it all back in the queue
+                let update_back_id = update.events.last().map(|event| event.event_id);
                 self.event_queue.extend(update.events);
-                self.event_queue.extend(extra);
+                self.event_queue.extend(
+                    extra
+                        .into_iter()
+                        .skip_while(|event| update_back_id.is_some_and(|id| event.event_id <= id)),
+                );
                 continue;
             }
 
@@ -440,6 +685,8 @@ impl HistoryUpdate {
             wft_started_id: -1,
             has_last_wft: false,
             wft_count: 0,
+            has_pending_speculative_updates: false,
+            use_chunking_v2: false,
         }
     }
 
@@ -478,11 +725,34 @@ impl HistoryUpdate {
     where
         <I as IntoIterator>::IntoIter: Send + 'static,
     {
+        Self::from_events_with_options(
+            events,
+            previous_wft_started_id,
+            wft_started_id,
+            has_last_wft,
+            false,
+            false,
+        )
+    }
+
+    fn from_events_with_options<I: IntoIterator<Item = HistoryEvent>>(
+        events: I,
+        previous_wft_started_id: i64,
+        wft_started_id: i64,
+        has_last_wft: bool,
+        has_pending_speculative_updates: bool,
+        use_chunking_v2: bool,
+    ) -> (Self, Vec<HistoryEvent>)
+    where
+        <I as IntoIterator>::IntoIter: Send + 'static,
+    {
         let mut all_events: Vec<_> = events.into_iter().collect();
         let mut last_end = find_end_index_of_next_wft_seq(
             all_events.as_slice(),
             previous_wft_started_id,
             has_last_wft,
+            has_pending_speculative_updates,
+            use_chunking_v2,
         );
         if matches!(last_end, NextWFTSeqEndIndex::Incomplete(_)) {
             return if has_last_wft {
@@ -493,6 +763,8 @@ impl HistoryUpdate {
                         wft_started_id,
                         has_last_wft,
                         wft_count: 1,
+                        has_pending_speculative_updates,
+                        use_chunking_v2,
                     },
                     vec![],
                 )
@@ -504,6 +776,8 @@ impl HistoryUpdate {
                         wft_started_id,
                         has_last_wft,
                         wft_count: 0,
+                        has_pending_speculative_updates,
+                        use_chunking_v2,
                     },
                     all_events,
                 )
@@ -519,6 +793,8 @@ impl HistoryUpdate {
                 &all_events[next_end_ix..],
                 next_end_eid,
                 has_last_wft,
+                has_pending_speculative_updates,
+                use_chunking_v2,
             )
             .add(next_end_ix);
             if matches!(next_end, NextWFTSeqEndIndex::Incomplete(_)) {
@@ -530,6 +806,8 @@ impl HistoryUpdate {
         // they must be considered part of the last sequence
         let remaining_events = if all_events.is_empty() || has_last_wft {
             vec![]
+        } else if use_chunking_v2 {
+            all_events[last_end.index() + 1..].to_vec()
         } else {
             all_events.split_off(last_end.index() + 1)
         };
@@ -541,6 +819,8 @@ impl HistoryUpdate {
                 wft_started_id,
                 has_last_wft,
                 wft_count,
+                has_pending_speculative_updates,
+                use_chunking_v2,
             },
             remaining_events,
         )
@@ -564,6 +844,8 @@ impl HistoryUpdate {
             wft_started_id,
             has_last_wft: true,
             wft_count: 0,
+            has_pending_speculative_updates: false,
+            use_chunking_v2: false,
         }
     }
 
@@ -579,8 +861,13 @@ impl HistoryUpdate {
         if let Some(ix_first_relevant) = self.starting_index_after_skipping(from_wft_started_id) {
             self.events.drain(0..ix_first_relevant);
         }
-        let next_wft_ix =
-            find_end_index_of_next_wft_seq(&self.events, from_wft_started_id, self.has_last_wft);
+        let next_wft_ix = find_end_index_of_next_wft_seq(
+            &self.events,
+            from_wft_started_id,
+            self.has_last_wft,
+            self.has_pending_speculative_updates,
+            self.use_chunking_v2,
+        );
         match next_wft_ix {
             NextWFTSeqEndIndex::Incomplete(siz) => {
                 if self.has_last_wft {
@@ -590,7 +877,7 @@ impl HistoryUpdate {
                         self.build_next_wft(siz)
                     }
                 } else {
-                    if siz != 0 {
+                    if siz != 0 && !self.use_chunking_v2 {
                         panic!(
                             "HistoryUpdate was created with an incomplete WFT. This is an SDK bug."
                         );
@@ -613,6 +900,7 @@ impl HistoryUpdate {
     /// [take_next_wft_sequence]. Will always return the first available WFT sequence if that has
     /// not been called first. May also return an empty iterator or incomplete sequence if we are at
     /// the end of history.
+    #[cfg(test)]
     pub(crate) fn peek_next_wft_sequence(&self, from_wft_started_id: i64) -> &[HistoryEvent] {
         let ix_first_relevant = self
             .starting_index_after_skipping(from_wft_started_id)
@@ -621,17 +909,44 @@ impl HistoryUpdate {
         if relevant_events.is_empty() {
             return relevant_events;
         }
-        let ix_end =
-            find_end_index_of_next_wft_seq(relevant_events, from_wft_started_id, self.has_last_wft)
-                .index();
+        let ix_end = find_end_index_of_next_wft_seq(
+            relevant_events,
+            from_wft_started_id,
+            self.has_last_wft,
+            self.has_pending_speculative_updates,
+            self.use_chunking_v2,
+        )
+        .index();
         &relevant_events[0..=ix_end]
+    }
+
+    /// Machine lookahead needs the command batch following the WFT just consumed, not the later
+    /// events v2 may retain only as proof of a stable chunk boundary.
+    pub(crate) fn peek_next_wft_commands(&self, from_wft_started_id: i64) -> &[HistoryEvent] {
+        let start = self
+            .starting_index_after_skipping(from_wft_started_id)
+            .unwrap_or_default();
+        let events = &self.events[start..];
+        if events.first().map(HistoryEvent::event_type) != Some(EventType::WorkflowTaskCompleted) {
+            return &[];
+        }
+        let count = events[1..]
+            .iter()
+            .take_while(|event| is_command_or_ignorable_unknown(event))
+            .count();
+        &events[1..1 + count]
     }
 
     /// Returns true if this update has the next needed WFT sequence, false if events will need to
     /// be fetched in order to create a complete update with the entire next WFT sequence.
     pub(crate) fn can_take_next_wft_sequence(&self, from_wft_started_id: i64) -> bool {
-        let next_wft_ix =
-            find_end_index_of_next_wft_seq(&self.events, from_wft_started_id, self.has_last_wft);
+        let next_wft_ix = find_end_index_of_next_wft_seq(
+            &self.events,
+            from_wft_started_id,
+            self.has_last_wft,
+            self.has_pending_speculative_updates,
+            self.use_chunking_v2,
+        );
         if let NextWFTSeqEndIndex::Incomplete(_) = next_wft_ix
             && !self.has_last_wft
         {
@@ -685,9 +1000,27 @@ impl NextWFTSeqEndIndex {
     }
 }
 
-/// Discovers the index of the last event in next WFT sequence within the passed-in slice
-/// For more on workflow task chunking, see arch_docs/workflow_task_chunking.md
 fn find_end_index_of_next_wft_seq(
+    events: &[HistoryEvent],
+    from_event_id: i64,
+    has_last_wft: bool,
+    has_pending_speculative_updates: bool,
+    use_chunking_v2: bool,
+) -> NextWFTSeqEndIndex {
+    if use_chunking_v2 {
+        find_end_index_of_next_wft_seq_v2(
+            events,
+            from_event_id,
+            has_last_wft,
+            has_pending_speculative_updates,
+        )
+    } else {
+        find_end_index_of_next_wft_seq_v1(events, from_event_id, has_last_wft)
+    }
+}
+
+/// Legacy behavior is replay compatibility and must remain unchanged.
+fn find_end_index_of_next_wft_seq_v1(
     events: &[HistoryEvent],
     from_event_id: i64,
     has_last_wft: bool,
@@ -801,6 +1134,159 @@ fn find_end_index_of_next_wft_seq(
     NextWFTSeqEndIndex::Incomplete(last_index)
 }
 
+fn is_command_or_ignorable_unknown(event: &HistoryEvent) -> bool {
+    event.is_command_event()
+        || (event.event_type() == EventType::Unspecified && event.is_ignorable())
+}
+
+/// V2 collapses an empty WFT only after its successor's complete command batch proves that no
+/// accepted Update created a distinct activation. An unbounded batch therefore requires another
+/// page rather than a provisional boundary.
+fn find_end_index_of_next_wft_seq_v2(
+    events: &[HistoryEvent],
+    from_event_id: i64,
+    has_last_wft: bool,
+    has_pending_speculative_updates: bool,
+) -> NextWFTSeqEndIndex {
+    use EventType::*;
+
+    if events.is_empty() {
+        return NextWFTSeqEndIndex::Incomplete(0);
+    }
+    let incomplete = || NextWFTSeqEndIndex::Incomplete(events.len() - 1);
+    let mut ix = events
+        .iter()
+        .position(|event| event.event_id > from_event_id)
+        .unwrap_or(events.len());
+    let mut prevent_heartbeat = false;
+
+    if events.get(ix).map(HistoryEvent::event_type) == Some(WorkflowExecutionStarted) {
+        prevent_heartbeat = true;
+        ix += 1;
+    }
+    if events.get(ix).map(HistoryEvent::event_type) == Some(WorkflowTaskCompleted) {
+        ix += 1;
+        while events.get(ix).is_some_and(is_command_or_ignorable_unknown) {
+            prevent_heartbeat = true;
+            ix += 1;
+        }
+        if ix == events.len() && !has_last_wft {
+            return incomplete();
+        }
+    }
+
+    while ix < events.len() {
+        let event_type = events[ix].event_type();
+        if events[ix].is_final_wf_execution_event() {
+            if ix + 1 == events.len() && !has_last_wft {
+                return incomplete();
+            }
+            return NextWFTSeqEndIndex::Complete(ix);
+        }
+        if event_type != WorkflowTaskStarted {
+            if !matches!(event_type, WorkflowTaskScheduled | WorkflowTaskCompleted) {
+                prevent_heartbeat = true;
+            }
+            ix += 1;
+            continue;
+        }
+
+        let started_ix = ix;
+        match events.get(ix + 1).map(HistoryEvent::event_type) {
+            None => {
+                return if has_last_wft {
+                    NextWFTSeqEndIndex::Complete(started_ix)
+                } else {
+                    incomplete()
+                };
+            }
+            Some(WorkflowTaskFailed | WorkflowTaskTimedOut) => {
+                ix += 2;
+                continue;
+            }
+            Some(WorkflowTaskCompleted) => {}
+            Some(_) if events[ix + 1].is_final_wf_execution_event() => {
+                return NextWFTSeqEndIndex::Complete(started_ix);
+            }
+            Some(_) => return NextWFTSeqEndIndex::Complete(started_ix),
+        }
+
+        let after_completion = ix + 2;
+        let Some(after_type) = events.get(after_completion).map(HistoryEvent::event_type) else {
+            return if has_last_wft {
+                NextWFTSeqEndIndex::Complete(started_ix)
+            } else {
+                incomplete()
+            };
+        };
+
+        if events
+            .get(after_completion)
+            .is_some_and(is_command_or_ignorable_unknown)
+        {
+            let mut command_ix = after_completion;
+            while events
+                .get(command_ix)
+                .is_some_and(is_command_or_ignorable_unknown)
+            {
+                command_ix += 1;
+            }
+            if command_ix == events.len() && !has_last_wft {
+                return incomplete();
+            }
+            return NextWFTSeqEndIndex::Complete(started_ix);
+        }
+        if after_type != WorkflowTaskScheduled || prevent_heartbeat {
+            return NextWFTSeqEndIndex::Complete(started_ix);
+        }
+
+        let successor_ix = after_completion + 1;
+        if events.get(successor_ix).map(HistoryEvent::event_type) != Some(WorkflowTaskStarted) {
+            return if successor_ix == events.len() && !has_last_wft {
+                incomplete()
+            } else {
+                NextWFTSeqEndIndex::Complete(started_ix)
+            };
+        }
+        match events.get(successor_ix + 1).map(HistoryEvent::event_type) {
+            None => {
+                return if !has_last_wft {
+                    incomplete()
+                } else if has_pending_speculative_updates {
+                    NextWFTSeqEndIndex::Complete(started_ix)
+                } else {
+                    NextWFTSeqEndIndex::Complete(successor_ix)
+                };
+            }
+            Some(WorkflowTaskCompleted) => {}
+            Some(_) => return NextWFTSeqEndIndex::Complete(started_ix),
+        }
+
+        let mut command_ix = successor_ix + 2;
+        let mut preserve_boundary = false;
+        while let Some(command) = events.get(command_ix) {
+            if command.event_type() == WorkflowExecutionUpdateAccepted
+                || command.event_type() == Unspecified
+            {
+                preserve_boundary = true;
+            }
+            if !is_command_or_ignorable_unknown(command) {
+                break;
+            }
+            command_ix += 1;
+        }
+        if command_ix == events.len() && !has_last_wft {
+            return incomplete();
+        }
+        if preserve_boundary {
+            return NextWFTSeqEndIndex::Complete(started_ix);
+        }
+        ix = successor_ix;
+    }
+
+    incomplete()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -812,6 +1298,7 @@ mod tests {
     use futures_util::TryStreamExt;
     use temporalio_common::protos::temporal::api::{
         common::v1::WorkflowExecution, enums::v1::WorkflowTaskFailedCause,
+        sdk::v1::WorkflowTaskCompletedMetadata,
         workflowservice::v1::GetWorkflowExecutionHistoryResponse,
     };
 
@@ -849,6 +1336,397 @@ mod tests {
         let seq = update.take_next_wft_sequence(from_id).unwrap_events();
         assert_eq!(seq, seq_peeked);
         seq
+    }
+
+    const WES: EventType = EventType::WorkflowExecutionStarted;
+    const SCHEDULED: EventType = EventType::WorkflowTaskScheduled;
+    const STARTED: EventType = EventType::WorkflowTaskStarted;
+    const COMPLETED: EventType = EventType::WorkflowTaskCompleted;
+
+    fn history(types: &[EventType]) -> Vec<HistoryEvent> {
+        types
+            .iter()
+            .enumerate()
+            .map(|(index, event_type)| HistoryEvent {
+                event_id: index as i64 + 1,
+                event_type: *event_type as i32,
+                ..Default::default()
+            })
+            .collect()
+    }
+
+    fn set_wft_flags(events: &mut [HistoryEvent], event_id: i64, flags: Vec<u32>) {
+        events[event_id as usize - 1].attributes =
+            Some(Attributes::WorkflowTaskCompletedEventAttributes(
+                WorkflowTaskCompletedEventAttributes {
+                    sdk_metadata: Some(WorkflowTaskCompletedMetadata {
+                        core_used_flags: flags,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            ));
+    }
+
+    fn v2_boundaries(events: Vec<HistoryEvent>, pending_update: bool) -> Vec<i64> {
+        let started_id = events
+            .iter()
+            .rev()
+            .find(|event| event.event_type() == EventType::WorkflowTaskStarted)
+            .unwrap()
+            .event_id;
+        let mut update = HistoryUpdate::from_events_with_options(
+            events,
+            0,
+            started_id,
+            true,
+            pending_update,
+            true,
+        )
+        .0;
+        let mut boundaries = vec![];
+        let mut from = 0;
+        while let NextWFT::WFT(events, _) = update.take_next_wft_sequence(from) {
+            from = events.last().unwrap().event_id;
+            boundaries.push(from);
+        }
+        boundaries
+    }
+
+    async fn assert_paginated_v2(
+        mut events: Vec<HistoryEvent>,
+        expected_boundaries: &[i64],
+        semantic_lookahead: Option<(i64, usize)>,
+    ) {
+        let first_completion = events
+            .iter()
+            .find(|event| event.event_type() == COMPLETED)
+            .unwrap()
+            .event_id;
+        set_wft_flags(
+            &mut events,
+            first_completion,
+            vec![CoreInternalFlags::WftChunkingV2 as u32],
+        );
+        let started_id = events
+            .iter()
+            .rev()
+            .find(|event| event.event_type() == EventType::WorkflowTaskStarted)
+            .unwrap()
+            .event_id;
+        for cut in 5..=events.len() {
+            let middle = events[4..cut].to_vec();
+            let tail = events[cut..].to_vec();
+            let mut client = mock_worker_client();
+            client
+                .expect_get_workflow_execution_history()
+                .times(1)
+                .return_once(move |_, _, _| {
+                    Ok(GetWorkflowExecutionHistoryResponse {
+                        history: Some(History { events: middle }),
+                        next_page_token: vec![2],
+                        ..Default::default()
+                    })
+                });
+            client
+                .expect_get_workflow_execution_history()
+                .times(1)
+                .return_once(move |_, _, _| {
+                    Ok(GetWorkflowExecutionHistoryResponse {
+                        history: Some(History { events: tail }),
+                        ..Default::default()
+                    })
+                });
+            let mut paginator = HistoryPaginator::new(
+                History {
+                    events: events[..4].to_vec(),
+                },
+                0,
+                started_id,
+                "wf".into(),
+                "run".into(),
+                NextPageToken::Next(vec![1]),
+                Arc::new(client),
+            );
+            let (mut update, mut boundaries, mut emitted, mut from) = (
+                paginator.extract_next_update().await.unwrap(),
+                vec![],
+                vec![],
+                0,
+            );
+            loop {
+                match update.take_next_wft_sequence(from) {
+                    NextWFT::WFT(batch, _) => {
+                        from = batch.last().unwrap().event_id;
+                        boundaries.push(from);
+                        emitted.extend(batch.into_iter().map(|event| event.event_id));
+                        if let Some((boundary, command_count)) = semantic_lookahead
+                            && boundary == from
+                        {
+                            assert_eq!(
+                                update.peek_next_wft_commands(from).len(),
+                                command_count,
+                                "page cut {cut}"
+                            );
+                        }
+                    }
+                    NextWFT::NeedFetch => update = paginator.extract_next_update().await.unwrap(),
+                    NextWFT::ReplayOver => break,
+                }
+            }
+            assert_eq!(boundaries, expected_boundaries, "page cut {cut}");
+            assert_eq!(
+                emitted,
+                (1..=events.len() as i64).collect::<Vec<_>>(),
+                "page cut {cut}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn v2_failure_inbound_and_update_matrix() {
+        let heartbeat = [
+            WES, SCHEDULED, STARTED, COMPLETED, SCHEDULED, STARTED, COMPLETED, SCHEDULED, STARTED,
+        ];
+        for failure in [
+            EventType::WorkflowTaskFailed,
+            EventType::WorkflowTaskTimedOut,
+        ] {
+            let mut types = heartbeat.to_vec();
+            types.extend([failure, SCHEDULED, STARTED]);
+            let events = history(&types);
+            assert_eq!(v2_boundaries(events.clone(), false), [3, 6, 12]);
+            assert_eq!(v2_boundaries(events[..9].to_vec(), true), [3, 6, 9]);
+            assert_eq!(v2_boundaries(events.clone(), true), [3, 6, 12]);
+            assert_paginated_v2(events, &[3, 6, 12], None).await;
+            types.extend([
+                COMPLETED,
+                EventType::WorkflowExecutionUpdateAccepted,
+                SCHEDULED,
+                STARTED,
+            ]);
+            let events = history(&types);
+            assert_eq!(v2_boundaries(events.clone(), false), [3, 6, 12, 16]);
+            assert_paginated_v2(events, &[3, 6, 12, 16], None).await;
+        }
+        for inbound in [
+            EventType::WorkflowExecutionSignaled,
+            EventType::TimerFired,
+            EventType::ActivityTaskCompleted,
+        ] {
+            let events = history(&[
+                WES, SCHEDULED, STARTED, COMPLETED, SCHEDULED, STARTED, COMPLETED, inbound,
+                SCHEDULED, STARTED,
+            ]);
+            assert_eq!(v2_boundaries(events.clone(), false), [3, 6, 10]);
+            assert_paginated_v2(events, &[3, 6, 10], None).await;
+        }
+        let events = history(&[
+            WES,
+            SCHEDULED,
+            STARTED,
+            COMPLETED,
+            SCHEDULED,
+            STARTED,
+            COMPLETED,
+            SCHEDULED,
+            STARTED,
+            COMPLETED,
+            EventType::MarkerRecorded,
+            SCHEDULED,
+            STARTED,
+        ]);
+        assert_eq!(v2_boundaries(events[..9].to_vec(), true), [3, 6, 9]);
+        assert_eq!(v2_boundaries(events.clone(), false), [3, 9, 13]);
+        assert_paginated_v2(events, &[3, 9, 13], None).await;
+        let events = history(&[
+            WES,
+            SCHEDULED,
+            STARTED,
+            COMPLETED,
+            EventType::TimerStarted,
+            SCHEDULED,
+            STARTED,
+            EventType::WorkflowExecutionTerminated,
+        ]);
+        assert_eq!(v2_boundaries(events.clone(), false), [3, 7, 8]);
+        assert_paginated_v2(events, &[3, 7, 8], None).await;
+    }
+
+    #[tokio::test]
+    async fn v2_update_command_batch_is_pagination_independent() {
+        let mut events = history(&[
+            WES,
+            SCHEDULED,
+            STARTED,
+            COMPLETED,
+            SCHEDULED,
+            STARTED,
+            COMPLETED,
+            SCHEDULED,
+            STARTED,
+            COMPLETED,
+            EventType::MarkerRecorded,
+            EventType::Unspecified,
+            EventType::WorkflowExecutionUpdateAccepted,
+            EventType::WorkflowExecutionUpdateAccepted,
+            EventType::MarkerRecorded,
+            SCHEDULED,
+            STARTED,
+        ]);
+        events[11].worker_may_ignore = true;
+
+        let mut live =
+            HistoryUpdate::from_events_with_options(events[..9].to_vec(), 0, 9, true, true, true).0;
+        next_check_peek(&mut live, 0);
+        let live_boundary = next_check_peek(&mut live, 3).last().unwrap().event_id;
+        assert_eq!(live_boundary, 6);
+        assert_eq!(v2_boundaries(events.clone(), false), [3, 6, 9, 17]);
+        assert_paginated_v2(events, &[3, 6, 9, 17], Some((9, 5))).await;
+    }
+
+    #[tokio::test]
+    async fn failed_attempt_does_not_select_before_flagged_first_success() {
+        let mut events = history(&[
+            WES,
+            SCHEDULED,
+            STARTED,
+            EventType::WorkflowTaskFailed,
+            SCHEDULED,
+            STARTED,
+            COMPLETED,
+        ]);
+        set_wft_flags(
+            &mut events,
+            7,
+            vec![CoreInternalFlags::WftChunkingV2 as u32],
+        );
+        let mut selected_registry = None;
+        let mut selected_latch = None;
+        for cut in 1..=events.len() {
+            let mut client = mock_worker_client();
+            if cut == 1 {
+                let failed_attempt = events[1..4].to_vec();
+                let successful_retry = events[4..].to_vec();
+                client
+                    .expect_get_workflow_execution_history()
+                    .times(1)
+                    .return_once(move |_, _, _| {
+                        Ok(GetWorkflowExecutionHistoryResponse {
+                            history: Some(History {
+                                events: failed_attempt,
+                            }),
+                            next_page_token: vec![2],
+                            ..Default::default()
+                        })
+                    });
+                client
+                    .expect_get_workflow_execution_history()
+                    .times(1)
+                    .return_once(move |_, _, _| {
+                        Ok(GetWorkflowExecutionHistoryResponse {
+                            history: Some(History {
+                                events: successful_retry,
+                            }),
+                            ..Default::default()
+                        })
+                    });
+            } else {
+                let tail = events[cut..].to_vec();
+                client
+                    .expect_get_workflow_execution_history()
+                    .times(1)
+                    .return_once(move |_, _, _| {
+                        Ok(GetWorkflowExecutionHistoryResponse {
+                            history: Some(History { events: tail }),
+                            ..Default::default()
+                        })
+                    });
+            }
+            let registry = WFTChunkingVersionRegistry::default();
+            let mut paginator = HistoryPaginator::new_with_registry(
+                History {
+                    events: events[..cut].to_vec(),
+                },
+                0,
+                6,
+                "wfid".into(),
+                "runid".into(),
+                NextPageToken::Next(vec![1]),
+                Arc::new(client),
+                false,
+                Some(registry.clone()),
+            );
+            paginator.extract_next_update().await.unwrap();
+            assert_eq!(
+                *paginator.chunking_version.lock(),
+                WFTChunkingVersion::V2,
+                "page cut {cut}"
+            );
+            assert!(!paginator.should_record_first_wft_flags());
+            selected_latch = Some(paginator.chunking_version.clone());
+            selected_registry = Some(registry);
+        }
+        let _selected_latch = selected_latch.unwrap();
+
+        let suffix = HistoryPaginator::new_with_registry(
+            History {
+                events: events[4..].to_vec(),
+            },
+            3,
+            6,
+            "wfid".to_string(),
+            "runid".to_string(),
+            NextPageToken::Done,
+            Arc::new(mock_worker_client()),
+            false,
+            selected_registry,
+        );
+        assert!(suffix.use_chunking_v2);
+        assert!(!suffix.requires_full_history_for_chunking_version());
+
+        let mut late_flag = history(&[
+            WES, SCHEDULED, STARTED, COMPLETED, SCHEDULED, STARTED, COMPLETED,
+        ]);
+        set_wft_flags(&mut late_flag, 4, vec![]);
+        set_wft_flags(
+            &mut late_flag,
+            7,
+            vec![CoreInternalFlags::WftChunkingV2 as u32],
+        );
+        let registry = WFTChunkingVersionRegistry::default();
+        let mut paginator = HistoryPaginator::new_with_registry(
+            History {
+                events: late_flag.clone(),
+            },
+            0,
+            6,
+            "wf".into(),
+            "late".into(),
+            NextPageToken::Done,
+            Arc::new(mock_worker_client()),
+            false,
+            Some(registry),
+        );
+        paginator.extract_next_update().await.unwrap();
+        assert_eq!(*paginator.chunking_version.lock(), WFTChunkingVersion::V1);
+
+        set_wft_flags(&mut late_flag, 4, vec![1_000_000]);
+        let mut paginator = HistoryPaginator::new(
+            History { events: late_flag },
+            0,
+            6,
+            "wf".into(),
+            "unknown".into(),
+            NextPageToken::Done,
+            Arc::new(mock_worker_client()),
+        );
+        let err = paginator.extract_next_update().await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        assert!(is_incompatible_history_status(&err));
+        assert!(!is_incompatible_history_status(
+            &tonic::Status::failed_precondition("server precondition")
+        ));
     }
 
     #[test]

--- a/crates/sdk-core/src/worker/workflow/history_update.rs
+++ b/crates/sdk-core/src/worker/workflow/history_update.rs
@@ -1153,7 +1153,7 @@ fn find_end_index_of_next_wft_seq_v2(
     if events.is_empty() {
         return NextWFTSeqEndIndex::Incomplete(0);
     }
-    let incomplete = || NextWFTSeqEndIndex::Incomplete(events.len() - 1);
+    let incomplete = NextWFTSeqEndIndex::Incomplete(events.len() - 1);
     let mut ix = events
         .iter()
         .position(|event| event.event_id > from_event_id)
@@ -1171,7 +1171,7 @@ fn find_end_index_of_next_wft_seq_v2(
             ix += 1;
         }
         if ix == events.len() && !has_last_wft {
-            return incomplete();
+            return incomplete;
         }
     }
 
@@ -1179,7 +1179,7 @@ fn find_end_index_of_next_wft_seq_v2(
         let event_type = events[ix].event_type();
         if events[ix].is_final_wf_execution_event() {
             if ix + 1 == events.len() && !has_last_wft {
-                return incomplete();
+                return incomplete;
             }
             return NextWFTSeqEndIndex::Complete(ix);
         }
@@ -1191,32 +1191,35 @@ fn find_end_index_of_next_wft_seq_v2(
             continue;
         }
 
+        // At this point `ix` identifies a WFT Started event. Its outcome is the immediately
+        // following event; looking beyond that pair is safe only after matching the outcome.
         let started_ix = ix;
         match events.get(ix + 1).map(HistoryEvent::event_type) {
             None => {
                 return if has_last_wft {
                     NextWFTSeqEndIndex::Complete(started_ix)
                 } else {
-                    incomplete()
+                    incomplete
                 };
             }
             Some(WorkflowTaskFailed | WorkflowTaskTimedOut) => {
+                // A failed attempt has no command batch or durable workflow decision. Consume its
+                // Started/outcome pair and keep scanning into the retry's logical WFT.
                 ix += 2;
                 continue;
             }
             Some(WorkflowTaskCompleted) => {}
-            Some(_) if events[ix + 1].is_final_wf_execution_event() => {
-                return NextWFTSeqEndIndex::Complete(started_ix);
-            }
             Some(_) => return NextWFTSeqEndIndex::Complete(started_ix),
         }
 
+        // The match above proved `ix + 1` is this attempt's Completed event, making `ix + 2` the
+        // first event after the completion.
         let after_completion = ix + 2;
         let Some(after_type) = events.get(after_completion).map(HistoryEvent::event_type) else {
             return if has_last_wft {
                 NextWFTSeqEndIndex::Complete(started_ix)
             } else {
-                incomplete()
+                incomplete
             };
         };
 
@@ -1232,7 +1235,7 @@ fn find_end_index_of_next_wft_seq_v2(
                 command_ix += 1;
             }
             if command_ix == events.len() && !has_last_wft {
-                return incomplete();
+                return incomplete;
             }
             return NextWFTSeqEndIndex::Complete(started_ix);
         }
@@ -1240,10 +1243,12 @@ fn find_end_index_of_next_wft_seq_v2(
             return NextWFTSeqEndIndex::Complete(started_ix);
         }
 
+        // Reaching here proved `after_completion` is Scheduled, whose matching Started event must
+        // immediately follow it.
         let successor_ix = after_completion + 1;
         if events.get(successor_ix).map(HistoryEvent::event_type) != Some(WorkflowTaskStarted) {
             return if successor_ix == events.len() && !has_last_wft {
-                incomplete()
+                incomplete
             } else {
                 NextWFTSeqEndIndex::Complete(started_ix)
             };
@@ -1251,7 +1256,7 @@ fn find_end_index_of_next_wft_seq_v2(
         match events.get(successor_ix + 1).map(HistoryEvent::event_type) {
             None => {
                 return if !has_last_wft {
-                    incomplete()
+                    incomplete
                 } else if has_pending_speculative_updates {
                     NextWFTSeqEndIndex::Complete(started_ix)
                 } else {
@@ -1262,6 +1267,8 @@ fn find_end_index_of_next_wft_seq_v2(
             Some(_) => return NextWFTSeqEndIndex::Complete(started_ix),
         }
 
+        // The preceding match proved `successor_ix + 1` is Completed, so commands emitted by that
+        // successor begin at `successor_ix + 2`.
         let mut command_ix = successor_ix + 2;
         let mut preserve_boundary = false;
         while let Some(command) = events.get(command_ix) {
@@ -1276,7 +1283,7 @@ fn find_end_index_of_next_wft_seq_v2(
             command_ix += 1;
         }
         if command_ix == events.len() && !has_last_wft {
-            return incomplete();
+            return incomplete;
         }
         if preserve_boundary {
             return NextWFTSeqEndIndex::Complete(started_ix);
@@ -1284,7 +1291,7 @@ fn find_end_index_of_next_wft_seq_v2(
         ix = successor_ix;
     }
 
-    incomplete()
+    incomplete
 }
 
 #[cfg(test)]

--- a/crates/sdk-core/src/worker/workflow/history_update.rs
+++ b/crates/sdk-core/src/worker/workflow/history_update.rs
@@ -34,6 +34,7 @@ static EMPTY_TASK_ERR: LazyLock<tonic::Status> = LazyLock::new(|| {
 });
 // A server RPC may use the same tonic code, so only errors marked locally are nondeterminism.
 const INCOMPATIBLE_HISTORY_STATUS_KEY: &str = "temporal-incompatible-history";
+const CHUNKING_VERSION_REGISTRY_PRUNE_INTERVAL: usize = 1024;
 
 pub(crate) fn is_incompatible_history_status(status: &tonic::Status) -> bool {
     status
@@ -112,8 +113,10 @@ enum WFTChunkingVersion {
 
 type WFTChunkingVersionLatch = Arc<Mutex<WFTChunkingVersion>>;
 
-/// Keeps the one-time version choice available while a run is cached. Dead entries are pruned on
-/// lookup so the registry does not retain completed run IDs.
+/// Shares the one-time version choice among same-run paginators and the successful-completion
+/// path. Cached and in-flight paginators own the strong references so the registry cannot keep
+/// completed runs alive; periodic pruning removes the run IDs left behind by expired weak
+/// references.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct WFTChunkingVersionRegistry {
     inner: Arc<Mutex<WFTChunkingVersionRegistryInner>>,
@@ -129,10 +132,9 @@ impl WFTChunkingVersionRegistry {
     fn get_or_create(&self, run_id: &str) -> WFTChunkingVersionLatch {
         let mut inner = self.inner.lock();
         inner.lookups_since_prune += 1;
-        // Most entries are live for the cache lifetime, so scanning the entire registry on every
-        // poll would make task intake quadratic in cache size. Periodic pruning bounds stale IDs
-        // while keeping the ordinary lookup constant-time.
-        if inner.lookups_since_prune >= 1024 {
+        // A full scan on every poll would make task intake quadratic in cache size. Amortizing it
+        // bounds newly accumulated dead IDs while keeping ordinary lookups constant-time.
+        if inner.lookups_since_prune >= CHUNKING_VERSION_REGISTRY_PRUNE_INTERVAL {
             inner
                 .versions
                 .retain(|_, version| version.strong_count() > 0);
@@ -1191,8 +1193,8 @@ fn find_end_index_of_next_wft_seq_v2(
             continue;
         }
 
-        // At this point `ix` identifies a WFT Started event. Its outcome is the immediately
-        // following event; looking beyond that pair is safe only after matching the outcome.
+        // The WFT outcome is adjacent at `ix + 1`. Failed and timed-out attempts have no durable
+        // workflow decision, so their retry remains in the same logical sequence.
         let started_ix = ix;
         match events.get(ix + 1).map(HistoryEvent::event_type) {
             None => {
@@ -1203,8 +1205,6 @@ fn find_end_index_of_next_wft_seq_v2(
                 };
             }
             Some(WorkflowTaskFailed | WorkflowTaskTimedOut) => {
-                // A failed attempt has no command batch or durable workflow decision. Consume its
-                // Started/outcome pair and keep scanning into the retry's logical WFT.
                 ix += 2;
                 continue;
             }
@@ -1212,8 +1212,8 @@ fn find_end_index_of_next_wft_seq_v2(
             Some(_) => return NextWFTSeqEndIndex::Complete(started_ix),
         }
 
-        // The match above proved `ix + 1` is this attempt's Completed event, making `ix + 2` the
-        // first event after the completion.
+        // Commands, if any, begin at `ix + 2`; defer at a page edge until their contiguous batch
+        // is bounded.
         let after_completion = ix + 2;
         let Some(after_type) = events.get(after_completion).map(HistoryEvent::event_type) else {
             return if has_last_wft {
@@ -1243,8 +1243,8 @@ fn find_end_index_of_next_wft_seq_v2(
             return NextWFTSeqEndIndex::Complete(started_ix);
         }
 
-        // Reaching here proved `after_completion` is Scheduled, whose matching Started event must
-        // immediately follow it.
+        // An empty completion is a heartbeat candidate only when the next WFT is immediately
+        // Scheduled then Started; an intervening event preserves the current boundary.
         let successor_ix = after_completion + 1;
         if events.get(successor_ix).map(HistoryEvent::event_type) != Some(WorkflowTaskStarted) {
             return if successor_ix == events.len() && !has_last_wft {
@@ -1267,8 +1267,8 @@ fn find_end_index_of_next_wft_seq_v2(
             Some(_) => return NextWFTSeqEndIndex::Complete(started_ix),
         }
 
-        // The preceding match proved `successor_ix + 1` is Completed, so commands emitted by that
-        // successor begin at `successor_ix + 2`.
+        // Successor commands begin at `successor_ix + 2`; scan the whole batch because a later
+        // UpdateAccepted—or unknown event treated conservatively like one—preserves this boundary.
         let mut command_ix = successor_ix + 2;
         let mut preserve_boundary = false;
         while let Some(command) = events.get(command_ix) {
@@ -1303,6 +1303,7 @@ mod tests {
         worker::client::mocks::mock_worker_client,
     };
     use futures_util::TryStreamExt;
+    use std::{sync::Barrier, thread};
     use temporalio_common::protos::temporal::api::{
         common::v1::WorkflowExecution, enums::v1::WorkflowTaskFailedCause,
         sdk::v1::WorkflowTaskCompletedMetadata,
@@ -1349,6 +1350,70 @@ mod tests {
     const SCHEDULED: EventType = EventType::WorkflowTaskScheduled;
     const STARTED: EventType = EventType::WorkflowTaskStarted;
     const COMPLETED: EventType = EventType::WorkflowTaskCompleted;
+
+    #[test]
+    fn chunking_version_registry_shares_and_releases_latches() {
+        let registry = WFTChunkingVersionRegistry::default();
+        let first = registry.get_or_create("run");
+        let second = registry.get_or_create("run");
+        let first_weak = Arc::downgrade(&first);
+
+        assert!(Arc::ptr_eq(&first, &second));
+        registry.record_successful_completion("run", true);
+        assert_eq!(*first.lock(), WFTChunkingVersion::V2);
+        assert_eq!(*second.lock(), WFTChunkingVersion::V2);
+
+        drop(first);
+        drop(second);
+        assert!(first_weak.upgrade().is_none());
+        assert_eq!(
+            *registry.get_or_create("run").lock(),
+            WFTChunkingVersion::Unknown
+        );
+
+        let registry = WFTChunkingVersionRegistry::default();
+        let live = registry.get_or_create("live");
+        for index in 0..CHUNKING_VERSION_REGISTRY_PRUNE_INTERVAL - 1 {
+            drop(registry.get_or_create(&format!("dead-{index}")));
+        }
+        let inner = registry.inner.lock();
+        assert!(inner.versions.contains_key("live"));
+        assert!(!inner.versions.contains_key("dead-0"));
+        assert!(inner.versions.len() <= 2);
+        drop(inner);
+        drop(live);
+    }
+
+    #[test]
+    fn chunking_version_registry_atomically_creates_latches() {
+        const LOOKUPS: usize = 8;
+
+        let registry = WFTChunkingVersionRegistry::default();
+        let barrier = Arc::new(Barrier::new(LOOKUPS));
+        let lookups = (0..LOOKUPS)
+            .map(|_| {
+                let registry = registry.clone();
+                let barrier = barrier.clone();
+                thread::spawn(move || {
+                    barrier.wait();
+                    registry.get_or_create("run")
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let lookups = lookups
+            .into_iter()
+            .map(|lookup| lookup.join().unwrap())
+            .collect::<Vec<_>>();
+        for lookup in &lookups[1..] {
+            assert!(Arc::ptr_eq(&lookups[0], lookup));
+        }
+
+        registry.record_successful_completion("run", true);
+        for lookup in lookups {
+            assert_eq!(*lookup.lock(), WFTChunkingVersion::V2);
+        }
+    }
 
     fn history(types: &[EventType]) -> Vec<HistoryEvent> {
         types

--- a/crates/sdk-core/src/worker/workflow/machines/workflow_machines.rs
+++ b/crates/sdk-core/src/worker/workflow/machines/workflow_machines.rs
@@ -264,7 +264,7 @@ impl WorkflowMachines {
             basics.capabilities,
             basics.sdk_name.to_owned(),
             basics.sdk_version.to_owned(),
-            basics.record_first_wft_flags,
+            basics.record_wft_chunking_v2,
         );
         // Peek ahead to determine used flags in the first WFT.
         if let Some(attrs) = basics.history.peek_next_wft_completed(0) {

--- a/crates/sdk-core/src/worker/workflow/machines/workflow_machines.rs
+++ b/crates/sdk-core/src/worker/workflow/machines/workflow_machines.rs
@@ -264,6 +264,7 @@ impl WorkflowMachines {
             basics.capabilities,
             basics.sdk_name.to_owned(),
             basics.sdk_version.to_owned(),
+            basics.record_first_wft_flags,
         );
         // Peek ahead to determine used flags in the first WFT.
         if let Some(attrs) = basics.history.peek_next_wft_completed(0) {
@@ -752,20 +753,13 @@ impl WorkflowMachines {
             ProtocolMessage(IncomingProtocolMessage),
         }
         let mut delayed_actions = vec![];
-        // Scan through to the next WFT, searching for any patch / la markers, so that we can
-        // pre-resolve them. This lookahead is necessary because we need these things to be already
-        // resolved in the same activations they would have been resolved in during initial
-        // execution. For example: If a workflow asks to run an LA and then waits on it, we will
-        // write the completion marker at the end of that WFT (as a command). So, upon replay,
-        // we need to lookahead and see that that LA is in fact resolved, so that we don't decide
-        // to execute it anew when lang says it wants to run it.
-        //
-        // Alternatively, lookahead can seemingly be avoided if we were to consider the commands
-        // that follow a WFT to be _part of_ that wft rather than the next one. That change might
-        // make sense to do, and maybe simplifies things slightly, but is a substantial alteration.
+        // Pre-resolve the contiguous command batch following the just-consumed completion so its
+        // effects appear in the same replay activation as they did during initial execution. V2
+        // can retain later events only to prove the chunk boundary, and those must not leak into
+        // the current activation.
         for e in self
             .last_history_from_server
-            .peek_next_wft_sequence(last_handled_wft_started_id)
+            .peek_next_wft_commands(last_handled_wft_started_id)
         {
             if let Some((patch_id, _)) = e.get_patch_marker_details() {
                 self.encountered_patch_markers.insert(

--- a/crates/sdk-core/src/worker/workflow/mod.rs
+++ b/crates/sdk-core/src/worker/workflow/mod.rs
@@ -113,7 +113,7 @@ pub const LEGACY_QUERY_ID: &str = "legacy_query";
 const WFT_HEARTBEAT_TIMEOUT_FRACTION: f32 = 0.8;
 const USE_WFT_CHUNKING_V2_ENV_VAR: &str = "TEMPORAL_USE_WFT_CHUNKING_V2";
 
-fn parse_wft_chunking_v2_opt_in(value: Option<&str>) -> bool {
+pub(crate) fn parse_wft_chunking_v2_opt_in(value: Option<&str>) -> bool {
     value.is_some_and(|value| matches!(value.to_ascii_lowercase().as_str(), "true" | "1"))
 }
 

--- a/crates/sdk-core/src/worker/workflow/mod.rs
+++ b/crates/sdk-core/src/worker/workflow/mod.rs
@@ -20,7 +20,7 @@ use crate::{
         MeteredPermitDealer, TrackedOwnedMeteredSemPermit, UsedMeteredSemPermit, dbg_panic,
         take_cell::TakeCell,
     },
-    internal_flags::InternalFlags,
+    internal_flags::{CoreInternalFlags, InternalFlags, use_wft_chunking_v2_opt_in},
     pollers::TrackedPermittedTqResp,
     protosext::{ValidPollWFTQResponse, protocol_messages::IncomingProtocolMessage},
     telemetry::{
@@ -33,7 +33,7 @@ use crate::{
         activities::{ActivitiesFromWFTsHandle, LocalActivityManager},
         client::{LegacyQueryResult, WorkerClient, WorkflowTaskCompletion},
         workflow::{
-            history_update::HistoryPaginator,
+            history_update::{HistoryPaginator, WFTChunkingVersionRegistry},
             machines::MachineError,
             managed_run::RunUpdateAct,
             wft_extraction::{HistoryFetchReq, WFTExtractor, WFTStreamIn},
@@ -139,6 +139,7 @@ pub(crate) struct Workflows {
     local_act_mgr: Option<Arc<LocalActivityManager>>,
     ever_polled: AtomicBool,
     default_versioning_behavior: Option<VersioningBehavior>,
+    chunking_versions: WFTChunkingVersionRegistry,
 }
 
 pub(crate) struct WorkflowBasics {
@@ -161,6 +162,7 @@ pub(crate) struct RunBasics<'a> {
     pub(crate) capabilities: &'a get_system_info_response::Capabilities,
     pub(crate) sdk_name: &'a str,
     pub(crate) sdk_version: &'a str,
+    pub(crate) record_first_wft_flags: bool,
 }
 
 impl Workflows {
@@ -177,6 +179,11 @@ impl Workflows {
         activity_tasks_handle: Option<ActivitiesFromWFTsHandle>,
         tracing_sub: Option<Arc<dyn Subscriber + Send + Sync>>,
     ) -> Self {
+        if use_wft_chunking_v2_opt_in() && !basics.server_capabilities.sdk_metadata {
+            warn!(
+                "TEMPORAL_USE_WFT_CHUNKING_V2 is enabled, but the server does not advertise SDK metadata support; new workflow runs will remain on WFT chunking v1"
+            );
+        }
         let (local_tx, local_rx) = unbounded_channel();
         let (fetch_tx, fetch_rx) = unbounded_channel();
         let shutdown_tok = basics.shutdown_token.clone();
@@ -185,11 +192,13 @@ impl Workflows {
             .worker_config
             .max_eager_activity_reservations_per_workflow_task;
         let default_versioning_behavior = basics.default_versioning_behavior;
+        let chunking_versions = WFTChunkingVersionRegistry::default();
         let extracted_wft_stream = WFTExtractor::build(
             client.clone(),
             basics.worker_config.fetching_concurrency,
             wft_stream,
             UnboundedReceiverStream::new(fetch_rx),
+            chunking_versions.clone(),
         );
         let locals_stream = if let Some(hb_rx) = heartbeat_timeout_rx {
             Either::Left(stream::select(
@@ -276,6 +285,7 @@ impl Workflows {
             local_act_mgr,
             ever_polled: AtomicBool::new(false),
             default_versioning_behavior,
+            chunking_versions,
         }
     }
 
@@ -340,16 +350,21 @@ impl Workflows {
                 },
                 WorkflowStreamAction::FailUnstoredWft {
                     run_id,
-                    task_token,
+                    task,
                     cause,
-                    failure,
+                    mut failure,
                 } => {
-                    self.handle_activation_failed(
-                        &run_id,
-                        Instant::now(),
-                        FailedActivationWFTReport::Report(task_token, cause, failure),
-                    )
-                    .await;
+                    let report = match task {
+                        AutoReplyTask::Workflow(task_token) => {
+                            FailedActivationWFTReport::Report(task_token, cause, failure)
+                        }
+                        AutoReplyTask::LegacyQuery(task_token) => {
+                            failure.force_cause = cause as i32;
+                            FailedActivationWFTReport::ReportLegacyQueryFailure(task_token, failure)
+                        }
+                    };
+                    self.handle_activation_failed(&run_id, Instant::now(), report)
+                        .await;
                 }
             }
         }
@@ -415,6 +430,10 @@ impl Workflows {
                     completion.return_new_workflow_task = false;
                 }
                 completion.sticky_attributes = sticky_attrs;
+                let used_chunking_v2 = completion
+                    .sdk_metadata
+                    .core_used_flags
+                    .contains(&(CoreInternalFlags::WftChunkingV2 as u32));
 
                 let mut reset_last_started_to = None;
                 self.handle_wft_reporting_errs(run_id, || async {
@@ -425,6 +444,9 @@ impl Workflows {
                             }
                             if response.reset_history_event_id > 0 {
                                 reset_last_started_to = Some(response.reset_history_event_id);
+                            } else {
+                                self.chunking_versions
+                                    .record_successful_completion(run_id, used_chunking_v2);
                             }
                             if let Some(wft) = response.workflow_task {
                                 *wft_from_complete = Some(validate_wft(wft)?);
@@ -609,7 +631,13 @@ impl Workflows {
             .await;
 
         let maybe_pwft = if let Some(wft) = wft_from_complete {
-            match HistoryPaginator::from_poll(wft, self.client.clone()).await {
+            match HistoryPaginator::from_poll(
+                wft,
+                self.client.clone(),
+                self.chunking_versions.clone(),
+            )
+            .await
+            {
                 Ok((paginator, wft)) => Some(WFTWithPaginator { wft, paginator }),
                 Err(e) => {
                     self.request_eviction(
@@ -934,12 +962,11 @@ struct WFStreamOutput {
 #[derive(Debug, derive_more::Display)]
 enum WorkflowStreamAction {
     Activation(ActivationOrAuto),
-    /// Fail a WFT that could not be associated with a run and therefore cannot use the normal
-    /// activation completion path.
+    /// Fail a task that was never stored on its run and cannot use the activation completion path.
     #[display("FailUnstoredWft(run_id={run_id})")]
     FailUnstoredWft {
         run_id: String,
-        task_token: TaskToken,
+        task: AutoReplyTask,
         cause: WorkflowTaskFailedCause,
         failure: Failure,
     },
@@ -1181,6 +1208,20 @@ impl TaskStorageMetrics {
         Self {
             download: completion.payload_download_metrics.clone(),
             upload: completion.payload_upload_metrics.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum AutoReplyTask {
+    Workflow(TaskToken),
+    LegacyQuery(TaskToken),
+}
+
+impl AutoReplyTask {
+    fn into_task_token(self) -> TaskToken {
+        match self {
+            Self::Workflow(task_token) | Self::LegacyQuery(task_token) => task_token,
         }
     }
 }

--- a/crates/sdk-core/src/worker/workflow/mod.rs
+++ b/crates/sdk-core/src/worker/workflow/mod.rs
@@ -20,7 +20,7 @@ use crate::{
         MeteredPermitDealer, TrackedOwnedMeteredSemPermit, UsedMeteredSemPermit, dbg_panic,
         take_cell::TakeCell,
     },
-    internal_flags::{CoreInternalFlags, InternalFlags, use_wft_chunking_v2_opt_in},
+    internal_flags::{CoreInternalFlags, InternalFlags},
     pollers::TrackedPermittedTqResp,
     protosext::{ValidPollWFTQResponse, protocol_messages::IncomingProtocolMessage},
     telemetry::{
@@ -54,7 +54,7 @@ use std::{
     ops::DerefMut,
     rc::Rc,
     result,
-    sync::{Arc, atomic, atomic::AtomicBool},
+    sync::{Arc, OnceLock, atomic, atomic::AtomicBool},
     thread,
     time::{Duration, Instant},
 };
@@ -111,6 +111,20 @@ pub const LEGACY_QUERY_ID: &str = "legacy_query";
 /// What percentage of a WFT timeout we are willing to wait before sending a WFT heartbeat when
 /// necessary.
 const WFT_HEARTBEAT_TIMEOUT_FRACTION: f32 = 0.8;
+const USE_WFT_CHUNKING_V2_ENV_VAR: &str = "TEMPORAL_USE_WFT_CHUNKING_V2";
+
+fn parse_wft_chunking_v2_opt_in(value: Option<&str>) -> bool {
+    value.is_some_and(|value| matches!(value.to_ascii_lowercase().as_str(), "true" | "1"))
+}
+
+fn use_wft_chunking_v2_opt_in() -> bool {
+    // Workers in one process must not choose different rollout policies if the environment is
+    // mutated after the first worker is constructed.
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        parse_wft_chunking_v2_opt_in(std::env::var(USE_WFT_CHUNKING_V2_ENV_VAR).ok().as_deref())
+    })
+}
 
 type Result<T, E = WFMachinesError> = result::Result<T, E>;
 type BoxedActivationStream = BoxStream<'static, Result<WorkflowStreamAction, PollError>>;
@@ -162,7 +176,7 @@ pub(crate) struct RunBasics<'a> {
     pub(crate) capabilities: &'a get_system_info_response::Capabilities,
     pub(crate) sdk_name: &'a str,
     pub(crate) sdk_version: &'a str,
-    pub(crate) record_first_wft_flags: bool,
+    pub(crate) record_wft_chunking_v2: bool,
 }
 
 impl Workflows {
@@ -179,11 +193,14 @@ impl Workflows {
         activity_tasks_handle: Option<ActivitiesFromWFTsHandle>,
         tracing_sub: Option<Arc<dyn Subscriber + Send + Sync>>,
     ) -> Self {
-        if use_wft_chunking_v2_opt_in() && !basics.server_capabilities.sdk_metadata {
+        let wft_chunking_v2_opt_in = use_wft_chunking_v2_opt_in();
+        if wft_chunking_v2_opt_in && !basics.server_capabilities.sdk_metadata {
             warn!(
                 "TEMPORAL_USE_WFT_CHUNKING_V2 is enabled, but the server does not advertise SDK metadata support; new workflow runs will remain on WFT chunking v1"
             );
         }
+        let may_record_wft_chunking_v2 =
+            wft_chunking_v2_opt_in && basics.server_capabilities.sdk_metadata;
         let (local_tx, local_rx) = unbounded_channel();
         let (fetch_tx, fetch_rx) = unbounded_channel();
         let shutdown_tok = basics.shutdown_token.clone();
@@ -240,6 +257,7 @@ impl Workflows {
 
                     let mut stream = WFStream::build(
                         basics,
+                        may_record_wft_chunking_v2,
                         extracted_wft_stream,
                         locals_stream,
                         local_activity_request_sink,
@@ -1921,6 +1939,16 @@ mod tests {
         payload_limits::{LimitClass, LimitSeverity},
         protos::coresdk::workflow_activation::SignalWorkflow,
     };
+
+    #[test]
+    fn chunking_v2_opt_in_requires_explicit_truthy_value() {
+        for value in [Some("true"), Some("TRUE"), Some("1")] {
+            assert!(parse_wft_chunking_v2_opt_in(value));
+        }
+        for value in [None, Some(""), Some("false"), Some("0"), Some("yes")] {
+            assert!(!parse_wft_chunking_v2_opt_in(value));
+        }
+    }
 
     #[test]
     fn task_storage_metrics_from_completion_keeps_directions_distinct() {

--- a/crates/sdk-core/src/worker/workflow/run_cache.rs
+++ b/crates/sdk-core/src/worker/workflow/run_cache.rs
@@ -17,6 +17,7 @@ pub(super) struct RunCache {
     worker_config: Arc<WorkerConfig>,
     sdk_name_and_version: (String, String),
     server_capabilities: get_system_info_response::Capabilities,
+    may_record_wft_chunking_v2: bool,
     /// Run id -> Data
     runs: LruCache<String, ManagedRun>,
     local_activity_request_sink: Option<Rc<dyn LocalActivityRequestSink>>,
@@ -29,6 +30,7 @@ impl RunCache {
         worker_config: Arc<WorkerConfig>,
         sdk_name_and_version: (String, String),
         server_capabilities: get_system_info_response::Capabilities,
+        may_record_wft_chunking_v2: bool,
         local_activity_request_sink: Option<impl LocalActivityRequestSink>,
         metrics: MetricsContext,
     ) -> Self {
@@ -43,6 +45,7 @@ impl RunCache {
             worker_config,
             sdk_name_and_version,
             server_capabilities,
+            may_record_wft_chunking_v2,
             runs: LruCache::new(
                 NonZeroUsize::new(lru_size).expect("LRU size is guaranteed positive"),
             ),
@@ -67,7 +70,8 @@ impl RunCache {
         let metrics = self
             .metrics
             .with_new_attrs([workflow_type(pwft.work.workflow_type.clone())]);
-        let record_first_wft_flags = pwft.paginator.should_record_first_wft_flags();
+        let record_wft_chunking_v2 =
+            self.may_record_wft_chunking_v2 && pwft.paginator.should_record_first_wft_flags();
         let (mrh, rur) = ManagedRun::new(
             RunBasics {
                 worker_config: self.worker_config.clone(),
@@ -79,7 +83,7 @@ impl RunCache {
                 capabilities: &self.server_capabilities,
                 sdk_name: &self.sdk_name_and_version.0,
                 sdk_version: &self.sdk_name_and_version.1,
-                record_first_wft_flags,
+                record_wft_chunking_v2,
             },
             pwft,
             self.local_activity_request_sink.clone(),

--- a/crates/sdk-core/src/worker/workflow/run_cache.rs
+++ b/crates/sdk-core/src/worker/workflow/run_cache.rs
@@ -67,6 +67,7 @@ impl RunCache {
         let metrics = self
             .metrics
             .with_new_attrs([workflow_type(pwft.work.workflow_type.clone())]);
+        let record_first_wft_flags = pwft.paginator.should_record_first_wft_flags();
         let (mrh, rur) = ManagedRun::new(
             RunBasics {
                 worker_config: self.worker_config.clone(),
@@ -78,6 +79,7 @@ impl RunCache {
                 capabilities: &self.server_capabilities,
                 sdk_name: &self.sdk_name_and_version.0,
                 sdk_version: &self.sdk_name_and_version.1,
+                record_first_wft_flags,
             },
             pwft,
             self.local_activity_request_sink.clone(),

--- a/crates/sdk-core/src/worker/workflow/wft_extraction.rs
+++ b/crates/sdk-core/src/worker/workflow/wft_extraction.rs
@@ -5,14 +5,14 @@ use crate::{
         WorkflowSlotKind,
         client::WorkerClient,
         workflow::{
-            CacheMissFetchReq, HistoryUpdate, NextPageReq, PermittedWFT,
-            history_update::HistoryPaginator,
+            AutoReplyTask, CacheMissFetchReq, HistoryUpdate, NextPageReq, PermittedWFT,
+            history_update::{HistoryPaginator, WFTChunkingVersionRegistry},
         },
     },
 };
 use futures_util::{FutureExt, Stream, StreamExt, stream, stream::PollNext};
 use std::{future, sync::Arc};
-use temporalio_common::protos::{TaskToken, coresdk::WorkflowSlotInfo};
+use temporalio_common::protos::coresdk::WorkflowSlotInfo;
 use tracing::Span;
 
 /// Transforms incoming validated WFTs and history fetching requests into [PermittedWFT]s ready
@@ -35,7 +35,7 @@ pub(super) enum WFTExtractorOutput {
     FailedFetch {
         run_id: String,
         err: tonic::Status,
-        auto_reply_fail_tt: Option<TaskToken>,
+        auto_reply_fail_task: Option<AutoReplyTask>,
     },
     PollerDead,
 }
@@ -62,17 +62,25 @@ impl WFTExtractor {
         max_fetch_concurrency: usize,
         wft_stream: impl Stream<Item = WFTStreamIn> + Send + 'static,
         fetch_stream: impl Stream<Item = HistoryFetchReq> + Send + 'static,
+        chunking_versions: WFTChunkingVersionRegistry,
     ) -> impl Stream<Item = Result<WFTExtractorOutput, tonic::Status>> + Send + 'static {
         let fetch_client = client.clone();
         let wft_stream = wft_stream
             .map(move |stream_in| {
                 let client = client.clone();
+                let chunking_versions = chunking_versions.clone();
                 async move {
                     match stream_in {
                         Ok((wft, permit)) => {
                             let run_id = wft.workflow_execution.run_id.clone();
-                            let tt = wft.task_token.clone();
-                            Ok(match HistoryPaginator::from_poll(wft, client).await {
+                            let auto_reply_fail_task = if wft.legacy_query.is_some() {
+                                AutoReplyTask::LegacyQuery(wft.task_token.clone())
+                            } else {
+                                AutoReplyTask::Workflow(wft.task_token.clone())
+                            };
+                            let page =
+                                HistoryPaginator::from_poll(wft, client, chunking_versions).await;
+                            Ok(match page {
                                 Ok((pag, prep)) => WFTExtractorOutput::NewWFT(PermittedWFT {
                                     permit: permit.into_used(WorkflowSlotInfo {
                                         workflow_type: prep.workflow_type.clone(),
@@ -84,7 +92,7 @@ impl WFTExtractor {
                                 Err(err) => WFTExtractorOutput::FailedFetch {
                                     run_id,
                                     err,
-                                    auto_reply_fail_tt: Some(tt),
+                                    auto_reply_fail_task: Some(auto_reply_fail_task),
                                 },
                             })
                         }
@@ -111,13 +119,22 @@ impl WFTExtractor {
                         // failure. We'll just proceed with shutdown.
                         HistoryFetchReq::Full(req, rc) => {
                             let run_id = req.original_wft.work.execution.run_id.clone();
-                            let task_token = req.original_wft.work.task_token.clone();
+                            let auto_reply_fail_task = if req
+                                .original_wft
+                                .work
+                                .legacy_query
+                                .is_some()
+                            {
+                                AutoReplyTask::LegacyQuery(req.original_wft.work.task_token.clone())
+                            } else {
+                                AutoReplyTask::Workflow(req.original_wft.work.task_token.clone())
+                            };
                             match HistoryPaginator::from_fetchreq(req, client).await {
                                 Ok(r) => WFTExtractorOutput::FetchResult(r, rc),
                                 Err(err) => WFTExtractorOutput::FailedFetch {
                                     run_id,
                                     err,
-                                    auto_reply_fail_tt: Some(task_token),
+                                    auto_reply_fail_task: Some(auto_reply_fail_task),
                                 },
                             }
                         }
@@ -132,7 +149,7 @@ impl WFTExtractor {
                                 Err(err) => WFTExtractorOutput::FailedFetch {
                                     run_id: req.paginator.run_id,
                                     err,
-                                    auto_reply_fail_tt: None,
+                                    auto_reply_fail_task: None,
                                 },
                             }
                         }

--- a/crates/sdk-core/src/worker/workflow/workflow_stream.rs
+++ b/crates/sdk-core/src/worker/workflow/workflow_stream.rs
@@ -64,6 +64,7 @@ impl WFStream {
     /// manager), which is a quite substantial change.
     pub(super) fn build(
         basics: WorkflowBasics,
+        may_record_wft_chunking_v2: bool,
         wft_stream: impl Stream<Item = Result<WFTExtractorOutput, tonic::Status>> + Send + 'static,
         local_rx: impl Stream<Item = LocalInput> + Send + 'static,
         local_activity_request_sink: Option<impl LocalActivityRequestSink>,
@@ -78,12 +79,18 @@ impl WFStream {
             // Priority always goes to the local stream
             |_: &mut ()| PollNext::Left,
         );
-        Self::build_internal(all_inputs, basics, local_activity_request_sink)
+        Self::build_internal(
+            all_inputs,
+            basics,
+            may_record_wft_chunking_v2,
+            local_activity_request_sink,
+        )
     }
 
     fn build_internal(
         all_inputs: impl Stream<Item = WFStreamInput>,
         basics: WorkflowBasics,
+        may_record_wft_chunking_v2: bool,
         local_activity_request_sink: Option<impl LocalActivityRequestSink>,
     ) -> impl Stream<Item = Result<WFStreamOutput, PollError>> {
         let mut state = WFStream {
@@ -92,6 +99,7 @@ impl WFStream {
                 basics.worker_config.clone(),
                 (basics.sdk_name.clone(), basics.sdk_version.clone()),
                 basics.server_capabilities,
+                may_record_wft_chunking_v2,
                 local_activity_request_sink,
                 basics.metrics.clone(),
             ),

--- a/crates/sdk-core/src/worker/workflow/workflow_stream.rs
+++ b/crates/sdk-core/src/worker/workflow/workflow_stream.rs
@@ -2,6 +2,7 @@ use crate::{
     MetricsContext,
     abstractions::dbg_panic,
     worker::workflow::{
+        history_update::is_incompatible_history_status,
         managed_run::RunUpdateAct,
         run_cache::RunCache,
         wft_extraction::{HistfetchRC, HistoryFetchReq, WFTExtractorOutput},
@@ -159,26 +160,44 @@ impl WFStream {
                     WFStreamInput::FailedFetch {
                         run_id,
                         err,
-                        auto_reply_fail_tt,
+                        auto_reply_fail_task,
                     } => {
+                        let incompatible = is_incompatible_history_status(&err);
+                        let cause = if incompatible {
+                            WorkflowTaskFailedCause::NonDeterministicError
+                        } else {
+                            WorkflowTaskFailedCause::WorkflowWorkerUnhandledFailure
+                        };
+                        let reason = if incompatible {
+                            EvictionReason::Nondeterminism
+                        } else {
+                            EvictionReason::PaginationOrHistoryFetch
+                        };
                         let message = format!("Fetching history failed: {err:?}");
-                        if !state.runs.has_run(&run_id)
-                            && let Some(task_token) = auto_reply_fail_tt.clone()
-                        {
+                        let has_run = state.runs.has_run(&run_id);
+                        let reply_now = incompatible || !has_run;
+                        if reply_now && let Some(task) = auto_reply_fail_task.clone() {
                             actions.push(WorkflowStreamAction::FailUnstoredWft {
-                                run_id,
-                                task_token,
-                                cause: WorkflowTaskFailedCause::WorkflowWorkerUnhandledFailure,
-                                failure: ApiFailure::application_failure(message, true).into(),
+                                run_id: run_id.clone(),
+                                task,
+                                cause,
+                                failure: ApiFailure::application_failure(message.clone(), true)
+                                    .into(),
                             });
+                        }
+                        if !has_run {
                             None
                         } else {
                             state
                                 .request_eviction(RequestEvictMsg {
                                     run_id,
                                     message,
-                                    reason: EvictionReason::PaginationOrHistoryFetch,
-                                    auto_reply_fail_tt,
+                                    reason,
+                                    auto_reply_fail_tt: if reply_now {
+                                        None
+                                    } else {
+                                        auto_reply_fail_task.map(AutoReplyTask::into_task_token)
+                                    },
                                 })
                                 .into_run_update_resp()
                         }
@@ -243,6 +262,15 @@ impl WFStream {
         &mut self,
         pwft: PermittedWFT,
     ) -> Result<RunUpdateAct, HistoryFetchReq> {
+        if pwft.paginator.requires_full_history_for_chunking_version() {
+            if !self.runs.has_run(&pwft.work.execution.run_id) {
+                self.metrics.sticky_cache_miss();
+            }
+            return Err(HistoryFetchReq::Full(
+                Box::new(CacheMissFetchReq { original_wft: pwft }),
+                self.history_fetch_refcounter.clone(),
+            ));
+        }
         // If the run already exists, possibly buffer the work and return early if we can't handle
         // it yet.
         let pwft = if let Some(rh) = self.runs.get_mut(&pwft.work.execution.run_id) {
@@ -633,7 +661,7 @@ enum WFStreamInput {
     FailedFetch {
         run_id: String,
         err: tonic::Status,
-        auto_reply_fail_tt: Option<TaskToken>,
+        auto_reply_fail_task: Option<AutoReplyTask>,
     },
 }
 impl From<LocalInput> for WFStreamInput {
@@ -701,7 +729,7 @@ enum ExternalPollerInputs {
     FailedFetch {
         run_id: String,
         err: tonic::Status,
-        auto_reply_fail_tt: Option<TaskToken>,
+        auto_reply_fail_task: Option<AutoReplyTask>,
     },
 }
 impl From<ExternalPollerInputs> for WFStreamInput {
@@ -714,11 +742,11 @@ impl From<ExternalPollerInputs> for WFStreamInput {
             ExternalPollerInputs::FailedFetch {
                 run_id,
                 err,
-                auto_reply_fail_tt,
+                auto_reply_fail_task,
             } => WFStreamInput::FailedFetch {
                 run_id,
                 err,
-                auto_reply_fail_tt,
+                auto_reply_fail_task,
             },
             ExternalPollerInputs::NextPage {
                 paginator,
@@ -751,11 +779,11 @@ impl From<Result<WFTExtractorOutput, tonic::Status>> for ExternalPollerInputs {
             Ok(WFTExtractorOutput::FailedFetch {
                 run_id,
                 err,
-                auto_reply_fail_tt,
+                auto_reply_fail_task,
             }) => ExternalPollerInputs::FailedFetch {
                 run_id,
                 err,
-                auto_reply_fail_tt,
+                auto_reply_fail_task,
             },
             Ok(WFTExtractorOutput::PollerDead) => ExternalPollerInputs::PollerDead,
             Err(e) => ExternalPollerInputs::PollerError(e),


### PR DESCRIPTION
## What was changed

- Add a v2 logical Workflow Task chunker with explicit event classification, pending-Update handling, complete command-batch lookahead, and pagination-safe deferral.
- Select v1 or v2 once per run from the first successful Workflow Task completion. Flagless runs stay on v1; they can adopt v2 through Continue-As-New.
- Keep the writer disabled by default behind `TEMPORAL_USE_WFT_CHUNKING_V2`; readers honor the durable history selection.
- Fail tasks with unknown first-completion Core flags instead of silently selecting the wrong chunker.

## Why?

The legacy heartbeat heuristic can choose different activation boundaries during live execution and replay, especially when `WorkflowExecutionUpdateAccepted` follows another command or another history page. That can change workflow-visible time and command production, resulting in nondeterminism.

## Checklist

1. Closes #1146. Builds on the investigation in #1281.

2. How was this tested:
   - `cargo test -p temporalio-sdk-core --lib`
   - `TEMPORAL_USE_WFT_CHUNKING_V2=true cargo test -p temporalio-sdk-core --lib`
   - `cargo lint`
   - `cargo test-lint`

3. Any docs updates needed?
   - Updated the Workflow Task chunking architecture and rollout document.