### PR TITLE
Respect counters_total_suffix in Prometheus exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ relevant information.
   `WorkflowStartOptions::start_signal` and `WorkflowStartSignal`.
 
 ### Fixed
+* The Prometheus exporter now respects `PrometheusExporterOptions::counters_total_suffix`,
+  appending `_total` to counter metric names when enabled.
 * An activity failure caused by oversized final heartbeat details is now counted in the
   `temporal_activity_execution_failed` metric as `failure_reason="PayloadsTooLarge"`. Previously it
   was counted under the reason for the failure the activity itself reported, and was not counted at

--- a/crates/common/src/telemetry/prometheus_meter.rs
+++ b/crates/common/src/telemetry/prometheus_meter.rs
@@ -483,6 +483,7 @@ impl MetricAttributable<Box<dyn HistogramF64Base>> for PromHistogramF64 {
 #[derive(Debug)]
 pub struct CorePrometheusMeter {
     registry: Registry,
+    counters_total_suffix: bool,
     use_seconds_for_durations: bool,
     unit_suffix: bool,
     bucket_overrides: crate::telemetry::HistogramBucketOverrides,
@@ -491,12 +492,14 @@ pub struct CorePrometheusMeter {
 impl CorePrometheusMeter {
     pub(super) fn new(
         registry: Registry,
+        counters_total_suffix: bool,
         use_seconds_for_durations: bool,
         unit_suffix: bool,
         bucket_overrides: crate::telemetry::HistogramBucketOverrides,
     ) -> Self {
         Self {
             registry,
+            counters_total_suffix,
             use_seconds_for_durations,
             unit_suffix,
             bucket_overrides,
@@ -558,7 +561,10 @@ impl CoreMeter for CorePrometheusMeter {
     }
 
     fn counter(&self, params: MetricParameters) -> Counter {
-        let metric_name = params.name.to_string();
+        let mut metric_name = params.name.to_string();
+        if self.counters_total_suffix {
+            metric_name.push_str("_total");
+        }
         Counter::new(Arc::new(PromMetric::<IntCounterVec>::new(
             metric_name,
             params.description.to_string(),
@@ -676,12 +682,14 @@ mod tests {
         metrics::{MetricKeyValue, NewAttributes, WORKFLOW_E2E_LATENCY_HISTOGRAM_NAME},
     };
     use prometheus::{Encoder, TextEncoder};
+    use rstest::rstest;
 
     #[test]
     fn test_prometheus_meter_dynamic_labels() {
         let registry = Registry::new(HashMap::from([("global".to_string(), "value".to_string())]));
         let meter = CorePrometheusMeter::new(
             registry.clone(),
+            false,
             false,
             false,
             HistogramBucketOverrides::default(),
@@ -717,11 +725,40 @@ mod tests {
         );
     }
 
+    #[rstest]
+    #[case(false, "test_counter")]
+    #[case(true, "test_counter_total")]
+    fn counter_total_suffix_option_controls_counter_names(
+        #[case] counters_total_suffix: bool,
+        #[case] expected_name: &str,
+    ) {
+        let registry = Registry::new(HashMap::new());
+        let meter = CorePrometheusMeter::new(
+            registry.clone(),
+            counters_total_suffix,
+            false,
+            false,
+            HistogramBucketOverrides::default(),
+        );
+        let counter = meter.counter(MetricParameters {
+            name: "test_counter".into(),
+            description: "A test counter metric".into(),
+            unit: "".into(),
+        });
+
+        counter.adds(1);
+
+        let output = output_string(&registry);
+        let expected_sample = format!("{expected_name} 1");
+        assert!(output.lines().any(|line| line == expected_sample));
+    }
+
     #[test]
     fn test_extend_attributes() {
         let registry = Registry::new(HashMap::new());
         let meter = CorePrometheusMeter::new(
             registry.clone(),
+            false,
             false,
             false,
             HistogramBucketOverrides::default(),
@@ -763,6 +800,7 @@ mod tests {
             registry.clone(),
             false,
             false,
+            false,
             HistogramBucketOverrides::default(),
         );
 
@@ -787,6 +825,7 @@ mod tests {
         let registry_s = Registry::new(HashMap::new());
         let meter_s = CorePrometheusMeter::new(
             registry_s.clone(),
+            false,
             true,
             false,
             HistogramBucketOverrides::default(),
@@ -817,6 +856,7 @@ mod tests {
             registry.clone(),
             false,
             false,
+            false,
             HistogramBucketOverrides::default(),
         );
         let counter = meter.counter(MetricParameters {
@@ -839,6 +879,7 @@ mod tests {
         )]));
         let meter = CorePrometheusMeter::new(
             registry.clone(),
+            false,
             false,
             false,
             HistogramBucketOverrides::default(),
@@ -875,6 +916,7 @@ mod tests {
             registry.clone(),
             false,
             false,
+            false,
             HistogramBucketOverrides::default(),
         );
         let dashes = meter.counter(MetricParameters {
@@ -894,6 +936,7 @@ mod tests {
         let registry = Registry::new(HashMap::new());
         let meter = CorePrometheusMeter::new(
             registry.clone(),
+            false,
             false,
             false,
             HistogramBucketOverrides::default(),

--- a/crates/common/src/telemetry/prometheus_server.rs
+++ b/crates/common/src/telemetry/prometheus_server.rs
@@ -29,6 +29,7 @@ pub fn start_prometheus_metric_exporter(
     let meter = Arc::new(
         crate::telemetry::prometheus_meter::CorePrometheusMeter::new(
             srv.registry().clone(),
+            opts.counters_total_suffix,
             opts.use_seconds_for_durations,
             opts.unit_suffix,
             opts.histogram_bucket_overrides,

--- a/crates/sdk-core/CHANGELOG.md
+++ b/crates/sdk-core/CHANGELOG.md
@@ -54,6 +54,8 @@ relevant information.
   are preserved on failure; workers warn when the server does not advertise support.
 
 ### Fixed
+* The Prometheus exporter now appends `_total` to counter metric names when an SDK enables the
+  counter suffix option.
 * An activity failure caused by oversized final heartbeat details is now counted in the
   `temporal_activity_execution_failed` metric as `failure_reason="PayloadsTooLarge"`. Previously it
   was counted under the reason for the failure the activity itself reported, and was not counted at

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -105,12 +105,14 @@ pub(crate) async fn get_text(endpoint: String) -> String {
 #[rstest::rstest]
 #[tokio::test]
 async fn prometheus_metrics_exported(
+    #[values(true, false)] counters_total_suffix: bool,
     #[values(true, false)] use_seconds_latency: bool,
     #[values(true, false)] custom_buckets: bool,
 ) {
     let opts = PrometheusExporterOptions::builder()
         .global_tags(HashMap::from([("global".to_string(), "hi!".to_string())]))
         .socket_addr(ANY_PORT.parse().unwrap())
+        .counters_total_suffix(counters_total_suffix)
         .use_seconds_for_durations(use_seconds_latency)
         .histogram_bucket_overrides(if custom_buckets {
             HistogramBucketOverrides {
@@ -159,8 +161,12 @@ async fn prometheus_metrics_exported(
              operation=\"GetSystemInfo\",service_name=\"temporal-core-sdk\",global=\"hi!\",le=\"50\"}"
         ));
     }
-    // Verify counter names are appropriate (don't end w/ '_total')
-    assert!(body.contains("temporal_request{"));
+    let request_metric_name = if counters_total_suffix {
+        "temporal_request_total"
+    } else {
+        "temporal_request"
+    };
+    assert!(body.contains(&format!("{request_metric_name}{{")));
     // Verify non-temporal metrics meter does not prefix
     let mm = rt.telemetry().get_metric_meter().unwrap();
     let g = mm.gauge(MetricParameters::from("mygauge"));


### PR DESCRIPTION
## What was changed

- Thread `PrometheusExporterOptions::counters_total_suffix` into the Core Prometheus meter.
- Append `_total` to counter metric names when enabled, while preserving existing names when disabled.
- Add unit and integration coverage for both option values.
- Add user-facing entries to both changelogs.

## Why?

The exporter accepted the counter suffix option but ignored it. Enabling the option therefore did not produce Prometheus-compatible `_total` counter names.

## Checklist

1. Closes #1526

2. How was this tested:

- `cargo test -p temporalio-common --features prometheus counter_total_suffix_option_controls_counter_names`
- `cargo integ-test prometheus_metrics_exported`

3. Any docs updates needed?

- No documentation updates are needed. The user-visible fix is documented in both changelogs.