### PR TITLE
Fix non-sticky WFT poller starvation with small workflow cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@ relevant information.
   was counted under the reason for the failure the activity itself reported, and was not counted at
   all when that failure was benign, even though the worker reported a payload-limit failure to the
   server.
+* Workers configured with a small `max_cached_workflows` no longer briefly stop accepting new
+  workflows. Sticky workflow-task pollers could consume every workflow-cache permit and starve the
+  non-sticky poller, so the worker would stop picking up new workflows until a poll timed out (up to
+  ~60s). The poll balancer now reserves a non-sticky slot against the cache size rather than the
+  slot-supplier size.
 
 ## [0.7.0] - 2026-08-17
 

--- a/crates/sdk-core/CHANGELOG.md
+++ b/crates/sdk-core/CHANGELOG.md
@@ -77,3 +77,8 @@ relevant information.
   already elapsed, a sub-millisecond unit, or a multi-unit value like `1m30s`. Previously such a
   header was ignored entirely, so the handler was never told the task had timed out, and a task
   left unanswered could block worker shutdown indefinitely.
+* Workers with a small workflow cache no longer briefly stop accepting new workflows. Sticky
+  workflow-task pollers could consume every workflow-cache permit and starve the non-sticky poller,
+  so the worker would stop picking up new workflows until a poll timed out (up to ~60s). The poll
+  balancer now reserves a non-sticky slot against the workflow cache size rather than the slot
+  supplier size.

--- a/crates/sdk-core/src/abstractions.rs
+++ b/crates/sdk-core/src/abstractions.rs
@@ -108,6 +108,11 @@ where
         self.supplier.available_slots()
     }
 
+    /// Hard cap on extant permits (the workflow cache size), if any.
+    pub(crate) fn max_permits(&self) -> Option<usize> {
+        self.max_permits
+    }
+
     pub(crate) fn slot_supplier_kind(&self) -> &SlotSupplierKind {
         &self.slot_supplier_kind
     }

--- a/crates/sdk-core/src/worker/workflow/wft_poller.rs
+++ b/crates/sdk-core/src/worker/workflow/wft_poller.rs
@@ -316,15 +316,16 @@ mod tests {
     #[tokio::test]
     async fn small_cache_does_not_starve_nonsticky_poller() {
         use crate::{
+            MetricsContext,
             abstractions::MeteredPermitDealer,
             replay::TestHistoryBuilder,
             test_help::{ResponseType, hist_to_poll_resp, test_worker_cfg},
             worker::{
-                NamespaceCapabilities, PollerBehavior, client::mocks::mock_manual_worker_client,
+                NamespaceCapabilities, PollerBehavior,
+                client::{WorkerClient, mocks::mock_manual_worker_client},
                 tuner::FixedSizeSlotSupplier,
             },
         };
-        use crate::{MetricsContext, worker::client::WorkerClient};
         use futures_util::FutureExt;
         use std::sync::atomic::{AtomicUsize, Ordering};
         use temporalio_common::protos::temporal::api::enums::v1::EventType;
@@ -338,18 +339,20 @@ mod tests {
         // sticky poller ample opportunity to grab every freed permit if nothing is reserved.
         let nonsticky_timeouts = Arc::new(AtomicUsize::new(0));
         let mut client = mock_manual_worker_client();
-        client.expect_poll_workflow_task().returning(move |_po, wfo| {
-            if wfo.sticky_queue_name.is_some() {
-                // Sticky poll never returns -> holds its permit for the test's duration.
-                std::future::pending().boxed()
-            } else if nonsticky_timeouts.fetch_add(1, Ordering::SeqCst) < 20 {
-                // Poll timeout: empty response releases the permit so it must be re-acquired.
-                async { Ok(PollWorkflowTaskQueueResponse::default()) }.boxed()
-            } else {
-                let real_task = real_task.clone();
-                async move { Ok(real_task) }.boxed()
-            }
-        });
+        client
+            .expect_poll_workflow_task()
+            .returning(move |_po, wfo| {
+                if wfo.sticky_queue_name.is_some() {
+                    // Sticky poll never returns -> holds its permit for the test's duration.
+                    std::future::pending().boxed()
+                } else if nonsticky_timeouts.fetch_add(1, Ordering::SeqCst) < 20 {
+                    // Poll timeout: empty response releases the permit so it must be re-acquired.
+                    async { Ok(PollWorkflowTaskQueueResponse::default()) }.boxed()
+                } else {
+                    let real_task = real_task.clone();
+                    async move { Ok(real_task) }.boxed()
+                }
+            });
 
         let wft_slots = MeteredPermitDealer::<WorkflowSlotKind>::new(
             Arc::new(FixedSizeSlotSupplier::new(10)),

--- a/crates/sdk-core/src/worker/workflow/wft_poller.rs
+++ b/crates/sdk-core/src/worker/workflow/wft_poller.rs
@@ -16,6 +16,12 @@ use temporalio_common::protos::temporal::api::workflowservice::v1::PollWorkflowT
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
+/// The concurrency limit the WFT poll balancer should reserve against: the smaller of the slot
+/// supplier size and the workflow cache size (both bound `acquire_owned`).
+fn poll_balance_limit(slots: Option<usize>, cache: Option<usize>) -> Option<usize> {
+    [slots, cache].into_iter().flatten().min()
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn make_wft_poller(
     config: &WorkerConfig,
@@ -43,9 +49,11 @@ pub(crate) fn make_wft_poller(
         &capabilities,
     );
     let wft_poller_shared = if sticky_queue_name.is_some() {
-        Some(Arc::new(WFTPollerShared::new(
-            wft_slots.available_permits(),
-        )))
+        // Balance on the limit `acquire_owned` actually enforces (min of slot supplier and cache
+        // size). Using only the slot supplier lets a small cache starve the non-sticky poller.
+        let balance_limit =
+            poll_balance_limit(wft_slots.available_permits(), wft_slots.max_permits());
+        Some(Arc::new(WFTPollerShared::new(balance_limit)))
     } else {
         None
     };
@@ -265,6 +273,17 @@ mod tests {
     };
     use futures_util::{StreamExt, pin_mut};
     use std::sync::Arc;
+
+    #[test]
+    fn poll_balance_limit_uses_smaller_of_slots_and_cache() {
+        // A small workflow cache must bound the poll balancer, else sticky polls can consume every
+        // shared permit and starve the non-sticky poller that fetches new workflows' first tasks.
+        assert_eq!(poll_balance_limit(Some(40), Some(2)), Some(2));
+        assert_eq!(poll_balance_limit(Some(2), Some(40)), Some(2));
+        assert_eq!(poll_balance_limit(Some(10), None), Some(10));
+        assert_eq!(poll_balance_limit(None, Some(5)), Some(5));
+        assert_eq!(poll_balance_limit(None, None), None);
+    }
 
     #[tokio::test]
     async fn poll_timeouts_do_not_produce_responses() {

--- a/crates/sdk-core/src/worker/workflow/wft_poller.rs
+++ b/crates/sdk-core/src/worker/workflow/wft_poller.rs
@@ -16,12 +16,6 @@ use temporalio_common::protos::temporal::api::workflowservice::v1::PollWorkflowT
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
-/// The concurrency limit the WFT poll balancer should reserve against: the smaller of the slot
-/// supplier size and the workflow cache size (both bound `acquire_owned`).
-fn poll_balance_limit(slots: Option<usize>, cache: Option<usize>) -> Option<usize> {
-    [slots, cache].into_iter().flatten().min()
-}
-
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn make_wft_poller(
     config: &WorkerConfig,
@@ -51,8 +45,10 @@ pub(crate) fn make_wft_poller(
     let wft_poller_shared = if sticky_queue_name.is_some() {
         // Balance on the limit `acquire_owned` actually enforces (min of slot supplier and cache
         // size). Using only the slot supplier lets a small cache starve the non-sticky poller.
-        let balance_limit =
-            poll_balance_limit(wft_slots.available_permits(), wft_slots.max_permits());
+        let balance_limit = [wft_slots.available_permits(), wft_slots.max_permits()]
+            .into_iter()
+            .flatten()
+            .min();
         Some(Arc::new(WFTPollerShared::new(balance_limit)))
     } else {
         None
@@ -274,17 +270,6 @@ mod tests {
     use futures_util::{StreamExt, pin_mut};
     use std::sync::Arc;
 
-    #[test]
-    fn poll_balance_limit_uses_smaller_of_slots_and_cache() {
-        // A small workflow cache must bound the poll balancer, else sticky polls can consume every
-        // shared permit and starve the non-sticky poller that fetches new workflows' first tasks.
-        assert_eq!(poll_balance_limit(Some(40), Some(2)), Some(2));
-        assert_eq!(poll_balance_limit(Some(2), Some(40)), Some(2));
-        assert_eq!(poll_balance_limit(Some(10), None), Some(10));
-        assert_eq!(poll_balance_limit(None, Some(5)), Some(5));
-        assert_eq!(poll_balance_limit(None, None), None);
-    }
-
     #[tokio::test]
     async fn poll_timeouts_do_not_produce_responses() {
         let mut mock_poller = mock_poller();
@@ -320,6 +305,84 @@ mod tests {
         pin_mut!(stream);
 
         assert_matches!(stream.next().await, None);
+    }
+
+    /// Cache (`max_permits`) of 2 under a supplier of 10: the balancer must reserve a poll slot
+    /// against the cache, not the supplier, or a saturated sticky poller starves the non-sticky one.
+    /// Sticky long-polls forever (holding permits) while non-sticky repeatedly times out and must
+    /// re-acquire; without the reservation sticky recaptures every freed permit, so non-sticky never
+    /// delivers its eventual real task. (A single fresh-start poll won't reproduce this: a free
+    /// permit is always available at startup.)
+    #[tokio::test]
+    async fn small_cache_does_not_starve_nonsticky_poller() {
+        use crate::{
+            abstractions::MeteredPermitDealer,
+            replay::TestHistoryBuilder,
+            test_help::{ResponseType, hist_to_poll_resp, test_worker_cfg},
+            worker::{
+                NamespaceCapabilities, PollerBehavior, client::mocks::mock_manual_worker_client,
+                tuner::FixedSizeSlotSupplier,
+            },
+        };
+        use crate::{MetricsContext, worker::client::WorkerClient};
+        use futures_util::FutureExt;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use temporalio_common::protos::temporal::api::enums::v1::EventType;
+
+        let mut t = TestHistoryBuilder::default();
+        t.add_by_type(EventType::WorkflowExecutionStarted);
+        t.add_full_wf_task();
+        let real_task = hist_to_poll_resp(&t, "wf-id", ResponseType::AllHistory).resp;
+
+        // Non-sticky times out (empty response) this many times before its real task, giving the
+        // sticky poller ample opportunity to grab every freed permit if nothing is reserved.
+        let nonsticky_timeouts = Arc::new(AtomicUsize::new(0));
+        let mut client = mock_manual_worker_client();
+        client.expect_poll_workflow_task().returning(move |_po, wfo| {
+            if wfo.sticky_queue_name.is_some() {
+                // Sticky poll never returns -> holds its permit for the test's duration.
+                std::future::pending().boxed()
+            } else if nonsticky_timeouts.fetch_add(1, Ordering::SeqCst) < 20 {
+                // Poll timeout: empty response releases the permit so it must be re-acquired.
+                async { Ok(PollWorkflowTaskQueueResponse::default()) }.boxed()
+            } else {
+                let real_task = real_task.clone();
+                async move { Ok(real_task) }.boxed()
+            }
+        });
+
+        let wft_slots = MeteredPermitDealer::<WorkflowSlotKind>::new(
+            Arc::new(FixedSizeSlotSupplier::new(10)),
+            MetricsContext::no_op(),
+            Some(2),
+            Arc::new(Default::default()),
+            None,
+        );
+        // Poller max > 1 so the sticky poller alone could otherwise claim every permit.
+        let cfg = {
+            let mut cfg = test_worker_cfg().build().unwrap();
+            cfg.workflow_task_poller_behavior = Some(PollerBehavior::SimpleMaximum(5_usize));
+            cfg
+        };
+
+        let client: Arc<dyn WorkerClient> = Arc::new(client);
+        let stream = make_wft_poller(
+            &cfg,
+            &Some("sticky-q".to_string()),
+            &client,
+            &MetricsContext::no_op(),
+            &CancellationToken::new(),
+            &wft_slots,
+            Arc::new(AtomicCell::new(None)),
+            Arc::new(AtomicCell::new(None)),
+            Arc::new(NamespaceCapabilities::default()),
+        );
+        pin_mut!(stream);
+        let got = tokio::time::timeout(std::time::Duration::from_secs(10), stream.next())
+            .await
+            .expect("non-sticky poll must be delivered; a small cache is starving it")
+            .expect("stream should yield a task");
+        assert!(got.is_ok());
     }
 
     #[tokio::test]

--- a/crates/sdk-core/src/worker/workflow/wft_poller.rs
+++ b/crates/sdk-core/src/worker/workflow/wft_poller.rs
@@ -264,11 +264,21 @@ pub(crate) fn validate_wft(
 mod tests {
     use super::*;
     use crate::{
-        abstractions::tests::fixed_size_permit_dealer, pollers::MockPermittedPollBuffer,
-        test_help::mock_poller, worker::WorkflowSlotKind,
+        abstractions::tests::fixed_size_permit_dealer,
+        pollers::MockPermittedPollBuffer,
+        replay::TestHistoryBuilder,
+        test_help::{ResponseType, hist_to_poll_resp, mock_poller, test_worker_cfg},
+        worker::{
+            PollerBehavior, WorkflowSlotKind, client::mocks::mock_manual_worker_client,
+            tuner::FixedSizeSlotSupplier,
+        },
     };
-    use futures_util::{StreamExt, pin_mut};
-    use std::sync::Arc;
+    use futures_util::{FutureExt, StreamExt, pin_mut};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use temporalio_common::protos::temporal::api::enums::v1::EventType;
 
     #[tokio::test]
     async fn poll_timeouts_do_not_produce_responses() {
@@ -315,21 +325,6 @@ mod tests {
     /// permit is always available at startup.)
     #[tokio::test]
     async fn small_cache_does_not_starve_nonsticky_poller() {
-        use crate::{
-            MetricsContext,
-            abstractions::MeteredPermitDealer,
-            replay::TestHistoryBuilder,
-            test_help::{ResponseType, hist_to_poll_resp, test_worker_cfg},
-            worker::{
-                NamespaceCapabilities, PollerBehavior,
-                client::{WorkerClient, mocks::mock_manual_worker_client},
-                tuner::FixedSizeSlotSupplier,
-            },
-        };
-        use futures_util::FutureExt;
-        use std::sync::atomic::{AtomicUsize, Ordering};
-        use temporalio_common::protos::temporal::api::enums::v1::EventType;
-
         let mut t = TestHistoryBuilder::default();
         t.add_by_type(EventType::WorkflowExecutionStarted);
         t.add_full_wf_task();


### PR DESCRIPTION
## Problem

With a small `max_cached_workflows`, a worker can intermittently fail to pick up a **new** workflow's first task for ~60s. The workflow sits with its first WFT `SCHEDULED` and `DescribeTaskQueue` on the normal queue shows no poller, until a sticky long-poll times out and it self-heals.

The way this surfaced was flaky behavior observed in sdk-typescript CI tests (https://github.com/temporalio/sdk-typescript/pull/2310) where the proposed fix was to just add retries to deal with the flake.  But ended up going down the rabbit hole to try and root-cause this and arrived here.

## Root cause

The sticky and non-sticky WFT pollers share a permit pool. `MeteredPermitDealer::acquire_owned` caps concurrency at `max_permits` = the **workflow cache size**. The balancer meant to keep at least one non-sticky poller alive (`WFTPollerShared`) was initialized with the **slot-supplier size** instead, so when the cache is smaller than the slot supplier the balancer never engages. Under startup contention the sticky poller's long-polls then take every shared permit and the non-sticky poller (which fetches new workflows' first tasks) starves at `acquire_owned`.

## Fix

Initialize the balancer with the limit `acquire_owned` actually enforces: `min(slot-supplier size, cache size)`. No-op when the cache is >= the slot-supplier size (the common case is unchanged); reserves a poll slot for the non-sticky poller when the cache is smaller.

### Why #835 didn't cover this
#835 (closing #775) fixed the same starvation class, but only in the resource-based tuner's slot supplier: it guarantees that supplier hands out at least one slot to each poller kind. It doesn't apply to the fixed-size slot supplier, where the binding concurrency limit is the workflow cache size (`max_permits`) rather than the supplier, so the shared `WFTPollerShared` balancer still gates on the slot-supplier size and a small cache lets the starvation recur. This PR closes that gap by balancing on `min(slot supplier, cache size)`, which covers both suppliers.

## Validation

Reproduced via a language-SDK worker with `max_cached_workflows: 2` under CPU oversubscription (fresh worker per iteration, new workflow each time): ~2–3% of iterations stalled ~60s with the exact signature above.

A/B on an otherwise-identical build (only this diff differs):
- without fix: 11 stalls / 400 iterations
- with fix: 0 stalls / 400; 0 / 800 under heavier load; 0 across 1600+ total
- large cache without the fix: 0 (confirming cache size is the lever)

`cargo test` for `worker::workflow::wft_poller` (incl. the added `poll_balance_limit` test) and `pollers::poll_buffer` pass; clippy clean on the touched files.
