### PR TITLE
Use shared changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,8 +6,9 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   changelog-check:
     name: Changelog checkpoint
-    uses: temporalio/.github/.github/workflows/changelog.yml@6f052b395a527ab62ec33e5e0d7d1faf551bb8b7
+    uses: temporalio/.github/.github/workflows/changelog.yml@d8129c755fbd1d3f18c5a7a5420d5754acc63e3f

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,13 @@
+name: Changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  changelog-check:
+    name: Changelog checkpoint
+    uses: temporalio/.github/.github/workflows/changelog.yml@6f052b395a527ab62ec33e5e0d7d1faf551bb8b7


### PR DESCRIPTION
## What was changed

Added a changelog check using the reusable workflow from temporalio/.github. The caller pins merged commit 6f052b395a527ab62ec33e5e0d7d1faf551bb8b7 and retains the local pull request triggers needed to rerun when skip-changelog is added or removed.

## Why?

This centralizes the check across SDK repositories and verifies that every changelog addition is under an Unreleased section, including after an intervening release changes the pull request merge result. The shared workflow was introduced by temporalio/.github#20.

## Checklist

1. Closes: N/A

2. How was this tested:

- actionlint
- git diff --check
- The shared workflow was exercised against mocked pass, failure, and label-override cases
- The shared workflow was verified against recent Go, Rust, and TypeScript changelog history

3. Any docs updates needed?

No repository documentation changes are needed. The shared workflow is documented in temporalio/.github.