### PR TITLE
feat(sdk): add encode_common_attributes to DefaultFailureConverter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ relevant information.
 ## Unreleased
 
 ### Added
+* `DefaultFailureConverter::new(true)` moves failure messages and stack traces into encoded
+  attributes so payload codecs can encrypt them.
 * `LocalActivityOptions::include_arguments_into_marker` allows Rust workflows to opt in to
   recording local activity arguments in Workflow history.
 * `WorkflowHandle::get_update_handle` creates a typed handle for an existing Workflow Update from
@@ -59,6 +61,7 @@ relevant information.
   `ClientInterceptor::update_with_start_workflow`.
 
 ### Breaking Changes :boom:
+* `DefaultFailureConverter` is no longer a unit struct. Use `DefaultFailureConverter::default()` instead.
 * The following types are now non-exhaustive: `Priority`, `WorkerDeploymentVersion`,
   `WorkerCallbacks`, `WorkflowExecutionInfo`, `ActivityCloseTimeouts`,
   `ActivityExecutionDecodeHint`, child-workflow and signal decode hints,
@@ -93,6 +96,8 @@ relevant information.
   `Waiting for all slot permits to release took too long!`, and release builds logged that error
   and dropped the result, leaving the server to time the activity out before retrying it.
   Shutdown now drains in-flight completions first.
+* Standalone activity result and describe APIs now apply the configured payload codec when
+  decoding failures, so encoded failure attributes and details are restored correctly.
 * The Prometheus exporter now respects `PrometheusExporterOptions::counters_total_suffix`,
   appending `_total` to counter metric names when enabled.
 * Workflow start requests now include the client's identity.

--- a/crates/client/src/activity/activity_execution_info.rs
+++ b/crates/client/src/activity/activity_execution_info.rs
@@ -11,6 +11,7 @@ use temporalio_common::{
         TemporalDeserializable,
     },
     error::IncomingError,
+    payload_visitor::decode_payloads,
     protos::{
         proto_ts_to_system_time,
         temporal::api::{
@@ -187,18 +188,25 @@ impl<ActivityT> ActivityExecutionDescription<ActivityT>
 where
     ActivityT: ActivityDefinition,
 {
-    pub(crate) fn new(
+    pub(crate) async fn new(
         data_converter: DataConverter,
         serialization_context: SerializationContextData,
         response: DescribeActivityExecutionResponse,
     ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
-        let Some(raw_info) = response.info else {
+        let Some(mut raw_info) = response.info else {
             return Err("info missing in describe response".into());
         };
+        if let Some(failure) = raw_info.last_failure.as_mut() {
+            decode_payloads(failure, data_converter.codec(), &serialization_context).await?;
+        }
+        let mut raw_outcome = response.outcome.and_then(|o| o.value);
+        if let Some(ActivityExecutionOutcomeValue::Failure(failure)) = raw_outcome.as_mut() {
+            decode_payloads(failure, data_converter.codec(), &serialization_context).await?;
+        }
         Ok(Self {
             raw_info,
             raw_input: response.input,
-            raw_outcome: response.outcome.and_then(|o| o.value),
+            raw_outcome,
             data_converter,
             serialization_context,
             _phantom: PhantomData,

--- a/crates/client/src/activity/activity_handle.rs
+++ b/crates/client/src/activity/activity_handle.rs
@@ -8,6 +8,7 @@ use std::marker::PhantomData;
 use temporalio_common::{
     ActivityDefinition,
     data_converters::{DecodablePayloads, NoopDecodeHint, SerializationContextData},
+    payload_visitor::decode_payloads,
     protos::temporal::api::{
         activity::v1::{ActivityExecutionOutcome, activity_execution_outcome},
         failure::v1::failure::FailureInfo,
@@ -104,7 +105,8 @@ where
                 activity_execution_outcome::Value::Result(payloads) => {
                     Ok(dc.from_payloads(&ctx, payloads.payloads).await?)
                 }
-                activity_execution_outcome::Value::Failure(failure) => {
+                activity_execution_outcome::Value::Failure(mut failure) => {
+                    decode_payloads(&mut failure, dc.codec(), &ctx).await?;
                     Err(match failure.failure_info {
                         Some(FailureInfo::CanceledFailureInfo(info)) => {
                             let payloads = info.details.unwrap_or_default().payloads;
@@ -156,7 +158,8 @@ where
             client.data_converter().clone(),
             SerializationContextData::Activity,
             resp,
-        )?)
+        )
+        .await?)
     }
 
     /// Requests cancellation of the activity. Does not wait for the cancellation to complete.
@@ -203,5 +206,143 @@ where
             .await?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::XorCodec;
+    use futures_util::future::BoxFuture;
+    use temporalio_common::{
+        UntypedActivity,
+        data_converters::{DataConverter, DefaultFailureConverter, PayloadConverter},
+        error::{ApplicationFailure, OutgoingActivityError, OutgoingError},
+        payload_visitor::encode_payloads,
+        protos::temporal::api::{
+            activity::v1::ActivityExecutionInfo,
+            failure::v1::Failure,
+            workflowservice::v1::{
+                DescribeActivityExecutionResponse, PollActivityExecutionResponse,
+            },
+        },
+    };
+    use tonic::{Request, Response, Status};
+
+    #[derive(Clone)]
+    struct MockActivityClient {
+        data_converter: DataConverter,
+        failure: Failure,
+    }
+
+    impl NamespacedClient for MockActivityClient {
+        fn namespace(&self) -> String {
+            "test-namespace".to_owned()
+        }
+
+        fn identity(&self) -> String {
+            "test-identity".to_owned()
+        }
+
+        fn data_converter(&self) -> &DataConverter {
+            &self.data_converter
+        }
+    }
+
+    impl WorkflowService for MockActivityClient {
+        fn poll_activity_execution(
+            &mut self,
+            _request: Request<PollActivityExecutionRequest>,
+        ) -> BoxFuture<'_, Result<Response<PollActivityExecutionResponse>, Status>> {
+            let failure = self.failure.clone();
+            Box::pin(async move {
+                Ok(Response::new(PollActivityExecutionResponse {
+                    outcome: Some(ActivityExecutionOutcome {
+                        value: Some(activity_execution_outcome::Value::Failure(failure)),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }))
+            })
+        }
+
+        fn describe_activity_execution(
+            &mut self,
+            _request: Request<DescribeActivityExecutionRequest>,
+        ) -> BoxFuture<'_, Result<Response<DescribeActivityExecutionResponse>, Status>> {
+            let failure = self.failure.clone();
+            Box::pin(async move {
+                Ok(Response::new(DescribeActivityExecutionResponse {
+                    info: Some(ActivityExecutionInfo {
+                        last_failure: Some(failure.clone()),
+                        ..Default::default()
+                    }),
+                    outcome: Some(ActivityExecutionOutcome {
+                        value: Some(activity_execution_outcome::Value::Failure(failure)),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }))
+            })
+        }
+    }
+
+    async fn activity_client_with_encoded_failure() -> MockActivityClient {
+        let data_converter = DataConverter::new(
+            PayloadConverter::default(),
+            DefaultFailureConverter::new(true),
+            XorCodec,
+        );
+        let context = SerializationContextData::Activity;
+        let mut failure = data_converter.to_failure(
+            &context,
+            OutgoingError::Activity(OutgoingActivityError::Application(Box::new(
+                ApplicationFailure::new(anyhow::anyhow!("private message")),
+            ))),
+        );
+        encode_payloads(&mut failure, data_converter.codec(), &context)
+            .await
+            .unwrap();
+        MockActivityClient {
+            data_converter,
+            failure,
+        }
+    }
+
+    #[tokio::test]
+    async fn result_decodes_failure_attributes_with_codec() {
+        let handle = ActivityHandle::<_, UntypedActivity>::new(
+            activity_client_with_encoded_failure().await,
+            "activity-id".to_owned(),
+            None,
+        );
+
+        let ActivityResultError::ActivityFailed(error) = handle.result().await.unwrap_err() else {
+            panic!("expected failed activity");
+        };
+        assert_eq!(error.failure().message, "private message");
+    }
+
+    #[tokio::test]
+    async fn describe_decodes_failure_attributes_with_codec() {
+        let handle = ActivityHandle::<_, UntypedActivity>::new(
+            activity_client_with_encoded_failure().await,
+            "activity-id".to_owned(),
+            None,
+        );
+
+        let description = handle
+            .describe(
+                ActivityDescribeOptions::builder()
+                    .include_outcome(true)
+                    .include_last_failure(true)
+                    .build(),
+            )
+            .await
+            .unwrap();
+        let outcome = description.outcome().await.unwrap().unwrap().unwrap_err();
+        let last_failure = description.last_failure().unwrap().unwrap();
+        assert_eq!(outcome.failure().message, "private message");
+        assert_eq!(last_failure.failure().message, "private message");
     }
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -3655,7 +3655,7 @@ mod tests {
             let recorded = Arc::new(Mutex::new(RecordedStart::default()));
             let data_converter = DataConverter::new(
                 PayloadConverter::default(),
-                DefaultFailureConverter,
+                DefaultFailureConverter::default(),
                 CountingCodec {
                     encode_calls: encode_calls.clone(),
                 },
@@ -3678,8 +3678,11 @@ mod tests {
             codec: impl PayloadCodec + Send + Sync + 'static,
         ) -> (MockStartWorkflowClient, Arc<Mutex<RecordedStart>>) {
             let recorded = Arc::new(Mutex::new(RecordedStart::default()));
-            let data_converter =
-                DataConverter::new(PayloadConverter::default(), DefaultFailureConverter, codec);
+            let data_converter = DataConverter::new(
+                PayloadConverter::default(),
+                DefaultFailureConverter::default(),
+                codec,
+            );
             (
                 MockStartWorkflowClient {
                     recorded: recorded.clone(),
@@ -3888,7 +3891,7 @@ mod tests {
             let recorded = Arc::new(Mutex::new(RecordedStart::default()));
             let data_converter = DataConverter::new(
                 PayloadConverter::UseWrappers,
-                DefaultFailureConverter,
+                DefaultFailureConverter::default(),
                 CountingCodec {
                     encode_calls: encode_calls.clone(),
                 },
@@ -4776,7 +4779,7 @@ mod tests {
         async fn list_workflows_exposes_typed_memo() {
             let data_converter = DataConverter::new(
                 PayloadConverter::default(),
-                DefaultFailureConverter,
+                DefaultFailureConverter::default(),
                 XorCodec,
             );
             let memo_payload = data_converter
@@ -4816,7 +4819,7 @@ mod tests {
                 total_workflows: 1,
                 data_converter: DataConverter::new(
                     PayloadConverter::default(),
-                    DefaultFailureConverter,
+                    DefaultFailureConverter::default(),
                     FailingCodec,
                 ),
                 memo_payload: Some(Payload::default()),

--- a/crates/client/src/schedules.rs
+++ b/crates/client/src/schedules.rs
@@ -1682,7 +1682,7 @@ mod tests {
     fn data_converter_with_codec() -> DataConverter {
         DataConverter::new(
             PayloadConverter::default(),
-            DefaultFailureConverter,
+            DefaultFailureConverter::default(),
             XorCodec,
         )
     }
@@ -2036,7 +2036,7 @@ mod tests {
             },
             data_converter: DataConverter::new(
                 PayloadConverter::default(),
-                DefaultFailureConverter,
+                DefaultFailureConverter::default(),
                 FailingCodec,
             ),
             ..Default::default()

--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -1423,7 +1423,7 @@ mod tests {
     async fn workflow_result_details_support_typed_decoding() {
         let converter = DataConverter::new(
             PayloadConverter::default(),
-            DefaultFailureConverter,
+            DefaultFailureConverter::default(),
             XorCodec,
         );
         let payloads = converter
@@ -1461,7 +1461,7 @@ mod tests {
     async fn workflow_description_memo_uses_saved_converter() {
         let converter = DataConverter::new(
             PayloadConverter::default(),
-            DefaultFailureConverter,
+            DefaultFailureConverter::default(),
             XorCodec,
         );
         let encoded = converter

--- a/crates/common-wasm/src/data_converters.rs
+++ b/crates/common-wasm/src/data_converters.rs
@@ -724,7 +724,7 @@ impl Default for DataConverter {
     fn default() -> Self {
         Self::new(
             PayloadConverter::default(),
-            DefaultFailureConverter,
+            DefaultFailureConverter::default(),
             DefaultPayloadCodec,
         )
     }

--- a/crates/common-wasm/src/data_converters.rs
+++ b/crates/common-wasm/src/data_converters.rs
@@ -5,7 +5,7 @@ mod failure_converter;
 
 pub use failure_converter::{
     ActivityExecutionDecodeHint, ChildWorkflowExecutionDecodeHint, ChildWorkflowStartDecodeHint,
-    DefaultFailureConverter, FailureConverter, FailureDecodeHint, NoopDecodeHint,
+    CommonAttributes, DefaultFailureConverter, FailureConverter, FailureDecodeHint, NoopDecodeHint,
     WorkflowSignalDecodeHint,
 };
 

--- a/crates/common-wasm/src/data_converters/failure_converter.rs
+++ b/crates/common-wasm/src/data_converters/failure_converter.rs
@@ -9,7 +9,10 @@
 //!   [`FailureDecodeHint`] implementations adapt that normalized value into the caller-facing error
 //!   type they expect.
 
-use super::{PayloadConversionError, PayloadConverter, SerializationContextData};
+use super::{
+    GenericPayloadConverter, PayloadConversionError, PayloadConverter, SerializationContext,
+    SerializationContextData,
+};
 use crate::{
     error::{
         ActivityExecutionError, ActivityFailureError, ApplicationFailure, CancelledError,
@@ -48,7 +51,41 @@ pub trait FailureConverter {
 }
 
 /// Default failure converter.
-pub struct DefaultFailureConverter;
+pub struct DefaultFailureConverter {
+    encode_common_attributes: bool,
+}
+
+/// A default failure converter that leaves common failure attributes unencoded.
+///
+/// This value preserves the original unit-struct construction syntax for downstream users.
+#[allow(non_upper_case_globals)]
+pub const DefaultFailureConverter: DefaultFailureConverter = DefaultFailureConverter::new(false);
+
+impl DefaultFailureConverter {
+    /// Creates a failure converter, optionally moving failure messages and stack traces into
+    /// encoded attributes.
+    pub const fn new(encode_common_attributes: bool) -> Self {
+        Self {
+            encode_common_attributes,
+        }
+    }
+}
+
+impl Default for DefaultFailureConverter {
+    fn default() -> Self {
+        Self::new(false)
+    }
+}
+
+/// Failure attributes that can be moved into an encoded payload.
+#[derive(serde::Deserialize, serde::Serialize)]
+#[non_exhaustive]
+pub struct CommonAttributes {
+    /// Failure message.
+    pub message: String,
+    /// Failure stack trace.
+    pub stack_trace: String,
+}
 
 /// Adapts a normalized incoming failure into a caller-facing error surface.
 pub trait FailureDecodeHint {
@@ -217,12 +254,21 @@ impl FailureConverter for DefaultFailureConverter {
                 signal.encode_failure(payload_converter, context)
             }
         };
-        encoded.unwrap_or_else(|converter_error| {
+        let mut failure = encoded.unwrap_or_else(|converter_error| {
             Failure::application_failure(
                 failed_error_conversion_message(&original_error, &converter_error),
                 false,
             )
-        })
+        });
+        if self.encode_common_attributes
+            && encode_common_attributes(&mut failure, payload_converter, context).is_err()
+        {
+            failure = Failure::application_failure(
+                "Failed encoding failure attributes".to_owned(),
+                false,
+            );
+        }
+        failure
     }
 
     fn to_error(
@@ -476,11 +522,39 @@ fn encode_failed_error_conversion(
     }
 }
 
+fn encode_common_attributes(
+    failure: &mut Failure,
+    payload_converter: &PayloadConverter,
+    context: &SerializationContextData,
+) -> Result<(), PayloadConversionError> {
+    if let Some(cause) = failure.cause.as_deref_mut() {
+        encode_common_attributes(cause, payload_converter, context)?;
+    }
+    failure.encoded_attributes = Some(payload_converter.to_payload(
+        &SerializationContext::new(context, payload_converter),
+        &CommonAttributes {
+            message: std::mem::take(&mut failure.message),
+            stack_trace: std::mem::take(&mut failure.stack_trace),
+        },
+    )?);
+    failure.message = "Encoded failure".to_owned();
+    Ok(())
+}
+
 fn decode_failure(
-    failure: Failure,
+    mut failure: Failure,
     payload_converter: &PayloadConverter,
     context: &SerializationContextData,
 ) -> IncomingError {
+    if let Some(encoded_attributes) = failure.encoded_attributes.clone()
+        && let Ok(attributes) = payload_converter.from_payload::<CommonAttributes>(
+            &SerializationContext::new(context, payload_converter),
+            encoded_attributes,
+        )
+    {
+        failure.message = attributes.message;
+        failure.stack_trace = attributes.stack_trace;
+    }
     let cause = failure
         .cause
         .clone()
@@ -624,7 +698,7 @@ mod tests {
     }
 
     fn convert(err: OutgoingWorkflowError) -> Failure {
-        DefaultFailureConverter.to_failure(
+        DefaultFailureConverter::default().to_failure(
             OutgoingError::Workflow(err),
             &PayloadConverter::default(),
             &SerializationContextData::Workflow,
@@ -634,7 +708,7 @@ mod tests {
     fn data_converter() -> crate::data_converters::DataConverter {
         crate::data_converters::DataConverter::new(
             PayloadConverter::default(),
-            DefaultFailureConverter,
+            DefaultFailureConverter::default(),
             crate::data_converters::DefaultPayloadCodec,
         )
     }
@@ -705,7 +779,7 @@ mod tests {
 
     #[test]
     fn application_failures_surface_detail_encoding_errors_with_original_message() {
-        let failure = DefaultFailureConverter.to_failure(
+        let failure = DefaultFailureConverter::default().to_failure(
             OutgoingError::Workflow(OutgoingWorkflowError::Application(Box::new(
                 ApplicationFailure::builder(anyhow::anyhow!("app boom"))
                     .details(AlwaysFailsSerialize)
@@ -741,7 +815,7 @@ mod tests {
             ..Default::default()
         };
 
-        let decoded = DefaultFailureConverter
+        let decoded = DefaultFailureConverter::default()
             .to_error(failure, &converter, &SerializationContextData::Workflow)
             .unwrap();
 
@@ -885,7 +959,7 @@ mod tests {
         ));
         assert!(cause.cause.is_none());
 
-        let decoded = DefaultFailureConverter
+        let decoded = DefaultFailureConverter::default()
             .to_error(
                 converted.clone(),
                 &PayloadConverter::default(),
@@ -905,6 +979,79 @@ mod tests {
             Some("generic inner cause")
         );
         assert!(wrapper.cause().is_none());
+    }
+
+    #[test]
+    fn failure_converter_encodes_and_decodes_cause_chain() {
+        let payload_converter = PayloadConverter::default();
+        let converter = DefaultFailureConverter::new(true);
+        let context = SerializationContextData::Workflow;
+        let failure = Failure {
+            message: "outer message".to_owned(),
+            stack_trace: "outer stack trace".to_owned(),
+            cause: Some(Box::new(Failure {
+                message: "inner message".to_owned(),
+                stack_trace: "inner stack trace".to_owned(),
+                failure_info: Some(FailureInfo::ApplicationFailureInfo(
+                    ApplicationFailureInfo::default(),
+                )),
+                ..Default::default()
+            })),
+            failure_info: Some(FailureInfo::ActivityFailureInfo(
+                ActivityFailureInfo::default(),
+            )),
+            ..Default::default()
+        };
+        let activity_error = ActivityExecutionError::Failed(ActivityFailureError::new(
+            failure,
+            ActivityFailureInfo::default(),
+            None,
+        ));
+
+        let failure = converter.to_failure(
+            OutgoingError::Workflow(OutgoingWorkflowError::ActivityExecution(Box::new(
+                activity_error,
+            ))),
+            &payload_converter,
+            &context,
+        );
+
+        assert_eq!(failure.message, "Encoded failure");
+        assert_eq!(failure.cause.as_ref().unwrap().message, "Encoded failure");
+        assert!(failure.stack_trace.is_empty());
+        assert!(failure.cause.as_ref().unwrap().stack_trace.is_empty());
+        let payload_context = SerializationContext::new(&context, &payload_converter);
+        let outer_attributes: CommonAttributes = payload_converter
+            .from_payload(
+                &payload_context,
+                failure.encoded_attributes.clone().unwrap(),
+            )
+            .unwrap();
+        let inner_attributes: CommonAttributes = payload_converter
+            .from_payload(
+                &payload_context,
+                failure
+                    .cause
+                    .as_ref()
+                    .unwrap()
+                    .encoded_attributes
+                    .clone()
+                    .unwrap(),
+            )
+            .unwrap();
+        assert_eq!(outer_attributes.message, "outer message");
+        assert_eq!(inner_attributes.message, "inner message");
+        assert_eq!(outer_attributes.stack_trace, "outer stack trace");
+        assert_eq!(inner_attributes.stack_trace, "inner stack trace");
+
+        let decoded = DefaultFailureConverter::default()
+            .to_error(failure, &payload_converter, &context)
+            .unwrap();
+        assert_eq!(decoded.failure().message, "outer message");
+        assert_eq!(decoded.failure().stack_trace, "outer stack trace");
+        let cause = decoded.cause().unwrap().failure();
+        assert_eq!(cause.message, "inner message");
+        assert_eq!(cause.stack_trace, "inner stack trace");
     }
 
     #[test]
@@ -937,7 +1084,7 @@ mod tests {
             ..Default::default()
         };
 
-        let decoded = DefaultFailureConverter
+        let decoded = DefaultFailureConverter::default()
             .to_error(
                 failure.clone(),
                 &PayloadConverter::default(),
@@ -970,7 +1117,7 @@ mod tests {
             ..Default::default()
         };
 
-        let decoded = DefaultFailureConverter
+        let decoded = DefaultFailureConverter::default()
             .to_error(
                 failure.clone(),
                 &PayloadConverter::default(),
@@ -996,7 +1143,7 @@ mod tests {
             ..Default::default()
         };
 
-        let decoded = DefaultFailureConverter
+        let decoded = DefaultFailureConverter::default()
             .to_error(
                 failure.clone(),
                 &PayloadConverter::default(),
@@ -1014,7 +1161,7 @@ mod tests {
         assert_eq!(reencoded.message, failure.message);
         assert_eq!(reencoded.cause.as_deref(), failure.cause.as_deref());
 
-        let decoded_reencoded = DefaultFailureConverter
+        let decoded_reencoded = DefaultFailureConverter::default()
             .to_error(
                 reencoded,
                 &PayloadConverter::default(),
@@ -1044,7 +1191,7 @@ mod tests {
             ..Default::default()
         };
 
-        let decoded = DefaultFailureConverter
+        let decoded = DefaultFailureConverter::default()
             .to_error(
                 failure.clone(),
                 &PayloadConverter::default(),
@@ -1115,7 +1262,7 @@ mod tests {
             ..Default::default()
         };
 
-        let decoded = DefaultFailureConverter
+        let decoded = DefaultFailureConverter::default()
             .to_error(
                 failure.clone(),
                 &PayloadConverter::default(),
@@ -1152,7 +1299,7 @@ mod tests {
         };
         let data_converter = crate::data_converters::DataConverter::new(
             PayloadConverter::default(),
-            DefaultFailureConverter,
+            DefaultFailureConverter::default(),
             crate::data_converters::DefaultPayloadCodec,
         );
 
@@ -1254,7 +1401,7 @@ mod tests {
             ..Default::default()
         };
 
-        let decoded = DefaultFailureConverter
+        let decoded = DefaultFailureConverter::default()
             .to_error(
                 failure.clone(),
                 &PayloadConverter::default(),
@@ -1290,7 +1437,7 @@ mod tests {
             ..Default::default()
         };
 
-        let decoded = DefaultFailureConverter
+        let decoded = DefaultFailureConverter::default()
             .to_error(
                 failure.clone(),
                 &PayloadConverter::default(),
@@ -1463,7 +1610,7 @@ mod tests {
 
     #[test]
     fn outgoing_cancelled_activity_errors_encode_to_cancelled_failures() {
-        let failure = DefaultFailureConverter.to_failure(
+        let failure = DefaultFailureConverter::default().to_failure(
             OutgoingError::Activity(OutgoingActivityError::Cancelled { details: None }),
             &PayloadConverter::default(),
             &SerializationContextData::Activity,
@@ -1478,7 +1625,7 @@ mod tests {
 
     #[test]
     fn outgoing_cancelled_activity_errors_encode_serializable_details_with_payload_converter() {
-        let failure = DefaultFailureConverter.to_failure(
+        let failure = DefaultFailureConverter::default().to_failure(
             OutgoingError::Activity(OutgoingActivityError::Cancelled {
                 details: Some("detail".to_string().into()),
             }),
@@ -1486,7 +1633,7 @@ mod tests {
             &SerializationContextData::Activity,
         );
 
-        let err = DefaultFailureConverter
+        let err = DefaultFailureConverter::default()
             .to_error(
                 failure,
                 &PayloadConverter::default(),

--- a/crates/common-wasm/src/data_converters/failure_converter.rs
+++ b/crates/common-wasm/src/data_converters/failure_converter.rs
@@ -55,12 +55,6 @@ pub struct DefaultFailureConverter {
     encode_common_attributes: bool,
 }
 
-/// A default failure converter that leaves common failure attributes unencoded.
-///
-/// This value preserves the original unit-struct construction syntax for downstream users.
-#[allow(non_upper_case_globals)]
-pub const DefaultFailureConverter: DefaultFailureConverter = DefaultFailureConverter::new(false);
-
 impl DefaultFailureConverter {
     /// Creates a failure converter, optionally moving failure messages and stack traces into
     /// encoded attributes.

--- a/crates/common-wasm/src/error.rs
+++ b/crates/common-wasm/src/error.rs
@@ -1271,7 +1271,7 @@ mod tests {
             ..Default::default()
         };
 
-        let decoded = DefaultFailureConverter
+        let decoded = DefaultFailureConverter::default()
             .to_error(
                 failure,
                 &PayloadConverter::default(),
@@ -1316,7 +1316,7 @@ mod tests {
                 ..Default::default()
             }],
         };
-        let failure = DefaultFailureConverter.to_failure(
+        let failure = DefaultFailureConverter::default().to_failure(
             OutgoingError::Workflow(OutgoingWorkflowError::Application(Box::new(
                 ApplicationFailure::builder(anyhow::anyhow!("oops"))
                     .type_name("MyType".to_owned())
@@ -1346,7 +1346,7 @@ mod tests {
             data: b"details".to_vec(),
             ..Default::default()
         };
-        let failure = DefaultFailureConverter.to_failure(
+        let failure = DefaultFailureConverter::default().to_failure(
             OutgoingError::Workflow(OutgoingWorkflowError::Application(Box::new(
                 ApplicationFailure::builder(anyhow::anyhow!("oops"))
                     .details(RawValue::new(vec![payload.clone()]))
@@ -1364,7 +1364,7 @@ mod tests {
 
     #[test]
     fn builder_accepts_serializable_details() {
-        let failure = DefaultFailureConverter.to_failure(
+        let failure = DefaultFailureConverter::default().to_failure(
             OutgoingError::Workflow(OutgoingWorkflowError::Application(Box::new(
                 ApplicationFailure::builder(anyhow::anyhow!("oops"))
                     .details("details".to_string())
@@ -1390,7 +1390,7 @@ mod tests {
 
     #[test]
     fn application_failure_encoding_surfaces_detail_encoding_errors() {
-        let failure = DefaultFailureConverter.to_failure(
+        let failure = DefaultFailureConverter::default().to_failure(
             OutgoingError::Workflow(OutgoingWorkflowError::Application(Box::new(
                 ApplicationFailure::builder(anyhow::anyhow!("oops"))
                     .details(AlwaysFailsSerialize)

--- a/crates/common/src/payload_visitor.rs
+++ b/crates/common/src/payload_visitor.rs
@@ -797,7 +797,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_encode_failure_encodes_application_failure_details() {
-        let mut failure = DefaultFailureConverter.to_failure(
+        let mut failure = DefaultFailureConverter::default().to_failure(
             OutgoingError::Workflow(OutgoingWorkflowError::Application(Box::new(
                 ApplicationFailure::builder(anyhow::anyhow!("app boom"))
                     .details(crate::data_converters::RawValue::new(vec![make_payload(

--- a/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
@@ -793,9 +793,9 @@ async fn option_none_workflow_input_is_recorded_as_binary_null() {
 
     let events = handle
         .fetch_history(Default::default())
+        .into_events()
         .await
-        .unwrap()
-        .into_events();
+        .unwrap();
     let input = events
         .iter()
         .find_map(|event| match event.attributes.as_ref() {

--- a/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
@@ -159,7 +159,7 @@ impl FailureConverter for FailingFailureConverter {
         payload_converter: &PayloadConverter,
         context: &SerializationContextData,
     ) -> Result<IncomingError, PayloadConversionError> {
-        DefaultFailureConverter.to_error(failure, payload_converter, context)
+        DefaultFailureConverter::default().to_error(failure, payload_converter, context)
     }
 }
 
@@ -961,7 +961,7 @@ async fn codec_errors_fail_tasks_and_retry(#[case] failure_point: CodecFailurePo
     let connection = get_integ_connection(None).await;
     let data_converter = DataConverter::new(
         PayloadConverter::default(),
-        DefaultFailureConverter,
+        DefaultFailureConverter::default(),
         codec.clone(),
     );
     let client_opts = ClientOptions::new(integ_namespace())
@@ -1009,7 +1009,7 @@ async fn codec_encodes_and_decodes_payloads() {
     let connection = get_integ_connection(None).await;
     let data_converter = DataConverter::new(
         PayloadConverter::default(),
-        DefaultFailureConverter,
+        DefaultFailureConverter::default(),
         codec.clone(),
     );
     let client_opts = ClientOptions::new(integ_namespace())
@@ -1067,7 +1067,7 @@ async fn describe_decodes_workflow_payload_fields() {
     let connection = get_integ_connection(None).await;
     let data_converter = DataConverter::new(
         PayloadConverter::default(),
-        DefaultFailureConverter,
+        DefaultFailureConverter::default(),
         codec.clone(),
     );
     let client_opts = ClientOptions::new(integ_namespace())
@@ -1145,7 +1145,7 @@ async fn describe_decodes_user_metadata_with_ungated_xor_codec() {
     let connection = get_integ_connection(None).await;
     let data_converter = DataConverter::new(
         PayloadConverter::default(),
-        DefaultFailureConverter,
+        DefaultFailureConverter::default(),
         codec.clone(),
     );
     let client_opts = ClientOptions::new(integ_namespace())
@@ -1209,7 +1209,7 @@ async fn codec_roundtrips_activity_cancellation_details() {
     let connection = get_integ_connection(None).await;
     let data_converter = DataConverter::new(
         PayloadConverter::default(),
-        DefaultFailureConverter,
+        DefaultFailureConverter::default(),
         codec.clone(),
     );
     let client_opts = ClientOptions::new(integ_namespace())
@@ -1258,7 +1258,7 @@ async fn codec_roundtrips_activity_heartbeat_timeout_details() {
     let connection = get_integ_connection(None).await;
     let data_converter = DataConverter::new(
         PayloadConverter::default(),
-        DefaultFailureConverter,
+        DefaultFailureConverter::default(),
         codec.clone(),
     );
     let client_opts = ClientOptions::new(integ_namespace())

--- a/crates/sdk-core/tests/integ_tests/plugin_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/plugin_tests.rs
@@ -218,7 +218,7 @@ async fn simple_plugin_configures_working_client_and_worker() {
     let worker_interceptor_calls = Arc::new(AtomicUsize::new(0));
     let data_converter = DataConverter::new(
         PayloadConverter::default(),
-        DefaultFailureConverter,
+        DefaultFailureConverter::default(),
         CountingPayloadCodec {
             encode_calls: encode_calls.clone(),
             decode_calls: decode_calls.clone(),

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1583,7 +1583,7 @@ mod tests {
         let codec = Arc::new(FailingEncodeCodec::default());
         let data_converter = DataConverter::new(
             PayloadConverter::default(),
-            DefaultFailureConverter,
+            DefaultFailureConverter::default(),
             codec.clone(),
         );
         let mut completion = WorkflowActivationCompletion::from_cmd(
@@ -1614,7 +1614,7 @@ mod tests {
         let codec = Arc::new(FailingEncodeCodec::default());
         let data_converter = DataConverter::new(
             PayloadConverter::default(),
-            DefaultFailureConverter,
+            DefaultFailureConverter::default(),
             codec.clone(),
         );
         let mut completion = ActivityTaskCompletion {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- `DefaultFailureConverter` now holds `encode_common_attributes` that controls the encoding of failure messages/stack traces as `encoded_attributes`. Note we aren't capturing stack trace for Rust so the stack trace aspect is primarily for cross lang purposes.
- Encode/decode payloads on failures for SAA

For reviewing you only really need to look at
  - crates/common-wasm/src/data_converters/failure_converter.rs
  - crates/client/src/activity/activity_handle.rs
  - crates/client/src/activity/activity_execution_info.rs
other changes are just `DefaultFailureConverter` -> `DefaultFailureConverter::default()`

## Why?
SDK parity.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Added basic unit tests that the flag is respected as well as verifying codecs get ran for SAA operations.

3. Any docs updates needed?
N/A
