### PR TITLE
fix(sdk): encode None as binary/null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ relevant information.
   `Waiting for all slot permits to release took too long!`, and release builds logged that error
   and dropped the result, leaving the server to time the activity out before retrying it.
   Shutdown now drains in-flight completions first.
+* The default payload converter now serializes Serde `null` values such as `Option::None` as
+  `binary/null` and accepts both `binary/null` and legacy `json/plain` null payloads.
 * The Prometheus exporter now respects `PrometheusExporterOptions::counters_total_suffix`,
   appending `_total` to counter metric names when enabled.
 * Workflow start requests now include the client's identity.

--- a/crates/common-wasm/src/data_converters.rs
+++ b/crates/common-wasm/src/data_converters.rs
@@ -488,15 +488,7 @@ impl GenericPayloadConverter for PayloadConverter {
     ) -> Result<Payload, PayloadConversionError> {
         // If a single payload is explicitly needed for `()`, then produce a null payload
         if std::any::TypeId::of::<T>() == std::any::TypeId::of::<()>() {
-            return Ok(Payload {
-                metadata: {
-                    let mut hm = HashMap::new();
-                    hm.insert("encoding".to_string(), b"binary/null".to_vec());
-                    hm
-                },
-                data: vec![],
-                external_payloads: vec![],
-            });
+            return Ok(binary_null_payload());
         }
         let mut payloads = self.to_payloads(context, val)?;
         if payloads.len() != 1 {
@@ -578,17 +570,31 @@ impl GenericPayloadConverter for PayloadConverter {
     }
 }
 
+fn binary_null_payload() -> Payload {
+    Payload {
+        metadata: {
+            let mut hm = HashMap::new();
+            hm.insert("encoding".to_string(), b"binary/null".to_vec());
+            hm
+        },
+        data: vec![],
+        external_payloads: vec![],
+    }
+}
+
+fn is_binary_null_payload(payload: &Payload) -> bool {
+    payload.data.is_empty()
+        && payload
+            .metadata
+            .get("encoding")
+            .map(|encoding| encoding == b"binary/null")
+            .unwrap_or(false)
+}
+
 fn is_unit_payloads(payloads: &[Payload]) -> bool {
     match payloads {
         [] => true,
-        [payload] => {
-            payload.data.is_empty()
-                && payload
-                    .metadata
-                    .get("encoding")
-                    .map(|encoding| encoding == b"binary/null")
-                    .unwrap_or(false)
-        }
+        [payload] => is_binary_null_payload(payload),
         _ => false,
     }
 }
@@ -629,6 +635,9 @@ impl ErasedSerdePayloadConverter for SerdeJsonPayloadConverter {
     ) -> Result<Payload, PayloadConversionError> {
         let as_json = serde_json::to_vec(value)
             .map_err(|e| PayloadConversionError::EncodingError(e.into()))?;
+        if as_json.as_slice() == b"null" {
+            return Ok(binary_null_payload());
+        }
         Ok(Payload {
             metadata: {
                 let mut hm = HashMap::new();
@@ -646,11 +655,14 @@ impl ErasedSerdePayloadConverter for SerdeJsonPayloadConverter {
         payload: Payload,
     ) -> Result<Box<dyn erased_serde::Deserializer<'static>>, PayloadConversionError> {
         let encoding = payload.metadata.get("encoding").map(|v| v.as_slice());
-        if encoding != Some(b"json/plain".as_slice()) {
+        let json_v = if encoding == Some(b"json/plain".as_slice()) {
+            serde_json::from_slice(&payload.data)
+                .map_err(|e| PayloadConversionError::EncodingError(Box::new(e)))?
+        } else if encoding == Some(b"binary/null".as_slice()) {
+            serde_json::Value::Null
+        } else {
             return Err(PayloadConversionError::WrongEncoding);
-        }
-        let json_v: serde_json::Value = serde_json::from_slice(&payload.data)
-            .map_err(|e| PayloadConversionError::EncodingError(Box::new(e)))?;
+        };
         Ok(Box::new(<dyn erased_serde::Deserializer>::erase(json_v)))
     }
 }
@@ -880,6 +892,52 @@ mod tests {
 
         let result: MultiArgs2<String, i32> = converter.from_payloads(&ctx, payloads).unwrap();
         assert_eq!(result, args);
+    }
+
+    #[test]
+    fn option_none_uses_binary_null_and_accepts_legacy_json_null() {
+        let converter = PayloadConverter::default();
+        let ctx = SerializationContext::new(&SerializationContextData::Workflow, &converter);
+
+        let payloads = converter
+            .to_payloads(&ctx, &Option::<String>::None)
+            .unwrap();
+        assert_eq!(payloads.len(), 1);
+        assert!(is_binary_null_payload(&payloads[0]));
+
+        let result: Option<String> = converter
+            .from_payload(&ctx, payloads.into_iter().next().unwrap())
+            .unwrap();
+        assert_eq!(result, None);
+
+        let legacy_json_null = Payload {
+            metadata: HashMap::from([("encoding".to_string(), b"json/plain".to_vec())]),
+            data: b"null".to_vec(),
+            external_payloads: vec![],
+        };
+        let result: Option<String> = converter.from_payload(&ctx, legacy_json_null).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn non_null_option_retains_json_encoding() {
+        let converter = PayloadConverter::default();
+        let ctx = SerializationContext::new(&SerializationContextData::Workflow, &converter);
+
+        let payload = converter
+            .to_payload(&ctx, &Some("value".to_string()))
+            .unwrap();
+        assert_eq!(payload.metadata.get("encoding").unwrap(), b"json/plain");
+        assert_eq!(payload.data, br#""value""#);
+    }
+
+    #[test]
+    fn empty_payloads_do_not_decode_as_option() {
+        let converter = PayloadConverter::default();
+        let ctx = SerializationContext::new(&SerializationContextData::Workflow, &converter);
+
+        let result: Result<Option<String>, _> = converter.from_payloads(&ctx, vec![]);
+        assert!(matches!(result, Err(PayloadConversionError::WrongEncoding)));
     }
 
     #[test]

--- a/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
@@ -756,6 +756,60 @@ async fn multi_args_serializes_as_multiple_payloads() {
     assert_eq!(second_payload_data, 42);
 }
 
+#[workflow]
+#[derive(Default)]
+struct BinaryNullWorkflow;
+
+#[workflow_methods]
+impl BinaryNullWorkflow {
+    #[run]
+    async fn run(_ctx: &mut WorkflowContext<Self>, input: Option<String>) -> WorkflowResult<()> {
+        assert_eq!(input, None);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn option_none_workflow_input_is_recorded_as_binary_null() {
+    let wf_name = BinaryNullWorkflow::name();
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter
+        .sdk_config
+        .register_workflow::<BinaryNullWorkflow>()
+        .unwrap();
+    let mut worker = starter.worker().await;
+    let handle = worker
+        .submit_workflow(
+            BinaryNullWorkflow::run,
+            Option::<String>::None,
+            WorkflowStartOptions::new(starter.get_task_queue(), wf_name).build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+
+    let events = handle
+        .fetch_history(Default::default())
+        .await
+        .unwrap()
+        .into_events();
+    let input = events
+        .iter()
+        .find_map(|event| match event.attributes.as_ref() {
+            Some(Attributes::WorkflowExecutionStartedEventAttributes(attributes)) => {
+                attributes.input.as_ref()
+            }
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(input.payloads.len(), 1);
+    assert_eq!(
+        input.payloads[0].metadata.get("encoding").unwrap(),
+        b"binary/null"
+    );
+    assert!(input.payloads[0].data.is_empty());
+}
+
 /// A codec that XORs payload data with a key and tracks encode/decode operations.
 struct XorCodec {
     key: u8,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- JSON converter now emits `binary/null` instead of `json/plain` with `null` body. This matches existing SDKs.
- We still respect the json variant if we encounter it

## Why?
Matches other SDK behavior encoding `nil`/`null`/`undefined`

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Unit tests along with integration to ensure that `None` as a workflow argument becomes `binary/null` now.

3. Any docs updates needed?
N/A