### PR TITLE
feat(metrics): emit `failure_reason` on existing activity failure metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ relevant information.
   and `list` read them back.
 * `MemoValue` and `MemoValues` are now exported from `temporalio_common` as well as
   `temporalio_workflow`, so the same types can be used from clients and workflows.
+* The `temporal_activity_execution_failed` and `temporal_local_activity_execution_failed` worker
+  metrics now carry a `failure_reason` attribute. Each is now split into one time series per
+  reason, which may affect existing dashboards.
 
 ### Breaking Changes :boom:
 * Values stored in a `MemoValue` must now be `Send + Sync`. It previously held its value in an
@@ -56,6 +59,13 @@ relevant information.
 
 * Signal-with-start is now invoked with `Client::signal_with_start_workflow`; remove uses of
   `WorkflowStartOptions::start_signal` and `WorkflowStartSignal`.
+
+### Fixed
+* An activity failure caused by oversized final heartbeat details is now counted in the
+  `temporal_activity_execution_failed` metric as `failure_reason="PayloadsTooLarge"`. Previously it
+  was counted under the reason for the failure the activity itself reported, and was not counted at
+  all when that failure was benign, even though the worker reported a payload-limit failure to the
+  server.
 
 ## [0.7.0] - 2026-08-17
 

--- a/crates/protos/protos/local/temporal/sdk/core/activity_result/activity_result.proto
+++ b/crates/protos/protos/local/temporal/sdk/core/activity_result/activity_result.proto
@@ -37,6 +37,30 @@ message Success {
 // Used to report activity failure either when executing or resolving
 message Failure {
     temporal.api.failure.v1.Failure failure = 1;
+    // Only meaningful on ActivityExecutionResult (lang -> core); ignored on ActivityResolution,
+    // which reuses this message.
+    ActivityTaskFailedCause cause = 2;
+}
+
+/*
+ * A well-known condition that caused an activity task to fail. Lang reports one alongside the
+ * failure so core can categorize activity failures instead of treating them all alike; it becomes
+ * the `failure_reason` metric label, so the set of values is deliberately small and bounded.
+ */
+enum ActivityTaskFailedCause {
+    ACTIVITY_TASK_FAILED_CAUSE_UNSPECIFIED = 0;
+    // A payload-bearing field on a request the worker sent for this activity task exceeded the
+    // per-field size limit configured on the server for the namespace.
+    // Check the activity task failure message for more information.
+    ACTIVITY_TASK_FAILED_CAUSE_PAYLOADS_TOO_LARGE = 1;
+    // The worker failed to offload a payload to, or retrieve one from, external storage while
+    // processing this activity task.
+    // Check the activity task failure message for more information.
+    ACTIVITY_TASK_FAILED_CAUSE_EXTERNAL_STORAGE_FAILURE = 2;
+    // The default cause for an activity task failure reported by a worker; a more specific cause
+    // takes precedence whenever the condition is recognized.
+    // Check the activity task failure message for more information.
+    ACTIVITY_TASK_FAILED_CAUSE_ACTIVITY_WORKER_UNHANDLED_FAILURE = 3;
 }
 
 /*

--- a/crates/protos/src/protos/mod.rs
+++ b/crates/protos/src/protos/mod.rs
@@ -746,7 +746,7 @@ pub mod coresdk {
                     Self {
                         status: Some(aer::Status::Failed(Failure {
                             failure: Some(fail),
-                            ..Default::default()
+                            cause: ActivityTaskFailedCause::ActivityWorkerUnhandledFailure as i32,
                         })),
                     }
                 }
@@ -833,7 +833,8 @@ pub mod coresdk {
                             Ok(p) => Some(aer::Status::Completed(Success { result: Some(p) })),
                             Err(f) => Some(aer::Status::Failed(Failure {
                                 failure: Some(f),
-                                ..Default::default()
+                                cause: ActivityTaskFailedCause::ActivityWorkerUnhandledFailure
+                                    as i32,
                             })),
                         },
                     }

--- a/crates/protos/src/protos/mod.rs
+++ b/crates/protos/src/protos/mod.rs
@@ -746,6 +746,7 @@ pub mod coresdk {
                     Self {
                         status: Some(aer::Status::Failed(Failure {
                             failure: Some(fail),
+                            ..Default::default()
                         })),
                     }
                 }
@@ -830,7 +831,10 @@ pub mod coresdk {
                     Self {
                         status: match r {
                             Ok(p) => Some(aer::Status::Completed(Success { result: Some(p) })),
-                            Err(f) => Some(aer::Status::Failed(Failure { failure: Some(f) })),
+                            Err(f) => Some(aer::Status::Failed(Failure {
+                                failure: Some(f),
+                                ..Default::default()
+                            })),
                         },
                     }
                 }
@@ -866,6 +870,7 @@ pub mod coresdk {
                     match self.status {
                         Some(activity_resolution::Status::Failed(Failure {
                             failure: Some(ref f),
+                            ..
                         })) => f.is_timeout(),
                         _ => None,
                     }

--- a/crates/sdk-core/CHANGELOG.md
+++ b/crates/sdk-core/CHANGELOG.md
@@ -44,6 +44,9 @@ relevant information.
 * Workers now log a `[TMPRL1104]` warning when a workflow task takes longer than 5 seconds. Set
   `TEMPORAL_WORKFLOW_TASK_DURATION_WARN_SECONDS` to change the threshold.
 * Core now supports attaching `EventGroupMarker`s to most workflow commands.
+* The `temporal_activity_execution_failed` and `temporal_local_activity_execution_failed` worker
+  metrics now carry a `failure_reason` attribute. Each is now split into one time series per
+  reason, which may affect existing dashboards.
 
 ### Breaking Changes :boom:
 * Activity failures now include the latest heartbeat details atomically instead of force-flushing a
@@ -51,6 +54,10 @@ relevant information.
   are preserved on failure; workers warn when the server does not advertise support.
 
 ### Fixed
+* An activity failure caused by oversized final heartbeat details is now counted in the
+  `temporal_activity_execution_failed` metric as `failure_reason="PayloadsTooLarge"`. Previously it
+  was counted under the reason for the failure the activity itself reported, and was not counted at
+  all when that failure was benign, even though a payload-limit failure was reported instead.
 * Workers now warn when autoscaling task polling encounters errors continuously for one minute.
   Repeated warnings use exponential backoff up to 15-minute intervals and stop after polling
   recovers.

--- a/crates/sdk-core/src/core_tests/activity_tasks.rs
+++ b/crates/sdk-core/src/core_tests/activity_tasks.rs
@@ -37,8 +37,8 @@ use temporalio_common::{
         coresdk::{
             ActivityTaskCompletion,
             activity_result::{
-                ActivityExecutionResult, ActivityResolution, Success, activity_execution_result,
-                activity_resolution,
+                ActivityExecutionResult, ActivityResolution, ActivityTaskFailedCause, Success,
+                activity_execution_result, activity_resolution,
             },
             activity_task::{ActivityCancelReason, ActivityTask, Cancel, activity_task},
             workflow_activation::{
@@ -679,7 +679,7 @@ async fn complete_act_with_fail_includes_latest_heartbeat() {
             })
         });
     mock_client.expect_fail_activity_task().times(1).returning(
-        move |_, _, last_heartbeat_details| {
+        move |_, _, _, last_heartbeat_details| {
             assert_eq!(last_heartbeat_details.unwrap().payloads[0].data, [last_hb]);
             Ok(RespondActivityTaskFailedResponse::default())
         },
@@ -843,7 +843,7 @@ async fn activity_failure_distinguishes_no_heartbeat_from_empty_heartbeat() {
                 Ok(RecordActivityTaskHeartbeatResponse::default())
             });
         mock_client.expect_fail_activity_task().times(1).returning(
-            move |_, _, last_heartbeat_details| {
+            move |_, _, _, last_heartbeat_details| {
                 if explicit_empty_heartbeat {
                     assert_eq!(last_heartbeat_details.unwrap().payloads, []);
                 } else {
@@ -958,7 +958,8 @@ async fn oversized_activity_result_failure_includes_latest_heartbeat() {
         .times(1)
         .returning(|_, _| Err(payload_too_large_status()));
     mock_client.expect_fail_activity_task().times(1).returning(
-        |_, failure, last_heartbeat_details| {
+        |_, cause, failure, last_heartbeat_details| {
+            assert_eq!(cause, ActivityTaskFailedCause::PayloadsTooLarge);
             assert_payloads_too_large_retryable(&failure);
             assert_eq!(last_heartbeat_details.unwrap().payloads[0].data, [2]);
             Ok(RespondActivityTaskFailedResponse::default())
@@ -1005,7 +1006,8 @@ async fn oversized_cancel_details_fails_activity() {
         .times(1)
         .returning(|_, _| Err(payload_too_large_status()));
     mock_client.expect_fail_activity_task().times(1).returning(
-        |_, failure, last_heartbeat_details| {
+        |_, cause, failure, last_heartbeat_details| {
+            assert_eq!(cause, ActivityTaskFailedCause::PayloadsTooLarge);
             assert_payloads_too_large_retryable(&failure);
             assert_eq!(last_heartbeat_details.unwrap().payloads[0].data, [2]);
             Ok(RespondActivityTaskFailedResponse::default())
@@ -1051,7 +1053,8 @@ async fn oversized_heartbeat_fails_activity() {
         .times(1)
         .returning(|_, _| Err(payload_too_large_status()));
     mock_client.expect_fail_activity_task().times(1).returning(
-        |_, failure, last_heartbeat_details| {
+        |_, cause, failure, last_heartbeat_details| {
+            assert_eq!(cause, ActivityTaskFailedCause::PayloadsTooLarge);
             assert_payloads_too_large_retryable(&failure);
             assert!(last_heartbeat_details.is_none());
             Ok(RespondActivityTaskFailedResponse::default())
@@ -1456,7 +1459,7 @@ async fn graceful_shutdown(#[values(true, false)] at_max_outstanding: bool) {
             Ok(RecordActivityTaskHeartbeatResponse::default())
         });
     mock_client.expect_fail_activity_task().times(3).returning(
-        |task_token, _, last_heartbeat_details| {
+        |task_token, _, _, last_heartbeat_details| {
             if task_token.0 == [1] {
                 assert_eq!(last_heartbeat_details.unwrap().payloads[0].data, [2]);
             } else {

--- a/crates/sdk-core/src/core_tests/activity_tasks.rs
+++ b/crates/sdk-core/src/core_tests/activity_tasks.rs
@@ -10,8 +10,8 @@ use crate::{
     worker::{
         PollerBehavior, WorkerVersioningStrategy,
         client::{
-            WorkerClient, WorkerClientBag,
-            mocks::{mock_manual_worker_client, mock_worker_client},
+            MockWorkerClient, WorkerClient, WorkerClientBag,
+            mocks::{DEFAULT_TEST_CAPABILITIES, mock_manual_worker_client, mock_worker_client},
         },
     },
 };
@@ -30,6 +30,7 @@ use std::{
 use temporalio_client::{
     Connection, ConnectionOptions, PayloadErrorLimits, SharedReplaceableClient,
     callback_based::{CallbackBasedGrpcService, GrpcSuccessResponse},
+    worker::ClientWorkerSet,
 };
 use temporalio_common::{
     payload_limits::{LimitClass, LimitSeverity, PayloadLimitViolation},
@@ -37,8 +38,8 @@ use temporalio_common::{
         coresdk::{
             ActivityTaskCompletion,
             activity_result::{
-                ActivityExecutionResult, ActivityResolution, ActivityTaskFailedCause, Success,
-                activity_execution_result, activity_resolution,
+                self as activity_result, ActivityExecutionResult, ActivityResolution,
+                ActivityTaskFailedCause, Success, activity_execution_result, activity_resolution,
             },
             activity_task::{ActivityCancelReason, ActivityTask, Cancel, activity_task},
             workflow_activation::{
@@ -52,8 +53,8 @@ use temporalio_common::{
         },
         temporal::api::{
             command::v1::{ScheduleActivityTaskCommandAttributes, command::Attributes},
-            enums::v1::EventType,
-            failure::v1::failure::FailureInfo,
+            enums::v1::{ApplicationErrorCategory, EventType},
+            failure::v1::{ApplicationFailureInfo, Failure, failure::FailureInfo},
             workflowservice::v1::{
                 GetSystemInfoResponse, PollActivityTaskQueueResponse,
                 RecordActivityTaskHeartbeatRequest, RecordActivityTaskHeartbeatResponse,
@@ -1036,6 +1037,102 @@ async fn oversized_cancel_details_fails_activity() {
         result: Some(ActivityExecutionResult::cancel_from_details(Some(
             vec![1_u8; 1024].into(),
         ))),
+    })
+    .await
+    .unwrap();
+    core.drain_activity_poller_and_shutdown().await;
+}
+
+/// Oversized *final* heartbeat details replace whatever lang reported, so the cause and failure sent
+/// to the server describe the payload-limit violation rather than the activity's own error, and the
+/// oversized details are dropped so the server does not reject the whole request.
+#[tokio::test]
+async fn oversized_final_heartbeat_details_replace_reported_failure() {
+    // Manually created because we need non-default payload error limits, and mockall matches
+    // expectations in creation order, so they cannot be overridden after `mock_worker_client`.
+    // This will no longer be needed if https://github.com/asomers/mockall/issues/283 is implemented.
+    let mut mock_client = MockWorkerClient::new();
+    let workers = Arc::new(ClientWorkerSet::new());
+    mock_client
+        .expect_payload_error_limits()
+        .returning(|| Some(PayloadErrorLimits { blob: 10, memo: 10 }));
+    mock_client
+        .expect_capabilities()
+        .returning(|| Some(*DEFAULT_TEST_CAPABILITIES));
+    mock_client
+        .expect_workers()
+        .returning(move || workers.clone());
+    mock_client.expect_is_mock().returning(|| true);
+    mock_client
+        .expect_shutdown_worker()
+        .returning(|_, _, _, _| Ok(ShutdownWorkerResponse {}));
+    mock_client
+        .expect_sdk_name_and_version()
+        .returning(|| ("test-core".to_string(), "0.0.0".to_string()));
+    mock_client
+        .expect_identity()
+        .returning(|| "test-identity".to_string());
+    mock_client
+        .expect_worker_grouping_key()
+        .returning(Uuid::new_v4);
+    mock_client
+        .expect_worker_instance_key()
+        .returning(Uuid::new_v4);
+    mock_client
+        .expect_set_heartbeat_client_fields()
+        .returning(|_| {});
+    mock_client
+        .expect_record_activity_heartbeat()
+        .returning(|_, _| Ok(RecordActivityTaskHeartbeatResponse::default()));
+    mock_client.expect_fail_activity_task().times(1).returning(
+        |_, cause, failure, last_heartbeat_details| {
+            assert_eq!(cause, ActivityTaskFailedCause::PayloadsTooLarge);
+            assert_payloads_too_large_retryable(&failure);
+            assert!(
+                last_heartbeat_details.is_none(),
+                "oversized details must be dropped"
+            );
+            Ok(RespondActivityTaskFailedResponse::default())
+        },
+    );
+
+    let core = mock_worker(MocksHolder::from_client_with_activities(
+        mock_client,
+        [PollActivityTaskQueueResponse {
+            task_token: vec![1],
+            activity_id: "act1".to_string(),
+            heartbeat_timeout: Some(prost_dur!(from_secs(10))),
+            ..Default::default()
+        }
+        .into()],
+    ));
+
+    let act = core.poll_activity_task().await.unwrap();
+    core.record_activity_heartbeat(ActivityHeartbeat {
+        task_token: act.task_token.clone(),
+        details: vec![vec![0_u8; 1024].into()],
+    });
+    // A benign failure is normally not reported as an execution failure at all; what reaches the
+    // server here is a payload-limit failure instead, which is not benign.
+    core.complete_activity_task(ActivityTaskCompletion {
+        task_token: act.task_token,
+        result: Some(ActivityExecutionResult {
+            status: Some(activity_execution_result::Status::Failed(
+                activity_result::Failure {
+                    failure: Some(Failure {
+                        message: "benign".to_string(),
+                        failure_info: Some(FailureInfo::ApplicationFailureInfo(
+                            ApplicationFailureInfo {
+                                category: ApplicationErrorCategory::Benign as i32,
+                                ..Default::default()
+                            },
+                        )),
+                        ..Default::default()
+                    }),
+                    cause: ActivityTaskFailedCause::ActivityWorkerUnhandledFailure as i32,
+                },
+            )),
+        }),
     })
     .await
     .unwrap();

--- a/crates/sdk-core/src/core_tests/workflow_tasks.rs
+++ b/crates/sdk-core/src/core_tests/workflow_tasks.rs
@@ -317,7 +317,7 @@ async fn scheduled_activity_timeout(hist_batches: &'static [usize]) {
                                     seq,
                                     result: Some(ActivityResolution {
                                         status: Some(activity_resolution::Status::Failed(ar::Failure {
-                                            failure: Some(failure)
+                                            failure: Some(failure), ..
                                         })),
                                     }), ..
                                 }
@@ -370,7 +370,7 @@ async fn started_activity_timeout(hist_batches: &'static [usize]) {
                                     seq,
                                     result: Some(ActivityResolution {
                                         status: Some(activity_resolution::Status::Failed(ar::Failure {
-                                            failure: Some(failure)
+                                            failure: Some(failure), ..
                                         })),
                                     }), ..
                                 }

--- a/crates/sdk-core/src/telemetry/metrics.rs
+++ b/crates/sdk-core/src/telemetry/metrics.rs
@@ -10,7 +10,10 @@ use std::{
     time::Duration,
 };
 use temporalio_common::{
-    protos::temporal::api::{enums::v1::WorkflowTaskFailedCause, failure::v1::Failure},
+    protos::{
+        coresdk::activity_result::ActivityTaskFailedCause,
+        temporal::api::{enums::v1::WorkflowTaskFailedCause, failure::v1::Failure},
+    },
     telemetry::metrics::{core::*, *},
 };
 
@@ -755,22 +758,26 @@ pub(crate) fn eager(is_eager: bool) -> MetricKeyValue {
 pub(crate) enum FailureReason {
     Nondeterminism,
     Workflow,
+    Activity,
     Timeout,
     NexusOperation(String),
     NexusHandlerError(String),
     GrpcMessageTooLarge,
     PayloadsTooLarge,
+    ExternalStorageError,
 }
 impl Display for FailureReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let str = match self {
             FailureReason::Nondeterminism => "NonDeterminismError".to_owned(),
             FailureReason::Workflow => "WorkflowError".to_owned(),
+            FailureReason::Activity => "ActivityError".to_owned(),
             FailureReason::Timeout => "timeout".to_owned(),
             FailureReason::NexusOperation(op) => format!("operation_{op}"),
             FailureReason::NexusHandlerError(op) => format!("handler_error_{op}"),
             FailureReason::GrpcMessageTooLarge => "GrpcMessageTooLarge".to_owned(),
             FailureReason::PayloadsTooLarge => "PayloadsTooLarge".to_owned(),
+            FailureReason::ExternalStorageError => "ExternalStorageError".to_owned(),
         };
         write!(f, "{str}")
     }
@@ -780,6 +787,16 @@ impl From<WorkflowTaskFailedCause> for FailureReason {
         match v {
             WorkflowTaskFailedCause::NonDeterministicError => FailureReason::Nondeterminism,
             _ => FailureReason::Workflow,
+        }
+    }
+}
+impl From<ActivityTaskFailedCause> for FailureReason {
+    fn from(v: ActivityTaskFailedCause) -> Self {
+        match v {
+            ActivityTaskFailedCause::PayloadsTooLarge => FailureReason::PayloadsTooLarge,
+            ActivityTaskFailedCause::ExternalStorageFailure => FailureReason::ExternalStorageError,
+            ActivityTaskFailedCause::Unspecified
+            | ActivityTaskFailedCause::ActivityWorkerUnhandledFailure => FailureReason::Activity,
         }
     }
 }

--- a/crates/sdk-core/src/test_help/integ_helpers.rs
+++ b/crates/sdk-core/src/test_help/integ_helpers.rs
@@ -6,7 +6,10 @@ pub use crate::{
     internal_flags::CoreInternalFlags,
     worker::{
         LEGACY_QUERY_ID,
-        client::{LegacyQueryResult, mocks::mock_worker_client},
+        client::{
+            LegacyQueryResult,
+            mocks::{mock_worker_client, mock_worker_client_with_error_limits},
+        },
     },
 };
 

--- a/crates/sdk-core/src/test_help/integ_helpers.rs
+++ b/crates/sdk-core/src/test_help/integ_helpers.rs
@@ -6,10 +6,7 @@ pub use crate::{
     internal_flags::CoreInternalFlags,
     worker::{
         LEGACY_QUERY_ID,
-        client::{
-            LegacyQueryResult,
-            mocks::{mock_worker_client, mock_worker_client_with_error_limits},
-        },
+        client::{LegacyQueryResult, mocks::mock_worker_client},
     },
 };
 

--- a/crates/sdk-core/src/worker/activities.rs
+++ b/crates/sdk-core/src/worker/activities.rs
@@ -442,7 +442,14 @@ impl WorkerActivityTasks {
                                 Some(make_payloads_too_large_failure(violation)),
                             )
                         } else {
-                            let cause = fail.cause();
+                            // An SDK reporting no cause recognized nothing more specific, which is
+                            // normalized to unhandled failure so all SDKs do not have to specify it.
+                            let cause = match fail.cause() {
+                                ActivityTaskFailedCause::Unspecified => {
+                                    ActivityTaskFailedCause::ActivityWorkerUnhandledFailure
+                                }
+                                c => c,
+                            };
                             if should_record_failure_metric(&fail.failure) {
                                 act_metrics
                                     .with_new_attrs([failure_reason(cause.into())])

--- a/crates/sdk-core/src/worker/activities.rs
+++ b/crates/sdk-core/src/worker/activities.rs
@@ -14,7 +14,8 @@ use crate::{
     },
     pollers::{BoxedActPoller, PermittedTqResp, TrackedPermittedTqResp, new_activity_task_poller},
     telemetry::metrics::{
-        MetricsContext, activity_type, eager, should_record_failure_metric, workflow_type,
+        FailureReason, MetricsContext, activity_type, eager, failure_reason,
+        should_record_failure_metric, workflow_type,
     },
     worker::{
         ActivitySlotKind, PollError,
@@ -36,13 +37,17 @@ use std::{
     },
     time::{Duration, Instant, SystemTime},
 };
-use temporalio_client::{payload_limit_violation_from, worker::CancelActivityCallback};
+use temporalio_client::{
+    PayloadErrorLimits, payload_limit_violation_from, worker::CancelActivityCallback,
+};
 use temporalio_common::{
-    payload_limits::PayloadLimitViolation,
+    payload_limits::{PayloadLimitViolation, PayloadLimits, validate_known_payload_limits},
     protos::{
         coresdk::{
             ActivityHeartbeat, ActivitySlotInfo,
-            activity_result::{self as ar, activity_execution_result as aer},
+            activity_result::{
+                self as ar, ActivityTaskFailedCause, activity_execution_result as aer,
+            },
             activity_task::{ActivityCancelReason, ActivityCancellationDetails, ActivityTask},
         },
         temporal::api::{
@@ -50,7 +55,9 @@ use temporalio_common::{
             failure::v1::{
                 ApplicationFailureInfo, CanceledFailureInfo, Failure, failure::FailureInfo,
             },
-            workflowservice::v1::PollActivityTaskQueueResponse,
+            workflowservice::v1::{
+                PollActivityTaskQueueResponse, RecordActivityTaskHeartbeatRequest,
+            },
         },
     },
 };
@@ -363,13 +370,24 @@ impl WorkerActivityTasks {
                 .evict(task_token.clone(), should_flush)
                 .await;
 
-            let last_heartbeat_details = act_info
-                .last_heartbeat_details
-                .map(|payloads| Payloads { payloads });
-
             // No need to report activities which we already know the server doesn't care about
             if !known_not_found {
                 let _flushing_guard = self.completers_lock.read().await;
+
+                let mut last_heartbeat_details = act_info
+                    .last_heartbeat_details
+                    .map(|payloads| Payloads { payloads });
+                // Only failure reports carry these to the server, and oversized details would make
+                // the server reject such a request outright, so drop them and report the violation
+                // as the failure instead. Checked here rather than in the client so that the
+                // reported failure, the cause, and the metric can't disagree about what happened.
+                let heartbeat_details_violation = last_heartbeat_details.as_ref().and_then(|d| {
+                    heartbeat_details_limit_violation(d, client.payload_error_limits())
+                });
+                if heartbeat_details_violation.is_some() {
+                    last_heartbeat_details = None;
+                }
+
                 let maybe_net_err = match status {
                     aer::Status::WillCompleteAsync(_) => None,
                     aer::Status::Completed(ar::Success { result }) => {
@@ -390,10 +408,15 @@ impl WorkerActivityTasks {
                             }
                             Err(e) => {
                                 if let Some(violation) = payload_limit_violation_from(&e) {
-                                    act_metrics.act_execution_failed();
+                                    act_metrics
+                                        .with_new_attrs([failure_reason(
+                                            FailureReason::PayloadsTooLarge,
+                                        )])
+                                        .act_execution_failed();
                                     client
                                         .fail_activity_task(
                                             task_token.clone(),
+                                            ActivityTaskFailedCause::PayloadsTooLarge,
                                             Some(make_payloads_too_large_failure(violation)),
                                             last_heartbeat_details.clone(),
                                         )
@@ -405,12 +428,35 @@ impl WorkerActivityTasks {
                             }
                         }
                     }
-                    aer::Status::Failed(ar::Failure { failure }) => {
-                        if should_record_failure_metric(&failure) {
-                            act_metrics.act_execution_failed();
-                        }
+                    aer::Status::Failed(fail) => {
+                        let (cause, failure) = if let Some(violation) =
+                            heartbeat_details_violation.as_ref()
+                        {
+                            // What reaches the server is no longer whatever lang reported, so
+                            // the metric must be recorded even for an otherwise benign failure.
+                            act_metrics
+                                .with_new_attrs([failure_reason(FailureReason::PayloadsTooLarge)])
+                                .act_execution_failed();
+                            (
+                                ActivityTaskFailedCause::PayloadsTooLarge,
+                                Some(make_payloads_too_large_failure(violation)),
+                            )
+                        } else {
+                            let cause = fail.cause();
+                            if should_record_failure_metric(&fail.failure) {
+                                act_metrics
+                                    .with_new_attrs([failure_reason(cause.into())])
+                                    .act_execution_failed();
+                            }
+                            (cause, fail.failure)
+                        };
                         client
-                            .fail_activity_task(task_token.clone(), failure, last_heartbeat_details)
+                            .fail_activity_task(
+                                task_token.clone(),
+                                cause,
+                                failure,
+                                last_heartbeat_details,
+                            )
                             .await
                             .err()
                     }
@@ -422,10 +468,21 @@ impl WorkerActivityTasks {
                             // We report cancels for graceful shutdown as failures, so we
                             // don't wait for the whole timeout to elapse, which is what would
                             // happen anyway.
+                            let (cause, failure) = match heartbeat_details_violation.as_ref() {
+                                Some(violation) => (
+                                    ActivityTaskFailedCause::PayloadsTooLarge,
+                                    make_payloads_too_large_failure(violation),
+                                ),
+                                None => (
+                                    ActivityTaskFailedCause::ActivityWorkerUnhandledFailure,
+                                    worker_shutdown_failure(),
+                                ),
+                            };
                             client
                                 .fail_activity_task(
                                     task_token.clone(),
-                                    Some(worker_shutdown_failure()),
+                                    cause,
+                                    Some(failure),
                                     last_heartbeat_details,
                                 )
                                 .await
@@ -453,10 +510,15 @@ impl WorkerActivityTasks {
                                 Ok(_) => None,
                                 Err(e) => {
                                     if let Some(violation) = payload_limit_violation_from(&e) {
-                                        act_metrics.act_execution_failed();
+                                        act_metrics
+                                            .with_new_attrs([failure_reason(
+                                                FailureReason::PayloadsTooLarge,
+                                            )])
+                                            .act_execution_failed();
                                         client
                                             .fail_activity_task(
                                                 task_token.clone(),
+                                                ActivityTaskFailedCause::PayloadsTooLarge,
                                                 Some(make_payloads_too_large_failure(violation)),
                                                 last_heartbeat_details,
                                             )
@@ -805,6 +867,26 @@ fn worker_shutdown_failure() -> Failure {
             },
         )),
     }
+}
+
+/// Validates final heartbeat details against the worker's payload error limits, since attaching
+/// oversized details to a failure request would make the server reject the request as a whole.
+fn heartbeat_details_limit_violation(
+    details: &Payloads,
+    limits: Option<PayloadErrorLimits>,
+) -> Option<PayloadLimitViolation> {
+    let limits = limits?;
+    validate_known_payload_limits(
+        &RecordActivityTaskHeartbeatRequest {
+            details: Some(details.clone()),
+            ..Default::default()
+        },
+        &PayloadLimits {
+            blob_error: limits.blob,
+            memo_error: limits.memo,
+            ..Default::default()
+        },
+    )
 }
 
 /// The failure is deliberately retryable: catching the violation client-side exists precisely to

--- a/crates/sdk-core/src/worker/activities/activity_heartbeat_manager.rs
+++ b/crates/sdk-core/src/worker/activities/activity_heartbeat_manager.rs
@@ -16,6 +16,7 @@ use temporalio_client::payload_limit_violation_from;
 use temporalio_common::protos::{
     coresdk::{
         ActivityHeartbeat, IntoPayloadsExt,
+        activity_result::ActivityTaskFailedCause,
         activity_task::{ActivityCancelReason, ActivityCancellationDetails, ActivityTask},
     },
     temporal::api::{
@@ -201,6 +202,7 @@ impl ActivityHeartbeatManager {
                                             if let Err(fe) = sg
                                                 .fail_activity_task(
                                                     tt.clone(),
+                                                    ActivityTaskFailedCause::PayloadsTooLarge,
                                                     Some(make_payloads_too_large_failure(violation)),
                                                     None,
                                                 )

--- a/crates/sdk-core/src/worker/activities/local_activities.rs
+++ b/crates/sdk-core/src/worker/activities/local_activities.rs
@@ -2,7 +2,9 @@ use crate::{
     MetricsContext, TaskToken,
     abstractions::{MeteredPermitDealer, OwnedMeteredSemPermit, UsedMeteredSemPermit, dbg_panic},
     protosext::ValidScheduleLA,
-    telemetry::metrics::{activity_type, should_record_failure_metric, workflow_type},
+    telemetry::metrics::{
+        FailureReason, activity_type, failure_reason, should_record_failure_metric, workflow_type,
+    },
     worker::{LocalActivitySlotKind, workflow::HeartbeatTimeoutMsg},
 };
 use futures_util::{
@@ -80,6 +82,7 @@ impl LocalActivityExecutionResult {
                 )),
                 ..Default::default()
             }),
+            ..Default::default()
         })
     }
 
@@ -612,14 +615,18 @@ impl LocalActivityManager {
             let outcome = match &status {
                 LocalActivityExecutionResult::Failed(fail) => {
                     if should_record_failure_metric(&fail.failure) {
-                        la_metrics.la_execution_failed()
+                        la_metrics
+                            .with_new_attrs([failure_reason(fail.cause().into())])
+                            .la_execution_failed()
                     }
                     Outcome::FailurePath {
                         backoff: calc_backoff!(fail),
                     }
                 }
                 LocalActivityExecutionResult::TimedOut(fail) => {
-                    la_metrics.la_execution_failed();
+                    la_metrics
+                        .with_new_attrs([failure_reason(FailureReason::Timeout)])
+                        .la_execution_failed();
                     is_timeout = true;
                     // Start to close timeouts are retryable, other timeout types aren't.
                     if matches!(status.get_timeout_type(), Some(TimeoutType::StartToClose)) {
@@ -1284,6 +1291,7 @@ mod tests {
                     )),
                     ..Default::default()
                 }),
+                ..Default::default()
             }),
         );
         assert_matches!(res, LACompleteAction::Report { .. });

--- a/crates/sdk-core/src/worker/client.rs
+++ b/crates/sdk-core/src/worker/client.rs
@@ -20,7 +20,10 @@ use temporalio_client::{
 };
 use temporalio_common::protos::{
     TaskToken,
-    coresdk::{workflow_commands::QueryResult, workflow_completion},
+    coresdk::{
+        activity_result::ActivityTaskFailedCause, workflow_commands::QueryResult,
+        workflow_completion,
+    },
     temporal::api::{
         command::v1::Command,
         common::v1::{
@@ -211,6 +214,7 @@ pub trait WorkerClient: Sync + Send {
     async fn fail_activity_task(
         &self,
         task_token: TaskToken,
+        cause: ActivityTaskFailedCause,
         failure: Option<Failure>,
         last_heartbeat_details: Option<Payloads>,
     ) -> Result<RespondActivityTaskFailedResponse>;
@@ -282,6 +286,10 @@ pub trait WorkerClient: Sync + Send {
     fn set_heartbeat_client_fields(&self, heartbeat: &mut WorkerHeartbeat);
     /// Set the worker's payload/memo error limits
     fn set_payload_error_limits(&self, _limits: Option<PayloadErrorLimits>) {}
+    /// Get the worker's payload/memo error limits
+    fn payload_error_limits(&self) -> Option<PayloadErrorLimits> {
+        None
+    }
 }
 
 /// Configuration options shared by workflow, activity, and Nexus polling calls
@@ -613,34 +621,13 @@ impl WorkerClient for WorkerClientBag {
     async fn fail_activity_task(
         &self,
         task_token: TaskToken,
-        mut failure: Option<Failure>,
-        mut last_heartbeat_details: Option<Payloads>,
+        // Unused until `RespondActivityTaskFailedRequest` gains a cause field
+        //  (https://github.com/temporalio/api/pull/816). Taken as a parameter regardless so the
+        //  cause is decided next to the failure it describes, as `fail_workflow_task` does.
+        _cause: ActivityTaskFailedCause,
+        failure: Option<Failure>,
+        last_heartbeat_details: Option<Payloads>,
     ) -> Result<RespondActivityTaskFailedResponse> {
-        let payload_error_limits = self.client.error_limits();
-        if let (Some(details), Some(limits)) =
-            (last_heartbeat_details.as_ref(), payload_error_limits)
-        {
-            let heartbeat_request = RecordActivityTaskHeartbeatRequest {
-                details: Some(details.clone()),
-                ..Default::default()
-            };
-            let payload_limits = temporalio_common::payload_limits::PayloadLimits {
-                blob_error: limits.blob,
-                memo_error: limits.memo,
-                ..Default::default()
-            };
-            if let Some(violation) =
-                temporalio_common::payload_limits::validate_known_payload_limits(
-                    &heartbeat_request,
-                    &payload_limits,
-                )
-            {
-                failure = Some(crate::worker::activities::make_payloads_too_large_failure(
-                    &violation,
-                ));
-                last_heartbeat_details = None;
-            }
-        }
         Ok(self
             .client
             .clone()
@@ -938,6 +925,10 @@ impl WorkerClient for WorkerClientBag {
     fn set_payload_error_limits(&self, limits: Option<PayloadErrorLimits>) {
         self.client.set_error_limits(limits);
     }
+
+    fn payload_error_limits(&self) -> Option<PayloadErrorLimits> {
+        self.client.error_limits()
+    }
 }
 
 impl NamespacedClient for WorkerClientBag {
@@ -1069,6 +1060,7 @@ mod tests {
         client
             .fail_activity_task(
                 TaskToken(vec![1]),
+                ActivityTaskFailedCause::ActivityWorkerUnhandledFailure,
                 None,
                 Some(last_heartbeat_details.clone()),
             )

--- a/crates/sdk-core/src/worker/client/mocks.rs
+++ b/crates/sdk-core/src/worker/client/mocks.rs
@@ -22,18 +22,8 @@ pub(crate) static DEFAULT_TEST_CAPABILITIES: &Capabilities = &Capabilities {
 #[cfg(any(feature = "test-utilities", test))]
 /// Create a mock client primed with basic necessary expectations
 pub fn mock_worker_client() -> MockWorkerClient {
-    mock_worker_client_with_error_limits(None)
-}
-
-#[cfg(any(feature = "test-utilities", test))]
-/// As [mock_worker_client], reporting the given payload/memo error limits. Mockall matches
-/// expectations in creation order, so limits must be set here rather than overridden afterward.
-pub fn mock_worker_client_with_error_limits(
-    error_limits: Option<PayloadErrorLimits>,
-) -> MockWorkerClient {
     let mut r = MockWorkerClient::new();
-    r.expect_payload_error_limits()
-        .returning(move || error_limits);
+    r.expect_payload_error_limits().returning(|| None);
     let workers = Arc::new(ClientWorkerSet::new());
     r.expect_capabilities()
         .returning(|| Some(*DEFAULT_TEST_CAPABILITIES));

--- a/crates/sdk-core/src/worker/client/mocks.rs
+++ b/crates/sdk-core/src/worker/client/mocks.rs
@@ -26,6 +26,8 @@ pub fn mock_worker_client() -> MockWorkerClient {
 }
 
 #[cfg(any(feature = "test-utilities", test))]
+/// As [mock_worker_client], reporting the given payload/memo error limits. Mockall matches
+/// expectations in creation order, so limits must be set here rather than overridden afterward.
 pub fn mock_worker_client_with_error_limits(
     error_limits: Option<PayloadErrorLimits>,
 ) -> MockWorkerClient {

--- a/crates/sdk-core/src/worker/client/mocks.rs
+++ b/crates/sdk-core/src/worker/client/mocks.rs
@@ -22,7 +22,16 @@ pub(crate) static DEFAULT_TEST_CAPABILITIES: &Capabilities = &Capabilities {
 #[cfg(any(feature = "test-utilities", test))]
 /// Create a mock client primed with basic necessary expectations
 pub fn mock_worker_client() -> MockWorkerClient {
+    mock_worker_client_with_error_limits(None)
+}
+
+#[cfg(any(feature = "test-utilities", test))]
+pub fn mock_worker_client_with_error_limits(
+    error_limits: Option<PayloadErrorLimits>,
+) -> MockWorkerClient {
     let mut r = MockWorkerClient::new();
+    r.expect_payload_error_limits()
+        .returning(move || error_limits);
     let workers = Arc::new(ClientWorkerSet::new());
     r.expect_capabilities()
         .returning(|| Some(*DEFAULT_TEST_CAPABILITIES));
@@ -113,6 +122,7 @@ mockall::mock! {
         fn fail_activity_task<'a, 'b>(
             &self,
             task_token: TaskToken,
+            cause: ActivityTaskFailedCause,
             failure: Option<Failure>,
             last_heartbeat_details: Option<Payloads>,
         ) -> impl Future<Output = Result<RespondActivityTaskFailedResponse>> + Send + 'b

--- a/crates/sdk-core/src/worker/workflow/machines/activity_state_machine.rs
+++ b/crates/sdk-core/src/worker/workflow/machines/activity_state_machine.rs
@@ -324,6 +324,7 @@ impl WFMachinesAdapter for ActivityMachine {
                         result: Some(ActivityResolution {
                             status: Some(activity_resolution::Status::Failed(ar::Failure {
                                 failure: Some(failure),
+                                ..Default::default()
                             })),
                         }),
                         is_local: false,

--- a/crates/sdk-core/src/worker/workflow/machines/local_activity_state_machine.rs
+++ b/crates/sdk-core/src/worker/workflow/machines/local_activity_state_machine.rs
@@ -134,6 +134,7 @@ impl From<CompleteLocalActivityData> for ResolveDat {
                     } else {
                         LocalActivityExecutionResult::Failed(ActFail {
                             failure: Some(fail),
+                            ..Default::default()
                         })
                     }
                 }
@@ -616,7 +617,7 @@ impl WFMachinesAdapter for LocalActivityMachine {
                         maybe_failure = fail.failure;
                     }
                     LocalActivityExecutionResult::Cancelled(Cancellation { failure })
-                    | LocalActivityExecutionResult::TimedOut(ActFail { failure }) => {
+                    | LocalActivityExecutionResult::TimedOut(ActFail { failure, .. }) => {
                         will_not_run_again = true;
                         maybe_failure = failure;
                     }

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -19,15 +19,16 @@ use std::{
     time::Duration,
 };
 use temporalio_client::{
-    Connection, MESSAGE_TOO_LARGE_KEY, NamespacedClient, PayloadErrorLimits,
-    REQUEST_LATENCY_HISTOGRAM_NAME, UntypedQuery, UntypedWorkflow, WorkflowExecutionInfo,
-    WorkflowQueryOptions, WorkflowStartOptions, grpc::WorkflowService,
+    Connection, MESSAGE_TOO_LARGE_KEY, NamespacedClient, REQUEST_LATENCY_HISTOGRAM_NAME,
+    UntypedQuery, UntypedWorkflow, WorkflowExecutionInfo, WorkflowQueryOptions,
+    WorkflowStartOptions, grpc::WorkflowService,
 };
 use temporalio_common::{
     data_converters::RawValue,
+    payload_limits::{LimitClass, LimitSeverity, PayloadLimitViolation},
     protos::{
         coresdk::{
-            ActivityHeartbeat, ActivityTaskCompletion,
+            ActivityTaskCompletion,
             activity_result::{
                 self as activity_result, ActivityExecutionResult, ActivityTaskFailedCause,
                 activity_execution_result,
@@ -44,10 +45,10 @@ use temporalio_common::{
         temporal::api::{
             common::v1::RetryPolicy,
             enums::v1::{
-                ApplicationErrorCategory, NexusHandlerErrorRetryBehavior, WorkflowIdConflictPolicy,
-                WorkflowIdReusePolicy, WorkflowTaskFailedCause,
+                NexusHandlerErrorRetryBehavior, WorkflowIdConflictPolicy, WorkflowIdReusePolicy,
+                WorkflowTaskFailedCause,
             },
-            failure::v1::{ApplicationFailureInfo, Failure, failure},
+            failure::v1::Failure,
             nexus::{
                 self,
                 v1::{
@@ -86,7 +87,7 @@ use temporalio_sdk_core::{
     replay::TestHistoryBuilder,
     test_help::{
         MockPollCfg, MocksHolder, ResponseType, TemporalMeter, WorkerExt, WorkerTestHelpers,
-        build_mock_pollers, mock_worker, mock_worker_client, mock_worker_client_with_error_limits,
+        build_mock_pollers, mock_worker, mock_worker_client,
     },
 };
 use tokio::{
@@ -2197,31 +2198,37 @@ async fn lang_reported_activity_failure_cause_reaches_metric() {
     );
 }
 
-/// Oversized heartbeat details replace whatever lang reported, so the metric must be recorded with
-/// the payload-limit reason even when the lang failure was benign (benign failures are otherwise
-/// not counted at all).
+/// A payload-limit violation detected while reporting an activity result is core's own doing, so it
+/// must reach the metric as its own reason rather than the generic activity one.
 #[tokio::test]
-async fn benign_failure_with_oversized_heartbeat_details_counts_as_payloads_too_large() {
+async fn payloads_too_large_activity_failure_reaches_metric() {
     let (telemopts, addr, _aborter) = prom_metrics(None);
     let rt = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
     let meter = rt.telemetry().get_temporal_metric_meter().unwrap();
 
-    let mut mock_client =
-        mock_worker_client_with_error_limits(Some(PayloadErrorLimits { blob: 10, memo: 10 }));
+    let mut mock_client = mock_worker_client();
     mock_client
-        .expect_record_activity_heartbeat()
-        .returning(|_, _| Ok(Default::default()));
-    mock_client.expect_fail_activity_task().times(1).returning(
-        |_, cause, failure, last_heartbeat_details| {
+        .expect_complete_activity_task()
+        .times(1)
+        .returning(|_, _| {
+            let violation = PayloadLimitViolation {
+                path: "result".to_string(),
+                class: LimitClass::Blob,
+                severity: LimitSeverity::Error,
+                size: 1024,
+                limit: 10,
+            };
+            let mut status = tonic::Status::invalid_argument("Payload size limit exceeded");
+            status.set_source(Arc::new(violation));
+            Err(status)
+        });
+    mock_client
+        .expect_fail_activity_task()
+        .times(1)
+        .returning(|_, cause, _, _| {
             assert_eq!(cause, ActivityTaskFailedCause::PayloadsTooLarge);
-            assert!(
-                last_heartbeat_details.is_none(),
-                "oversized details must be dropped"
-            );
-            assert!(failure.is_some(), "failure present");
             Ok(Default::default())
-        },
-    );
+        });
 
     let mut mock = MocksHolder::from_client_with_activities(
         mock_client,
@@ -2229,7 +2236,6 @@ async fn benign_failure_with_oversized_heartbeat_details_counts_as_payloads_too_
             task_token: vec![1],
             activity_id: "act1".to_string(),
             activity_type: Some("act_type".into()),
-            heartbeat_timeout: Some(prost_dur!(from_secs(10))),
             ..Default::default()
         }
         .into()],
@@ -2238,29 +2244,9 @@ async fn benign_failure_with_oversized_heartbeat_details_counts_as_payloads_too_
     let core = mock_worker(mock);
 
     let act = core.poll_activity_task().await.unwrap();
-    core.record_activity_heartbeat(ActivityHeartbeat {
-        task_token: act.task_token.clone(),
-        details: vec![vec![0_u8; 1024].into()],
-    });
     core.complete_activity_task(ActivityTaskCompletion {
         task_token: act.task_token,
-        result: Some(ActivityExecutionResult {
-            status: Some(activity_execution_result::Status::Failed(
-                activity_result::Failure {
-                    failure: Some(Failure {
-                        message: "benign".to_string(),
-                        failure_info: Some(failure::FailureInfo::ApplicationFailureInfo(
-                            ApplicationFailureInfo {
-                                category: ApplicationErrorCategory::Benign as i32,
-                                ..Default::default()
-                            },
-                        )),
-                        ..Default::default()
-                    }),
-                    cause: ActivityTaskFailedCause::ActivityWorkerUnhandledFailure as i32,
-                },
-            )),
-        }),
+        result: Some(ActivityExecutionResult::ok(vec![0_u8; 1024].into())),
     })
     .await
     .unwrap();

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -1018,7 +1018,7 @@ async fn activity_metrics() {
         async fn pass_fail_act(ctx: ActivityContext, i: String) -> Result<String, ActivityError> {
             match i.as_str() {
                 "pass" => Ok("pass".to_string()),
-                "cancel" => {
+                "cancel" | "timeout" => {
                     ctx.cancelled().await;
                     Err(ActivityError::cancelled())
                 }
@@ -1089,7 +1089,23 @@ async fn activity_metrics() {
                     )
                     .build(),
             );
-            let _ = join!(local_act_pass, local_act_fail);
+            // Outlives its start-to-close timeout, so core resolves it as timed out rather than
+            // as the cancel the activity reports once core stops it.
+            let local_act_timeout = ctx.execute_local_activity(
+                PassFailActivities::pass_fail_act,
+                "timeout".to_string(),
+                LocalActivityOptions::builder()
+                    .start_to_close_timeout(Duration::from_millis(100))
+                    .retry_policy(
+                        RetryPolicy {
+                            maximum_attempts: 1,
+                            ..Default::default()
+                        }
+                        .into(),
+                    )
+                    .build(),
+            );
+            let _ = join!(local_act_pass, local_act_fail, local_act_timeout);
             // TODO: Currently takes a WFT b/c of https://github.com/temporalio/sdk-core/issues/856
             local_act_cancel.cancel();
             let _ = local_act_cancel.await;
@@ -1136,11 +1152,18 @@ async fn activity_metrics() {
     assert!(body.contains(&format!(
         "temporal_local_activity_total{{activity_type=\"pass_fail_act\",namespace=\"{NAMESPACE}\",\
              service_name=\"temporal-core-sdk\",task_queue=\"{task_queue}\",\
-             workflow_type=\"{wf_type}\"}} 3"
+             workflow_type=\"{wf_type}\"}} 4"
     )));
     assert!(body.contains(&format!(
         "temporal_local_activity_execution_failed{{activity_type=\"pass_fail_act\",\
              failure_reason=\"ActivityError\",\
+             namespace=\"{NAMESPACE}\",service_name=\"temporal-core-sdk\",\
+             task_queue=\"{task_queue}\",\
+             workflow_type=\"{wf_type}\"}} 1"
+    )));
+    assert!(body.contains(&format!(
+        "temporal_local_activity_execution_failed{{activity_type=\"pass_fail_act\",\
+             failure_reason=\"timeout\",\
              namespace=\"{NAMESPACE}\",service_name=\"temporal-core-sdk\",\
              task_queue=\"{task_queue}\",\
              workflow_type=\"{wf_type}\"}} 1"
@@ -1155,7 +1178,7 @@ async fn activity_metrics() {
         "temporal_local_activity_execution_latency_count{{activity_type=\"pass_fail_act\",\
              namespace=\"{NAMESPACE}\",service_name=\"temporal-core-sdk\",\
              task_queue=\"{task_queue}\",\
-             workflow_type=\"{wf_type}\"}} 3"
+             workflow_type=\"{wf_type}\"}} 4"
     )));
     assert!(body.contains(&format!(
         "temporal_local_activity_succeed_endtoend_latency_count{{activity_type=\"pass_fail_act\",\

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -19,16 +19,19 @@ use std::{
     time::Duration,
 };
 use temporalio_client::{
-    Connection, MESSAGE_TOO_LARGE_KEY, NamespacedClient, REQUEST_LATENCY_HISTOGRAM_NAME,
-    UntypedQuery, UntypedWorkflow, WorkflowExecutionInfo, WorkflowQueryOptions,
-    WorkflowStartOptions, grpc::WorkflowService,
+    Connection, MESSAGE_TOO_LARGE_KEY, NamespacedClient, PayloadErrorLimits,
+    REQUEST_LATENCY_HISTOGRAM_NAME, UntypedQuery, UntypedWorkflow, WorkflowExecutionInfo,
+    WorkflowQueryOptions, WorkflowStartOptions, grpc::WorkflowService,
 };
 use temporalio_common::{
     data_converters::RawValue,
     protos::{
         coresdk::{
-            ActivityTaskCompletion,
-            activity_result::ActivityExecutionResult,
+            ActivityHeartbeat, ActivityTaskCompletion,
+            activity_result::{
+                self as activity_result, ActivityExecutionResult, ActivityTaskFailedCause,
+                activity_execution_result,
+            },
             nexus::{NexusTaskCompletion, nexus_task, nexus_task_completion},
             workflow_activation::{WorkflowActivationJob, workflow_activation_job},
             workflow_commands::{
@@ -41,10 +44,10 @@ use temporalio_common::{
         temporal::api::{
             common::v1::RetryPolicy,
             enums::v1::{
-                NexusHandlerErrorRetryBehavior, WorkflowIdConflictPolicy, WorkflowIdReusePolicy,
-                WorkflowTaskFailedCause,
+                ApplicationErrorCategory, NexusHandlerErrorRetryBehavior, WorkflowIdConflictPolicy,
+                WorkflowIdReusePolicy, WorkflowTaskFailedCause,
             },
-            failure::v1::Failure,
+            failure::v1::{ApplicationFailureInfo, Failure, failure},
             nexus::{
                 self,
                 v1::{
@@ -52,7 +55,9 @@ use temporalio_common::{
                     request::Variant, start_operation_response,
                 },
             },
-            workflowservice::v1::{DescribeNamespaceRequest, ListNamespacesRequest},
+            workflowservice::v1::{
+                DescribeNamespaceRequest, ListNamespacesRequest, PollActivityTaskQueueResponse,
+            },
         },
     },
     telemetry::{
@@ -80,8 +85,8 @@ use temporalio_sdk_core::{
     WorkflowSlotKind, init_worker, prost_dur,
     replay::TestHistoryBuilder,
     test_help::{
-        MockPollCfg, ResponseType, TemporalMeter, WorkerExt, WorkerTestHelpers, build_mock_pollers,
-        mock_worker, mock_worker_client,
+        MockPollCfg, MocksHolder, ResponseType, TemporalMeter, WorkerExt, WorkerTestHelpers,
+        build_mock_pollers, mock_worker, mock_worker_client, mock_worker_client_with_error_limits,
     },
 };
 use tokio::{
@@ -1108,6 +1113,7 @@ async fn activity_metrics() {
     let wf_type = ActivityMetricsWf::name();
     assert!(body.contains(&format!(
         "temporal_activity_execution_failed{{activity_type=\"pass_fail_act\",\
+             failure_reason=\"ActivityError\",\
              namespace=\"{NAMESPACE}\",service_name=\"temporal-core-sdk\",\
              task_queue=\"{task_queue}\",workflow_type=\"{wf_type}\"}} 1"
     )));
@@ -1134,6 +1140,7 @@ async fn activity_metrics() {
     )));
     assert!(body.contains(&format!(
         "temporal_local_activity_execution_failed{{activity_type=\"pass_fail_act\",\
+             failure_reason=\"ActivityError\",\
              namespace=\"{NAMESPACE}\",service_name=\"temporal-core-sdk\",\
              task_queue=\"{task_queue}\",\
              workflow_type=\"{wf_type}\"}} 1"
@@ -2093,5 +2100,167 @@ async fn grpc_message_too_large_wf_task_execution_failed_metric_includes_workflo
     assert!(
         metric_line.contains("workflow_type=\"default_wf_type\""),
         "Expected workflow_type label on metric, got: {metric_line}"
+    );
+}
+
+/// A cause reported by lang must survive to the metric as its own `failure_reason`, rather than
+/// being flattened into the catch-all activity reason.
+#[tokio::test]
+async fn lang_reported_activity_failure_cause_reaches_metric() {
+    let (telemopts, addr, _aborter) = prom_metrics(None);
+    let rt = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
+    let meter = rt.telemetry().get_temporal_metric_meter().unwrap();
+
+    let mut mock_client = mock_worker_client();
+    mock_client
+        .expect_fail_activity_task()
+        .times(1)
+        .returning(|_, cause, _, _| {
+            assert_eq!(cause, ActivityTaskFailedCause::ExternalStorageFailure);
+            Ok(Default::default())
+        });
+
+    let mut mock = MocksHolder::from_client_with_activities(
+        mock_client,
+        [PollActivityTaskQueueResponse {
+            task_token: vec![1],
+            activity_id: "act1".to_string(),
+            activity_type: Some("act_type".into()),
+            ..Default::default()
+        }
+        .into()],
+    );
+    mock.set_temporal_meter(meter);
+    let core = mock_worker(mock);
+
+    let act = core.poll_activity_task().await.unwrap();
+    core.complete_activity_task(ActivityTaskCompletion {
+        task_token: act.task_token,
+        result: Some(ActivityExecutionResult {
+            status: Some(activity_execution_result::Status::Failed(
+                activity_result::Failure {
+                    failure: Some(Failure {
+                        message: "storage exploded".to_string(),
+                        ..Default::default()
+                    }),
+                    cause: ActivityTaskFailedCause::ExternalStorageFailure as i32,
+                },
+            )),
+        }),
+    })
+    .await
+    .unwrap();
+    core.drain_activity_poller_and_shutdown().await;
+
+    let metric_line = eventually(
+        || {
+            let endpoint = format!("http://{addr}/metrics");
+            async move {
+                let body = get_text(endpoint).await;
+                body.lines()
+                    .find(|l| l.starts_with("temporal_activity_execution_failed{"))
+                    .map(ToString::to_string)
+                    .ok_or_else(|| anyhow!("activity_execution_failed metric not found"))
+            }
+        },
+        Duration::from_secs(5),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        metric_line.contains("failure_reason=\"ExternalStorageError\""),
+        "Expected ExternalStorageError failure reason on metric, got: {metric_line}"
+    );
+}
+
+/// Oversized heartbeat details replace whatever lang reported, so the metric must be recorded with
+/// the payload-limit reason even when the lang failure was benign (benign failures are otherwise
+/// not counted at all).
+#[tokio::test]
+async fn benign_failure_with_oversized_heartbeat_details_counts_as_payloads_too_large() {
+    let (telemopts, addr, _aborter) = prom_metrics(None);
+    let rt = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
+    let meter = rt.telemetry().get_temporal_metric_meter().unwrap();
+
+    let mut mock_client =
+        mock_worker_client_with_error_limits(Some(PayloadErrorLimits { blob: 10, memo: 10 }));
+    mock_client
+        .expect_record_activity_heartbeat()
+        .returning(|_, _| Ok(Default::default()));
+    mock_client.expect_fail_activity_task().times(1).returning(
+        |_, cause, failure, last_heartbeat_details| {
+            assert_eq!(cause, ActivityTaskFailedCause::PayloadsTooLarge);
+            assert!(
+                last_heartbeat_details.is_none(),
+                "oversized details must be dropped"
+            );
+            assert!(failure.is_some(), "failure present");
+            Ok(Default::default())
+        },
+    );
+
+    let mut mock = MocksHolder::from_client_with_activities(
+        mock_client,
+        [PollActivityTaskQueueResponse {
+            task_token: vec![1],
+            activity_id: "act1".to_string(),
+            activity_type: Some("act_type".into()),
+            heartbeat_timeout: Some(prost_dur!(from_secs(10))),
+            ..Default::default()
+        }
+        .into()],
+    );
+    mock.set_temporal_meter(meter);
+    let core = mock_worker(mock);
+
+    let act = core.poll_activity_task().await.unwrap();
+    core.record_activity_heartbeat(ActivityHeartbeat {
+        task_token: act.task_token.clone(),
+        details: vec![vec![0_u8; 1024].into()],
+    });
+    core.complete_activity_task(ActivityTaskCompletion {
+        task_token: act.task_token,
+        result: Some(ActivityExecutionResult {
+            status: Some(activity_execution_result::Status::Failed(
+                activity_result::Failure {
+                    failure: Some(Failure {
+                        message: "benign".to_string(),
+                        failure_info: Some(failure::FailureInfo::ApplicationFailureInfo(
+                            ApplicationFailureInfo {
+                                category: ApplicationErrorCategory::Benign as i32,
+                                ..Default::default()
+                            },
+                        )),
+                        ..Default::default()
+                    }),
+                    cause: ActivityTaskFailedCause::ActivityWorkerUnhandledFailure as i32,
+                },
+            )),
+        }),
+    })
+    .await
+    .unwrap();
+    core.drain_activity_poller_and_shutdown().await;
+
+    let metric_line = eventually(
+        || {
+            let endpoint = format!("http://{addr}/metrics");
+            async move {
+                let body = get_text(endpoint).await;
+                body.lines()
+                    .find(|l| l.starts_with("temporal_activity_execution_failed{"))
+                    .map(ToString::to_string)
+                    .ok_or_else(|| anyhow!("activity_execution_failed metric not found"))
+            }
+        },
+        Duration::from_secs(5),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        metric_line.contains("failure_reason=\"PayloadsTooLarge\""),
+        "Expected PayloadsTooLarge failure reason on metric, got: {metric_line}"
     );
 }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -1076,7 +1076,7 @@ async fn activity_non_retryable_failure() {
                 variant: Some(workflow_activation_job::Variant::ResolveActivity(
                     ResolveActivity {seq, result: Some(ActivityResolution{
                     status: Some(act_res::Status::Failed(activity_result::Failure{
-                        failure: Some(f),
+                        failure: Some(f), ..
                     }))}),..}
                 )),
             },
@@ -1143,7 +1143,7 @@ async fn activity_non_retryable_failure_with_error() {
                 variant: Some(workflow_activation_job::Variant::ResolveActivity(
                     ResolveActivity {seq, result: Some(ActivityResolution{
                     status: Some(act_res::Status::Failed(activity_result::Failure{
-                        failure: Some(f),
+                        failure: Some(f), ..
                     }))}),..}
                 )),
             },
@@ -1499,7 +1499,7 @@ async fn started_activity_timeout() {
                         result: Some(ActivityResolution{
                             status: Some(
                                 act_res::Status::Failed(
-                                    activity_result::Failure{failure: Some(_)}
+                                    activity_result::Failure{failure: Some(_), ..}
                                 )
                             ),
                             ..


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Activity and local activity failure counters now carry `failure_reason`, matching workflow and Nexus task failures. Values: `ActivityError` (default), `PayloadsTooLarge`, `ExternalStorageError`, and `timeout` for local activity timeouts. `GrpcMessageTooLarge` has been deliberately left out since activity workers do not produce activity task failures when encountering gRPC message size limit error.
- Also corrects a mislabeled counter: when oversized final heartbeat details replaced the reported failure, the metric was labeled from the lang cause and suppressed entirely for benign failures, though a payloads-too-large failure reached the server.

## Why?

Better metrics observability into known activity failure reasons.

## Checklist
<!--- add/delete as needed --->

1. Closes #1516

2. How was this tested: unit and mock integration tests

3. Any docs updates needed? Yes
