### PR TITLE
Add AWS Lambda worker support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ relevant information.
 ## Unreleased
 
 ### Added
+* The experimental `temporalio-sdk-aws-lambda` crate runs a versioned Rust SDK Worker for each AWS
+  Lambda invocation with Lambda-oriented concurrency defaults and deadline-aware graceful shutdown.
 * `LocalActivityOptions::include_arguments_into_marker` allows Rust workflows to opt in to
   recording local activity arguments in Workflow history.
 * `WorkflowHandle::get_update_handle` creates a typed handle for an existing Workflow Update from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@ relevant information.
 
 ### Added
 * The experimental `temporalio-sdk-aws-lambda` crate runs a versioned Rust SDK Worker for each AWS
-  Lambda invocation with Lambda-oriented concurrency defaults and deadline-aware graceful shutdown.
+  Lambda invocation with Lambda-oriented concurrency defaults, deadline-aware graceful shutdown,
+  and optional OTLP metrics and tracing configured for the AWS Distro for OpenTelemetry Lambda
+  layers.
 * `LocalActivityOptions::include_arguments_into_marker` allows Rust workflows to opt in to
   recording local activity arguments in Workflow history.
 * `WorkflowHandle::get_update_handle` creates a typed handle for an existing Workflow Update from

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/sdk",
     "crates/workflow",
     "crates/sdk-core-c-bridge",
+    "crates/sdk-aws-lambda",
     "crates/changelog-release-notes",
 ]
 resolver = "2"

--- a/crates/common/src/telemetry/otel.rs
+++ b/crates/common/src/telemetry/otel.rs
@@ -305,6 +305,12 @@ impl CoreMeter for CoreOtelMeter {
 }
 
 impl CoreOtelMeter {
+    /// Export all metrics currently buffered by this meter.
+    pub fn force_flush(&self) -> Result<(), anyhow::Error> {
+        self._mp.force_flush()?;
+        Ok(())
+    }
+
     fn create_histogram(&self, params: MetricParameters) -> opentelemetry::metrics::Histogram<u64> {
         self.meter
             .u64_histogram(params.name)

--- a/crates/sdk-aws-lambda/Cargo.toml
+++ b/crates/sdk-aws-lambda/Cargo.toml
@@ -11,13 +11,39 @@ keywords = ["temporal", "workflow", "aws", "lambda", "serverless"]
 categories = ["development-tools"]
 readme = "README.md"
 
+[features]
+default = []
+otel = [
+  "dep:opentelemetry",
+  "dep:opentelemetry-otlp",
+  "dep:opentelemetry_sdk",
+  "dep:tracing-opentelemetry",
+  "dep:tracing-subscriber",
+  "temporalio-common/otel",
+  "temporalio-sdk/otel",
+]
+
 [dependencies]
 anyhow = "1.0"
 lambda_runtime = "1.3"
+opentelemetry = { workspace = true, features = ["trace"], optional = true }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = [
+  "grpc-tonic",
+  "tokio",
+  "trace",
+], optional = true }
+opentelemetry_sdk = { version = "0.32", default-features = false, features = [
+  "rt-tokio",
+  "trace",
+], optional = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { version = "1.47", default-features = false, features = ["sync", "time"] }
 tracing = "0.1"
+tracing-opentelemetry = { version = "0.33", optional = true }
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+  "registry",
+], optional = true }
 
 [dependencies.temporalio-client]
 path = "../client"

--- a/crates/sdk-aws-lambda/Cargo.toml
+++ b/crates/sdk-aws-lambda/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "temporalio-sdk-aws-lambda"
+version = "0.1.0"
+edition = "2024"
+authors = ["Temporal Technologies Inc. <sdk@temporal.io>"]
+license-file = { workspace = true }
+description = "AWS Lambda integration for the Temporal Rust SDK"
+homepage = "https://temporal.io/"
+repository = "https://github.com/temporalio/sdk-rust"
+keywords = ["temporal", "workflow", "aws", "lambda", "serverless"]
+categories = ["development-tools"]
+readme = "README.md"
+
+[dependencies]
+anyhow = "1.0"
+lambda_runtime = "1.3"
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { version = "1.47", default-features = false, features = ["sync", "time"] }
+tracing = "0.1"
+
+[dependencies.temporalio-client]
+path = "../client"
+version = "0.7"
+default-features = false
+features = ["envconfig", "tls-ring"]
+
+[dependencies.temporalio-common]
+path = "../common"
+version = "0.7"
+default-features = false
+
+[dependencies.temporalio-sdk]
+path = "../sdk"
+version = "0.7"
+default-features = false
+features = ["envconfig"]
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1.47", default-features = false, features = [
+  "macros",
+  "rt",
+  "sync",
+  "test-util",
+  "time",
+] }
+
+[lints]
+workspace = true

--- a/crates/sdk-aws-lambda/README.md
+++ b/crates/sdk-aws-lambda/README.md
@@ -1,0 +1,38 @@
+# Temporal Rust SDK AWS Lambda integration
+
+This experimental crate runs a Temporal Worker for the bounded lifetime of an AWS Lambda
+invocation. It creates a new Temporal client and Worker for each invocation, begins graceful
+shutdown before the invocation deadline, and then runs registered shutdown hooks.
+
+```rust,no_run
+use std::sync::Arc;
+use temporalio_common::worker::WorkerDeploymentVersion;
+use temporalio_sdk::WorkerOptions;
+use temporalio_sdk_aws_lambda::LambdaWorker;
+
+# async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+let version = WorkerDeploymentVersion::builder()
+    .deployment_name("payments")
+    .build_id("2026-08-28")
+    .build();
+let mut worker_options = WorkerOptions::new("payments-task-queue").build();
+// Register workflows and activities on worker_options here.
+
+LambdaWorker::builder(version, worker_options)
+    .build()?
+    .run()
+    .await?;
+# Ok(())
+# }
+```
+
+Client connection settings are loaded from environment variables and an optional `temporal.toml`.
+The file lookup order is `TEMPORAL_CONFIG_FILE`, `$LAMBDA_TASK_ROOT/temporal.toml`, and
+`./temporal.toml`. `TEMPORAL_TASK_QUEUE` is used when the supplied worker options have an empty task
+queue.
+
+The builder applies Lambda-oriented limits by default: 10 Workflow Task slots, 2 Activity slots,
+2 Local Activity slots, 2 Workflow Task pollers, 1 Activity Task poller, 1 Nexus Task poller, a
+workflow cache size of 30, and a five-second graceful shutdown period. Eager Activity execution is
+always disabled, and Worker Deployment Versioning is always enabled. Call `worker_tuner` to
+explicitly replace the fixed-size Lambda tuner with a custom tuner.

--- a/crates/sdk-aws-lambda/README.md
+++ b/crates/sdk-aws-lambda/README.md
@@ -36,3 +36,41 @@ The builder applies Lambda-oriented limits by default: 10 Workflow Task slots, 2
 workflow cache size of 30, and a five-second graceful shutdown period. Eager Activity execution is
 always disabled, and Worker Deployment Versioning is always enabled. Call `worker_tuner` to
 explicitly replace the fixed-size Lambda tuner with a custom tuner.
+
+## OpenTelemetry
+
+Enable the `otel` feature to configure Temporal metrics and tracing for the AWS Distro for
+OpenTelemetry Collector Lambda layer:
+
+```toml
+[dependencies]
+temporalio-sdk-aws-lambda = { version = "0.1", features = ["otel"] }
+```
+
+```rust,no_run
+use temporalio_sdk_aws_lambda::otel::OpenTelemetryOptions;
+
+# fn configure(
+#     version: temporalio_common::worker::WorkerDeploymentVersion,
+#     worker_options: temporalio_sdk::WorkerOptions,
+# ) -> Result<(), temporalio_sdk_aws_lambda::LambdaWorkerError> {
+let worker = temporalio_sdk_aws_lambda::LambdaWorker::builder(version, worker_options)
+    .open_telemetry(OpenTelemetryOptions::default())
+    .build()?;
+# Ok(())
+# }
+```
+
+The default OTLP gRPC endpoint is `OTEL_EXPORTER_OTLP_ENDPOINT`, then
+`http://localhost:4317`. The service name is taken from `OTEL_SERVICE_NAME`, then
+`AWS_LAMBDA_FUNCTION_NAME`, and otherwise defaults to `temporal-lambda-worker`. Traces use
+AWS X-Ray-compatible trace IDs. Metrics and spans are force-flushed within the invocation's
+shutdown window while their providers remain active for warm starts.
+
+Attach the ADOT Collector Lambda layer and point `OTEL_EXPORTER_OTLP_ENDPOINT` at its receiver.
+The Lambda integration configures Temporal telemetry; application code outside Temporal still
+requires separate instrumentation.
+
+`open_telemetry` creates a telemetry-enabled Temporal runtime and therefore cannot be combined with
+the builder's `runtime` method. Applications that provide their own runtime can use `shutdown_hook`
+to flush their application-owned telemetry providers.

--- a/crates/sdk-aws-lambda/src/lib.rs
+++ b/crates/sdk-aws-lambda/src/lib.rs
@@ -6,6 +6,9 @@
 //! Worker polls until the invocation enters its reserved shutdown window, drains gracefully, runs
 //! shutdown hooks, and then returns control to the Lambda runtime.
 
+#[cfg(feature = "otel")]
+pub mod otel;
+
 use std::{
     env,
     future::Future,
@@ -106,6 +109,10 @@ pub enum LambdaWorkerError {
     /// The Temporal SDK runtime could not be created.
     #[error("failed to create Temporal runtime: {0}")]
     Runtime(#[source] anyhow::Error),
+    /// OpenTelemetry providers or exporters could not be configured.
+    #[cfg(feature = "otel")]
+    #[error("failed to configure OpenTelemetry: {0}")]
+    OpenTelemetry(#[source] anyhow::Error),
     /// The Temporal client could not connect.
     #[error("failed to connect Temporal client: {0}")]
     ClientConnect(#[from] ClientConnectError),
@@ -144,6 +151,8 @@ pub struct LambdaWorkerBuilder {
     custom_tuner: Option<Arc<dyn WorkerTuner + Send + Sync>>,
     default_versioning_behavior: VersioningBehavior,
     shutdown_hooks: Vec<ShutdownHook>,
+    #[cfg(feature = "otel")]
+    open_telemetry: Option<otel::OpenTelemetryOptions>,
 }
 
 impl LambdaWorkerBuilder {
@@ -161,6 +170,17 @@ impl LambdaWorkerBuilder {
     /// Use an already-created Temporal SDK runtime.
     pub fn runtime(mut self, runtime: Arc<Runtime>) -> Self {
         self.runtime = Some(runtime);
+        self
+    }
+
+    /// Configure OTLP metrics and tracing using AWS Lambda-oriented defaults.
+    ///
+    /// This creates the SDK runtime, so it cannot be combined with [`Self::runtime`]. Pending
+    /// telemetry is force-flushed after every invocation without shutting down the providers,
+    /// allowing them to remain available for warm starts.
+    #[cfg(feature = "otel")]
+    pub fn open_telemetry(mut self, options: otel::OpenTelemetryOptions) -> Self {
+        self.open_telemetry = Some(options);
         self
     }
 
@@ -230,6 +250,26 @@ impl LambdaWorkerBuilder {
                 (None, None) => load_client_options()?,
                 _ => unreachable!("client_options sets both option types"),
             };
+        #[cfg(feature = "otel")]
+        let runtime = match (self.runtime, self.open_telemetry) {
+            (Some(_), Some(_)) => {
+                return Err(LambdaWorkerError::InvalidConfiguration(
+                    "runtime and OpenTelemetry options cannot both be supplied".to_owned(),
+                ));
+            }
+            (Some(runtime), None) => runtime,
+            (None, Some(options)) => {
+                let integration = otel::OpenTelemetryIntegration::new(options)
+                    .map_err(LambdaWorkerError::OpenTelemetry)?;
+                self.shutdown_hooks.push(integration.flush_hook());
+                integration.runtime()
+            }
+            (None, None) => Arc::new(
+                Runtime::new_assume_tokio(Default::default())
+                    .map_err(LambdaWorkerError::Runtime)?,
+            ),
+        };
+        #[cfg(not(feature = "otel"))]
         let runtime = match self.runtime {
             Some(runtime) => runtime,
             None => Arc::new(
@@ -286,6 +326,8 @@ impl LambdaWorker {
             custom_tuner: None,
             default_versioning_behavior: VersioningBehavior::Pinned,
             shutdown_hooks: Vec::new(),
+            #[cfg(feature = "otel")]
+            open_telemetry: None,
         }
     }
 
@@ -618,6 +660,29 @@ mod tests {
             options.deployment_options.default_versioning_behavior,
             Some(VersioningBehavior::AutoUpgrade)
         );
+    }
+
+    #[cfg(feature = "otel")]
+    #[tokio::test]
+    async fn rejects_open_telemetry_with_caller_owned_runtime() {
+        let runtime = Arc::new(Runtime::new_assume_tokio(Default::default()).unwrap());
+        let result = LambdaWorker::builder(version(), WorkerOptions::new("queue").build())
+            .client_options(
+                ConnectionOptions::new(
+                    temporalio_client::Url::parse("http://localhost:7233").unwrap(),
+                )
+                .build(),
+                ClientOptions::new("default").build(),
+            )
+            .runtime(runtime)
+            .open_telemetry(otel::OpenTelemetryOptions::default())
+            .build();
+
+        assert!(matches!(
+            result,
+            Err(LambdaWorkerError::InvalidConfiguration(message))
+                if message.contains("runtime and OpenTelemetry")
+        ));
     }
 
     #[test]

--- a/crates/sdk-aws-lambda/src/lib.rs
+++ b/crates/sdk-aws-lambda/src/lib.rs
@@ -1,0 +1,797 @@
+#![warn(missing_docs)]
+
+//! AWS Lambda support for the Temporal Rust SDK.
+//!
+//! A [`LambdaWorker`] creates a fresh Temporal client and Worker for every Lambda invocation. The
+//! Worker polls until the invocation enters its reserved shutdown window, drains gracefully, runs
+//! shutdown hooks, and then returns control to the Lambda runtime.
+
+use std::{
+    env,
+    future::Future,
+    path::{Path, PathBuf},
+    pin::Pin,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+
+use lambda_runtime::{LambdaEvent, service_fn};
+use temporalio_client::{
+    Client, ClientOptions, ConnectionOptions,
+    envconfig::{ConfigError, DataSource, LoadClientConfigProfileOptions},
+    errors::ClientConnectError,
+};
+use temporalio_common::worker::{
+    VersioningBehavior, WorkerDeploymentOptions, WorkerDeploymentVersion,
+};
+use temporalio_sdk::{
+    Runtime, Worker, WorkerCreateError, WorkerOptions, WorkerRunError,
+    runtime::{PollerBehavior, TunerHolder, WorkerTuner},
+};
+use tokio::time::{Instant, sleep, sleep_until, timeout};
+
+const DEFAULT_CONFIG_FILE: &str = "temporal.toml";
+const ENV_CONFIG_FILE: &str = "TEMPORAL_CONFIG_FILE";
+const ENV_LAMBDA_TASK_ROOT: &str = "LAMBDA_TASK_ROOT";
+const ENV_TASK_QUEUE: &str = "TEMPORAL_TASK_QUEUE";
+const MINIMUM_WORK_TIME: Duration = Duration::from_secs(1);
+const LOW_WORK_TIME_WARNING: Duration = Duration::from_secs(5);
+
+type HookFuture = Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>>;
+type ShutdownHook = Arc<dyn Fn(Duration) -> HookFuture + Send + Sync>;
+
+/// Lambda-oriented Worker limits applied by [`LambdaWorkerBuilder`].
+///
+/// These settings are distinct from [`WorkerOptions`] so callers can explicitly choose Lambda
+/// defaults or replace them without the integration guessing whether an SDK default was intentional.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct LambdaWorkerDefaults {
+    /// Maximum concurrent Workflow Tasks.
+    pub workflow_slots: usize,
+    /// Maximum concurrent Activities.
+    pub activity_slots: usize,
+    /// Maximum concurrent Local Activities.
+    pub local_activity_slots: usize,
+    /// Maximum concurrent Nexus Tasks. Rust SDK Nexus registration is not yet exposed, but the
+    /// slot supplier is configured for forward compatibility.
+    pub nexus_slots: usize,
+    /// Maximum concurrent Workflow Task polls.
+    pub workflow_task_pollers: usize,
+    /// Maximum concurrent Activity Task polls.
+    pub activity_task_pollers: usize,
+    /// Maximum concurrent Nexus Task polls.
+    pub nexus_task_pollers: usize,
+    /// Maximum number of cached Workflows.
+    pub max_cached_workflows: usize,
+    /// Time allowed for graceful Worker shutdown.
+    pub graceful_shutdown_period: Duration,
+    /// Time reserved after Worker shutdown for hooks and final cleanup.
+    pub shutdown_hook_buffer: Duration,
+}
+
+impl Default for LambdaWorkerDefaults {
+    fn default() -> Self {
+        Self {
+            workflow_slots: 10,
+            activity_slots: 2,
+            local_activity_slots: 2,
+            nexus_slots: 5,
+            workflow_task_pollers: 2,
+            activity_task_pollers: 1,
+            nexus_task_pollers: 1,
+            max_cached_workflows: 30,
+            graceful_shutdown_period: Duration::from_secs(5),
+            shutdown_hook_buffer: Duration::from_secs(2),
+        }
+    }
+}
+
+/// Errors produced while configuring or running a Lambda Worker.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum LambdaWorkerError {
+    /// The Worker Deployment Version is incomplete.
+    #[error("worker deployment name and build ID must both be non-empty")]
+    InvalidDeploymentVersion,
+    /// No task queue was configured.
+    #[error("task queue is required: set WorkerOptions.task_queue or {ENV_TASK_QUEUE}")]
+    MissingTaskQueue,
+    /// A Lambda Worker limit is invalid.
+    #[error("invalid Lambda Worker configuration: {0}")]
+    InvalidConfiguration(String),
+    /// Client environment or file configuration could not be loaded.
+    #[error("failed to load Temporal client configuration: {0}")]
+    ClientConfiguration(#[from] ConfigError),
+    /// The Temporal SDK runtime could not be created.
+    #[error("failed to create Temporal runtime: {0}")]
+    Runtime(#[source] anyhow::Error),
+    /// The Temporal client could not connect.
+    #[error("failed to connect Temporal client: {0}")]
+    ClientConnect(#[from] ClientConnectError),
+    /// The Temporal client did not connect before the Worker shutdown window began.
+    #[error("Temporal client did not connect within the {0:?} work budget")]
+    ClientConnectTimedOut(Duration),
+    /// The Temporal Worker could not be created.
+    #[error("failed to create Temporal Worker: {0}")]
+    WorkerCreate(#[from] WorkerCreateError),
+    /// The Temporal Worker stopped with an error.
+    #[error("Temporal Worker failed: {0}")]
+    WorkerRun(#[from] WorkerRunError),
+    /// Too little invocation time remains to start a Worker.
+    #[error(
+        "insufficient Lambda invocation time: {remaining:?} remaining with a {shutdown_buffer:?} shutdown buffer"
+    )]
+    InsufficientTime {
+        /// Time remaining in the invocation.
+        remaining: Duration,
+        /// Time reserved for shutdown.
+        shutdown_buffer: Duration,
+    },
+    /// The Worker did not finish before its graceful shutdown allowance elapsed.
+    #[error("Temporal Worker did not stop within {0:?}")]
+    ShutdownTimedOut(Duration),
+}
+
+/// Builder for [`LambdaWorker`].
+pub struct LambdaWorkerBuilder {
+    version: WorkerDeploymentVersion,
+    worker_options: WorkerOptions,
+    connection_options: Option<ConnectionOptions>,
+    client_options: Option<ClientOptions>,
+    runtime: Option<Arc<Runtime>>,
+    defaults: LambdaWorkerDefaults,
+    custom_tuner: Option<Arc<dyn WorkerTuner + Send + Sync>>,
+    default_versioning_behavior: VersioningBehavior,
+    shutdown_hooks: Vec<ShutdownHook>,
+}
+
+impl LambdaWorkerBuilder {
+    /// Use explicit connection and namespace-bound client options instead of environment loading.
+    pub fn client_options(
+        mut self,
+        connection_options: ConnectionOptions,
+        client_options: ClientOptions,
+    ) -> Self {
+        self.connection_options = Some(connection_options);
+        self.client_options = Some(client_options);
+        self
+    }
+
+    /// Use an already-created Temporal SDK runtime.
+    pub fn runtime(mut self, runtime: Arc<Runtime>) -> Self {
+        self.runtime = Some(runtime);
+        self
+    }
+
+    /// Replace the Lambda-oriented limits and shutdown timings.
+    pub fn lambda_defaults(mut self, defaults: LambdaWorkerDefaults) -> Self {
+        self.defaults = defaults;
+        self
+    }
+
+    /// Explicitly use a custom Worker tuner instead of the Lambda fixed-size tuner.
+    pub fn worker_tuner(mut self, tuner: Arc<dyn WorkerTuner + Send + Sync>) -> Self {
+        self.custom_tuner = Some(tuner);
+        self
+    }
+
+    /// Set the default versioning behavior for Workflows without a registration-time behavior.
+    ///
+    /// The default is [`VersioningBehavior::Pinned`]. `Unspecified` is rejected.
+    pub fn default_versioning_behavior(mut self, behavior: VersioningBehavior) -> Self {
+        self.default_versioning_behavior = behavior;
+        self
+    }
+
+    /// Add a hook that runs after the invocation's Worker has stopped.
+    ///
+    /// Hooks run in registration order. Each receives the invocation time remaining when it starts.
+    /// Hook failures are logged and do not prevent later hooks from running.
+    pub fn shutdown_hook<F, Fut>(mut self, hook: F) -> Self
+    where
+        F: Fn(Duration) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        self.shutdown_hooks
+            .push(Arc::new(move |remaining| Box::pin(hook(remaining))));
+        self
+    }
+
+    /// Validate options and build a reusable Lambda handler.
+    ///
+    /// When no client options were supplied, configuration is loaded from `temporal.toml` and
+    /// environment variables. This method must run inside a Tokio runtime unless [`Self::runtime`]
+    /// was used.
+    pub fn build(mut self) -> Result<LambdaWorker, LambdaWorkerError> {
+        validate_version(&self.version)?;
+        validate_defaults(&self.defaults)?;
+        if self.default_versioning_behavior == VersioningBehavior::Unspecified {
+            return Err(LambdaWorkerError::InvalidConfiguration(
+                "default versioning behavior cannot be Unspecified".to_owned(),
+            ));
+        }
+
+        self.worker_options.task_queue =
+            resolve_task_queue(&self.worker_options.task_queue, |name| env::var(name).ok())
+                .ok_or(LambdaWorkerError::MissingTaskQueue)?;
+
+        apply_worker_configuration(
+            &mut self.worker_options,
+            &self.version,
+            &self.defaults,
+            self.custom_tuner,
+            self.default_versioning_behavior,
+        );
+
+        let (connection_options, client_options) =
+            match (self.connection_options, self.client_options) {
+                (Some(connection), Some(client)) => (connection, client),
+                (None, None) => load_client_options()?,
+                _ => unreachable!("client_options sets both option types"),
+            };
+        let runtime = match self.runtime {
+            Some(runtime) => runtime,
+            None => Arc::new(
+                Runtime::new_assume_tokio(Default::default())
+                    .map_err(LambdaWorkerError::Runtime)?,
+            ),
+        };
+        let shutdown_buffer = self
+            .defaults
+            .graceful_shutdown_period
+            .saturating_add(self.defaults.shutdown_hook_buffer);
+
+        Ok(LambdaWorker {
+            inner: Arc::new(LambdaWorkerInner {
+                connection_options,
+                client_options,
+                worker_options: self.worker_options,
+                runtime,
+                shutdown_buffer,
+                shutdown_hooks: self.shutdown_hooks,
+            }),
+        })
+    }
+}
+
+/// A reusable AWS Lambda handler that runs one Temporal Worker per invocation.
+#[derive(Clone)]
+pub struct LambdaWorker {
+    inner: Arc<LambdaWorkerInner>,
+}
+
+struct LambdaWorkerInner {
+    connection_options: ConnectionOptions,
+    client_options: ClientOptions,
+    worker_options: WorkerOptions,
+    runtime: Arc<Runtime>,
+    shutdown_buffer: Duration,
+    shutdown_hooks: Vec<ShutdownHook>,
+}
+
+impl LambdaWorker {
+    /// Start building a Lambda Worker around existing SDK Worker registrations.
+    pub fn builder(
+        version: WorkerDeploymentVersion,
+        worker_options: WorkerOptions,
+    ) -> LambdaWorkerBuilder {
+        LambdaWorkerBuilder {
+            version,
+            worker_options,
+            connection_options: None,
+            client_options: None,
+            runtime: None,
+            defaults: LambdaWorkerDefaults::default(),
+            custom_tuner: None,
+            default_versioning_behavior: VersioningBehavior::Pinned,
+            shutdown_hooks: Vec::new(),
+        }
+    }
+
+    /// Handle one Lambda invocation.
+    ///
+    /// The event payload is ignored; the invocation exists to give the Worker a bounded polling
+    /// window and an invocation-specific identity.
+    pub async fn handle<T>(&self, event: LambdaEvent<T>) -> Result<(), LambdaWorkerError> {
+        let deadline = event.context.deadline();
+        let initial_remaining = remaining_until(deadline);
+        let work_time = initial_remaining
+            .checked_sub(self.inner.shutdown_buffer)
+            .ok_or(LambdaWorkerError::InsufficientTime {
+                remaining: initial_remaining,
+                shutdown_buffer: self.inner.shutdown_buffer,
+            })?;
+        if work_time <= MINIMUM_WORK_TIME {
+            return Err(LambdaWorkerError::InsufficientTime {
+                remaining: initial_remaining,
+                shutdown_buffer: self.inner.shutdown_buffer,
+            });
+        }
+        if work_time < LOW_WORK_TIME_WARNING {
+            tracing::warn!(
+                ?work_time,
+                shutdown_buffer = ?self.inner.shutdown_buffer,
+                "Lambda invocation has little time available for Temporal Worker polling"
+            );
+        }
+
+        let shutdown_at = deadline
+            .checked_sub(self.inner.shutdown_buffer)
+            .expect("the checked work-time calculation already succeeded");
+        let result = self.run_worker(event.context, shutdown_at).await;
+        self.run_shutdown_hooks(deadline).await;
+        result
+    }
+
+    /// Run this handler using the standard AWS Lambda Rust runtime.
+    pub async fn run(self) -> Result<(), lambda_runtime::Error> {
+        lambda_runtime::run(service_fn(move |event: LambdaEvent<serde_json::Value>| {
+            let worker = self.clone();
+            async move {
+                worker.handle(event).await.map_err(|error| {
+                    Box::new(std::io::Error::other(error.to_string())) as lambda_runtime::Error
+                })
+            }
+        }))
+        .await
+    }
+
+    async fn run_worker(
+        &self,
+        context: lambda_runtime::Context,
+        shutdown_at: SystemTime,
+    ) -> Result<(), LambdaWorkerError> {
+        let mut connection_options = self.inner.connection_options.clone();
+        if connection_options.identity.is_empty()
+            && self.inner.worker_options.client_identity_override.is_none()
+        {
+            connection_options.identity = invocation_identity(&context);
+        }
+
+        let connect_budget = remaining_until(shutdown_at);
+        let client = timeout(
+            connect_budget,
+            Client::connect(connection_options, self.inner.client_options.clone()),
+        )
+        .await
+        .map_err(|_| LambdaWorkerError::ClientConnectTimedOut(connect_budget))??;
+        let mut worker = Worker::new(
+            &self.inner.runtime,
+            client,
+            self.inner.worker_options.clone(),
+        )?;
+        let initiate_shutdown = worker.shutdown_handle();
+        let work_time = remaining_until(shutdown_at);
+        let worker_result = run_until_shutdown(
+            worker.run(),
+            sleep(work_time),
+            initiate_shutdown,
+            self.inner.shutdown_buffer,
+        )
+        .await?;
+        worker_result.map_err(LambdaWorkerError::WorkerRun)
+    }
+
+    async fn run_shutdown_hooks(&self, deadline: SystemTime) {
+        for hook in &self.inner.shutdown_hooks {
+            let remaining = remaining_until(deadline);
+            if remaining.is_zero() {
+                tracing::error!("Lambda deadline reached before all shutdown hooks ran");
+                break;
+            }
+            match timeout(remaining, hook(remaining)).await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    tracing::error!(%error, "Lambda Worker shutdown hook failed");
+                }
+                Err(_) => {
+                    tracing::error!("Lambda Worker shutdown hook exceeded the invocation deadline");
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn apply_worker_configuration(
+    options: &mut WorkerOptions,
+    version: &WorkerDeploymentVersion,
+    defaults: &LambdaWorkerDefaults,
+    custom_tuner: Option<Arc<dyn WorkerTuner + Send + Sync>>,
+    default_versioning_behavior: VersioningBehavior,
+) {
+    options.tuner = custom_tuner.unwrap_or_else(|| {
+        Arc::new(TunerHolder::fixed_size(
+            defaults.workflow_slots,
+            defaults.activity_slots,
+            defaults.local_activity_slots,
+            defaults.nexus_slots,
+        ))
+    });
+    options.workflow_task_poller_behavior = Some(PollerBehavior::SimpleMaximum(
+        defaults.workflow_task_pollers,
+    ));
+    options.activity_task_poller_behavior = Some(PollerBehavior::SimpleMaximum(
+        defaults.activity_task_pollers,
+    ));
+    options.nexus_task_poller_behavior =
+        Some(PollerBehavior::SimpleMaximum(defaults.nexus_task_pollers));
+    options.max_cached_workflows = defaults.max_cached_workflows;
+    options.graceful_shutdown_period = Some(defaults.graceful_shutdown_period);
+    options.max_eager_activity_reservations_per_workflow_task = 0;
+    options.deployment_options = WorkerDeploymentOptions::new(version.clone())
+        .use_worker_versioning(true)
+        .default_versioning_behavior(default_versioning_behavior)
+        .build();
+}
+
+fn validate_version(version: &WorkerDeploymentVersion) -> Result<(), LambdaWorkerError> {
+    if version.deployment_name.trim().is_empty() || version.build_id.trim().is_empty() {
+        Err(LambdaWorkerError::InvalidDeploymentVersion)
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_defaults(defaults: &LambdaWorkerDefaults) -> Result<(), LambdaWorkerError> {
+    if defaults.workflow_slots == 0
+        || defaults.activity_slots == 0
+        || defaults.local_activity_slots == 0
+        || defaults.nexus_slots == 0
+    {
+        return Err(LambdaWorkerError::InvalidConfiguration(
+            "all fixed-size tuner slot counts must be greater than zero".to_owned(),
+        ));
+    }
+    if defaults.workflow_task_pollers < 2 {
+        return Err(LambdaWorkerError::InvalidConfiguration(
+            "workflow_task_pollers must be at least 2 when sticky caching is enabled".to_owned(),
+        ));
+    }
+    if defaults.activity_task_pollers == 0 || defaults.nexus_task_pollers == 0 {
+        return Err(LambdaWorkerError::InvalidConfiguration(
+            "activity_task_pollers and nexus_task_pollers must be greater than zero".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn load_client_options() -> Result<(ConnectionOptions, ClientOptions), ConfigError> {
+    let load_options =
+        match resolve_config_file(|name| env::var_os(name), env::current_dir().ok().as_deref()) {
+            Some(path) => LoadClientConfigProfileOptions::builder()
+                .config_source(DataSource::Path(path.to_string_lossy().into_owned()))
+                .build(),
+            None => LoadClientConfigProfileOptions::builder()
+                .disable_file(true)
+                .build(),
+        };
+    ClientOptions::load_from_config(load_options)
+}
+
+fn resolve_config_file(
+    getenv: impl Fn(&str) -> Option<std::ffi::OsString>,
+    current_dir: Option<&Path>,
+) -> Option<PathBuf> {
+    if let Some(path) = getenv(ENV_CONFIG_FILE).filter(|path| !path.is_empty()) {
+        return Some(PathBuf::from(path));
+    }
+    if let Some(task_root) = getenv(ENV_LAMBDA_TASK_ROOT).filter(|path| !path.is_empty()) {
+        let candidate = PathBuf::from(task_root).join(DEFAULT_CONFIG_FILE);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    current_dir
+        .map(|dir| dir.join(DEFAULT_CONFIG_FILE))
+        .filter(|path| path.is_file())
+}
+
+fn resolve_task_queue(configured: &str, getenv: impl Fn(&str) -> Option<String>) -> Option<String> {
+    if !configured.trim().is_empty() {
+        return Some(configured.to_owned());
+    }
+    getenv(ENV_TASK_QUEUE).filter(|task_queue| !task_queue.trim().is_empty())
+}
+
+fn invocation_identity(context: &lambda_runtime::Context) -> String {
+    let request_id = if context.request_id.is_empty() {
+        "unknown"
+    } else {
+        &context.request_id
+    };
+    let function_arn = if context.invoked_function_arn.is_empty() {
+        "unknown"
+    } else {
+        &context.invoked_function_arn
+    };
+    format!("{request_id}@{function_arn}")
+}
+
+fn remaining_until(deadline: SystemTime) -> Duration {
+    deadline
+        .duration_since(SystemTime::now())
+        .unwrap_or(Duration::ZERO)
+}
+
+async fn run_until_shutdown<R, D, S, E>(
+    run: R,
+    shutdown_delay: D,
+    initiate_shutdown: S,
+    graceful_shutdown_period: Duration,
+) -> Result<Result<(), E>, LambdaWorkerError>
+where
+    R: Future<Output = Result<(), E>>,
+    D: Future<Output = ()>,
+    S: FnOnce(),
+{
+    tokio::pin!(run);
+    tokio::pin!(shutdown_delay);
+    tokio::select! {
+        result = &mut run => Ok(result),
+        () = &mut shutdown_delay => {
+            initiate_shutdown();
+            let shutdown_deadline = Instant::now() + graceful_shutdown_period;
+            tokio::select! {
+                result = &mut run => Ok(result),
+                () = sleep_until(shutdown_deadline) => {
+                    Err(LambdaWorkerError::ShutdownTimedOut(graceful_shutdown_period))
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        ffi::OsString,
+        sync::{
+            Mutex,
+            atomic::{AtomicBool, Ordering},
+        },
+    };
+    use tokio::sync::{Notify, oneshot};
+
+    fn version() -> WorkerDeploymentVersion {
+        WorkerDeploymentVersion::builder()
+            .deployment_name("deployment")
+            .build_id("build")
+            .build()
+    }
+
+    #[test]
+    fn applies_lambda_worker_configuration() {
+        let mut options = WorkerOptions::new("queue").build();
+        let defaults = LambdaWorkerDefaults::default();
+        apply_worker_configuration(
+            &mut options,
+            &version(),
+            &defaults,
+            None,
+            VersioningBehavior::Pinned,
+        );
+
+        assert_eq!(options.max_cached_workflows, 30);
+        assert_eq!(
+            options.workflow_task_poller_behavior,
+            Some(PollerBehavior::SimpleMaximum(2))
+        );
+        assert_eq!(
+            options.activity_task_poller_behavior,
+            Some(PollerBehavior::SimpleMaximum(1))
+        );
+        assert_eq!(
+            options.nexus_task_poller_behavior,
+            Some(PollerBehavior::SimpleMaximum(1))
+        );
+        assert_eq!(options.max_eager_activity_reservations_per_workflow_task, 0);
+        assert_eq!(
+            options.graceful_shutdown_period,
+            Some(Duration::from_secs(5))
+        );
+        assert!(options.deployment_options.use_worker_versioning);
+        assert_eq!(options.deployment_options.version, version());
+        assert_eq!(
+            options.deployment_options.default_versioning_behavior,
+            Some(VersioningBehavior::Pinned)
+        );
+    }
+
+    #[test]
+    fn custom_tuner_is_preserved_explicitly() {
+        let custom: Arc<dyn WorkerTuner + Send + Sync> =
+            Arc::new(TunerHolder::fixed_size(3, 4, 5, 6));
+        let mut options = WorkerOptions::new("queue").build();
+        apply_worker_configuration(
+            &mut options,
+            &version(),
+            &LambdaWorkerDefaults::default(),
+            Some(custom.clone()),
+            VersioningBehavior::AutoUpgrade,
+        );
+
+        assert!(Arc::ptr_eq(&options.tuner, &custom));
+        assert_eq!(
+            options.deployment_options.default_versioning_behavior,
+            Some(VersioningBehavior::AutoUpgrade)
+        );
+    }
+
+    #[test]
+    fn validates_version_and_limits() {
+        let invalid_version = WorkerDeploymentVersion::builder()
+            .deployment_name("")
+            .build_id("build")
+            .build();
+        assert!(matches!(
+            validate_version(&invalid_version),
+            Err(LambdaWorkerError::InvalidDeploymentVersion)
+        ));
+
+        let defaults = LambdaWorkerDefaults {
+            workflow_task_pollers: 1,
+            ..Default::default()
+        };
+        assert!(matches!(
+            validate_defaults(&defaults),
+            Err(LambdaWorkerError::InvalidConfiguration(_))
+        ));
+    }
+
+    #[test]
+    fn resolves_config_file_in_lambda_order() {
+        let temp = tempfile::tempdir().unwrap();
+        let task_root = temp.path().join("task");
+        let cwd = temp.path().join("cwd");
+        std::fs::create_dir_all(&task_root).unwrap();
+        std::fs::create_dir_all(&cwd).unwrap();
+        std::fs::write(task_root.join(DEFAULT_CONFIG_FILE), "").unwrap();
+        std::fs::write(cwd.join(DEFAULT_CONFIG_FILE), "").unwrap();
+
+        let explicit = temp.path().join("explicit.toml");
+        let resolved = resolve_config_file(
+            |name| match name {
+                ENV_CONFIG_FILE => Some(explicit.clone().into_os_string()),
+                ENV_LAMBDA_TASK_ROOT => Some(task_root.clone().into_os_string()),
+                _ => None,
+            },
+            Some(&cwd),
+        );
+        assert_eq!(resolved, Some(explicit));
+
+        let resolved = resolve_config_file(
+            |name| (name == ENV_LAMBDA_TASK_ROOT).then(|| OsString::from(task_root.as_os_str())),
+            Some(&cwd),
+        );
+        assert_eq!(resolved, Some(task_root.join(DEFAULT_CONFIG_FILE)));
+
+        std::fs::remove_file(task_root.join(DEFAULT_CONFIG_FILE)).unwrap();
+        let resolved = resolve_config_file(
+            |name| (name == ENV_LAMBDA_TASK_ROOT).then(|| OsString::from(task_root.as_os_str())),
+            Some(&cwd),
+        );
+        assert_eq!(resolved, Some(cwd.join(DEFAULT_CONFIG_FILE)));
+    }
+
+    #[test]
+    fn explicit_task_queue_wins_and_environment_is_fallback() {
+        assert_eq!(
+            resolve_task_queue("configured", |_| Some("environment".to_owned())),
+            Some("configured".to_owned())
+        );
+        assert_eq!(
+            resolve_task_queue("  ", |_| Some("environment".to_owned())),
+            Some("environment".to_owned())
+        );
+        assert_eq!(resolve_task_queue("", |_| None), None);
+    }
+
+    #[test]
+    fn builds_invocation_identity_from_lambda_context() {
+        let mut context = lambda_runtime::Context::default();
+        context.request_id = "request-123".to_owned();
+        context.invoked_function_arn = "arn:aws:lambda:region:account:function:worker".to_owned();
+        assert_eq!(
+            invocation_identity(&context),
+            "request-123@arn:aws:lambda:region:account:function:worker"
+        );
+
+        let context = lambda_runtime::Context::default();
+        assert_eq!(invocation_identity(&context), "unknown@unknown");
+    }
+
+    #[tokio::test]
+    async fn lifecycle_initiates_shutdown_and_waits_for_run() {
+        let (trigger_tx, trigger_rx) = oneshot::channel();
+        let stopped = Arc::new(Notify::new());
+        let stopped_for_run = stopped.clone();
+        let shutdown_called = Arc::new(AtomicBool::new(false));
+        let shutdown_called_for_closure = shutdown_called.clone();
+
+        let run = async move {
+            stopped_for_run.notified().await;
+            Result::<(), ()>::Ok(())
+        };
+        let result = run_until_shutdown(
+            run,
+            async move {
+                trigger_rx.await.unwrap();
+            },
+            move || {
+                shutdown_called_for_closure.store(true, Ordering::SeqCst);
+                stopped.notify_one();
+            },
+            Duration::from_secs(5),
+        );
+        trigger_tx.send(()).unwrap();
+
+        assert_eq!(result.await.unwrap(), Ok(()));
+        assert!(shutdown_called.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn lifecycle_times_out_when_run_does_not_stop() {
+        let (trigger_tx, trigger_rx) = oneshot::channel();
+        let shutdown_called = Arc::new(AtomicBool::new(false));
+        let shutdown_called_for_closure = shutdown_called.clone();
+        let never = Arc::new(Notify::new());
+        let run = async move {
+            never.notified().await;
+            Result::<(), ()>::Ok(())
+        };
+
+        let result = run_until_shutdown(
+            run,
+            async move {
+                trigger_rx.await.unwrap();
+            },
+            move || shutdown_called_for_closure.store(true, Ordering::SeqCst),
+            Duration::from_secs(5),
+        );
+        trigger_tx.send(()).unwrap();
+
+        assert!(matches!(
+            result.await,
+            Err(LambdaWorkerError::ShutdownTimedOut(duration))
+                if duration == Duration::from_secs(5)
+        ));
+        assert!(shutdown_called.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn shutdown_hooks_run_in_order_and_continue_after_errors() {
+        let order = Arc::new(Mutex::new(Vec::new()));
+        let first_order = order.clone();
+        let second_order = order.clone();
+        let worker = LambdaWorker {
+            inner: Arc::new(LambdaWorkerInner {
+                connection_options: ConnectionOptions::new(
+                    temporalio_client::Url::parse("http://localhost:7233").unwrap(),
+                )
+                .build(),
+                client_options: ClientOptions::new("default").build(),
+                worker_options: WorkerOptions::new("queue").build(),
+                runtime: Arc::new(Runtime::new_assume_tokio(Default::default()).unwrap()),
+                shutdown_buffer: Duration::from_secs(7),
+                shutdown_hooks: vec![
+                    Arc::new(move |_| {
+                        first_order.lock().unwrap().push("first");
+                        Box::pin(async { anyhow::bail!("expected") })
+                    }),
+                    Arc::new(move |_| {
+                        second_order.lock().unwrap().push("second");
+                        Box::pin(async { Ok(()) })
+                    }),
+                ],
+            }),
+        };
+
+        worker
+            .run_shutdown_hooks(SystemTime::now() + Duration::from_secs(1))
+            .await;
+        assert_eq!(*order.lock().unwrap(), vec!["first", "second"]);
+    }
+}

--- a/crates/sdk-aws-lambda/src/otel.rs
+++ b/crates/sdk-aws-lambda/src/otel.rs
@@ -1,0 +1,230 @@
+//! OpenTelemetry configuration for Lambda Workers.
+
+use std::{
+    collections::HashMap,
+    env,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use opentelemetry::trace::{SpanId, TraceId, TracerProvider as _};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::{
+    Resource,
+    trace::{IdGenerator, RandomIdGenerator, SdkTracerProvider},
+};
+use temporalio_client::Url;
+use temporalio_common::telemetry::{
+    OtelCollectorOptions, TelemetryOptions, build_otlp_metric_exporter, metrics::CoreMeter,
+};
+use temporalio_sdk::{Runtime, runtime::RuntimeOptions};
+use tracing_subscriber::layer::SubscriberExt as _;
+
+use crate::ShutdownHook;
+
+const DEFAULT_ENDPOINT: &str = "http://localhost:4317";
+const DEFAULT_SERVICE_NAME: &str = "temporal-lambda-worker";
+const ENV_AWS_LAMBDA_FUNCTION_NAME: &str = "AWS_LAMBDA_FUNCTION_NAME";
+const ENV_OTEL_EXPORTER_OTLP_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
+const ENV_OTEL_SERVICE_NAME: &str = "OTEL_SERVICE_NAME";
+
+/// Options for Lambda-oriented OpenTelemetry metrics and tracing.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct OpenTelemetryOptions {
+    /// OTLP gRPC collector endpoint.
+    ///
+    /// Defaults to `OTEL_EXPORTER_OTLP_ENDPOINT`, then `http://localhost:4317`, which is the
+    /// endpoint exposed by the AWS Distro for OpenTelemetry Collector Lambda layer.
+    pub endpoint: Option<Url>,
+    /// OpenTelemetry `service.name` resource attribute.
+    ///
+    /// Defaults to `OTEL_SERVICE_NAME`, `AWS_LAMBDA_FUNCTION_NAME`, then
+    /// `temporal-lambda-worker`.
+    pub service_name: Option<String>,
+    /// Interval between periodic metric exports. Defaults to ten seconds.
+    pub metric_export_interval: Duration,
+}
+
+impl Default for OpenTelemetryOptions {
+    fn default() -> Self {
+        Self {
+            endpoint: None,
+            service_name: None,
+            metric_export_interval: Duration::from_secs(10),
+        }
+    }
+}
+
+pub(crate) struct OpenTelemetryIntegration {
+    runtime: Arc<Runtime>,
+    flush_hook: ShutdownHook,
+}
+
+impl OpenTelemetryIntegration {
+    pub(crate) fn new(options: OpenTelemetryOptions) -> Result<Self, anyhow::Error> {
+        if options.metric_export_interval.is_zero() {
+            anyhow::bail!("OpenTelemetry metric export interval must be greater than zero");
+        }
+        let endpoint = match options.endpoint {
+            Some(endpoint) => endpoint,
+            None => resolve_endpoint(|name| env::var(name).ok())?,
+        };
+        let service_name = options
+            .service_name
+            .filter(|name| !name.trim().is_empty())
+            .unwrap_or_else(|| resolve_service_name(|name| env::var(name).ok()));
+        let meter = Arc::new(build_otlp_metric_exporter(
+            OtelCollectorOptions::builder()
+                .url(endpoint.clone())
+                .metric_periodicity(options.metric_export_interval)
+                .global_tags(HashMap::from([(
+                    "service.name".to_owned(),
+                    service_name.clone(),
+                )]))
+                .build(),
+        )?);
+        let span_exporter = opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(endpoint.to_string())
+            .build()?;
+        let tracer_provider = SdkTracerProvider::builder()
+            .with_batch_exporter(span_exporter)
+            .with_id_generator(AwsXrayIdGenerator)
+            .with_resource(Resource::builder().with_service_name(service_name).build())
+            .build();
+        let tracer = tracer_provider.tracer("temporal-sdk");
+        let subscriber =
+            tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer));
+        let telemetry_options = TelemetryOptions::builder()
+            .metrics(meter.clone() as Arc<dyn CoreMeter>)
+            .subscriber_override(Arc::new(subscriber))
+            .build();
+        let runtime_options = RuntimeOptions::builder()
+            .telemetry_options(telemetry_options)
+            .build()
+            .map_err(anyhow::Error::msg)?;
+        let runtime = Arc::new(Runtime::new_assume_tokio(runtime_options)?);
+        let flush_hook: ShutdownHook = Arc::new(move |_| {
+            let meter = meter.clone();
+            let tracer_provider = tracer_provider.clone();
+            Box::pin(async move {
+                tokio::task::spawn_blocking(move || {
+                    let metric_result = meter.force_flush();
+                    let trace_result = tracer_provider.force_flush().map_err(anyhow::Error::from);
+                    match (metric_result, trace_result) {
+                        (Ok(()), Ok(())) => Ok(()),
+                        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+                        (Err(metric_error), Err(trace_error)) => Err(anyhow::anyhow!(
+                            "metric flush failed: {metric_error}; trace flush failed: {trace_error}"
+                        )),
+                    }
+                })
+                .await??;
+                Ok(())
+            })
+        });
+
+        Ok(Self {
+            runtime,
+            flush_hook,
+        })
+    }
+
+    pub(crate) fn runtime(&self) -> Arc<Runtime> {
+        self.runtime.clone()
+    }
+
+    pub(crate) fn flush_hook(&self) -> ShutdownHook {
+        self.flush_hook.clone()
+    }
+}
+
+fn resolve_endpoint(getenv: impl Fn(&str) -> Option<String>) -> Result<Url, anyhow::Error> {
+    let endpoint = getenv(ENV_OTEL_EXPORTER_OTLP_ENDPOINT)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
+    Ok(Url::parse(&endpoint)?)
+}
+
+fn resolve_service_name(getenv: impl Fn(&str) -> Option<String>) -> String {
+    getenv(ENV_OTEL_SERVICE_NAME)
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| getenv(ENV_AWS_LAMBDA_FUNCTION_NAME).filter(|value| !value.trim().is_empty()))
+        .unwrap_or_else(|| DEFAULT_SERVICE_NAME.to_owned())
+}
+
+#[derive(Debug)]
+struct AwsXrayIdGenerator;
+
+impl IdGenerator for AwsXrayIdGenerator {
+    fn new_trace_id(&self) -> TraceId {
+        xray_trace_id(
+            SystemTime::now(),
+            RandomIdGenerator::default().new_trace_id(),
+        )
+    }
+
+    fn new_span_id(&self) -> SpanId {
+        RandomIdGenerator::default().new_span_id()
+    }
+}
+
+fn xray_trace_id(timestamp: SystemTime, random: TraceId) -> TraceId {
+    let mut bytes = random.to_bytes();
+    let epoch_seconds = timestamp
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs() as u32;
+    bytes[..4].copy_from_slice(&epoch_seconds.to_be_bytes());
+    TraceId::from_bytes(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_lambda_open_telemetry_defaults() {
+        assert_eq!(
+            resolve_endpoint(|_| None).unwrap().as_str(),
+            "http://localhost:4317/"
+        );
+        assert_eq!(resolve_service_name(|_| None), DEFAULT_SERVICE_NAME);
+    }
+
+    #[test]
+    fn environment_overrides_open_telemetry_defaults() {
+        assert_eq!(
+            resolve_endpoint(|name| (name == ENV_OTEL_EXPORTER_OTLP_ENDPOINT)
+                .then(|| "http://collector:4317".to_owned()))
+            .unwrap()
+            .as_str(),
+            "http://collector:4317/"
+        );
+        assert_eq!(
+            resolve_service_name(|name| match name {
+                ENV_OTEL_SERVICE_NAME => Some("explicit".to_owned()),
+                ENV_AWS_LAMBDA_FUNCTION_NAME => Some("function".to_owned()),
+                _ => None,
+            }),
+            "explicit"
+        );
+        assert_eq!(
+            resolve_service_name(
+                |name| (name == ENV_AWS_LAMBDA_FUNCTION_NAME).then(|| "function".to_owned())
+            ),
+            "function"
+        );
+    }
+
+    #[test]
+    fn creates_xray_compatible_trace_id() {
+        let random = TraceId::from_bytes([0x55; 16]);
+        let timestamp = UNIX_EPOCH + Duration::from_secs(0x1234_5678);
+        let trace_id = xray_trace_id(timestamp, random).to_bytes();
+
+        assert_eq!(&trace_id[..4], &[0x12, 0x34, 0x56, 0x78]);
+        assert_eq!(&trace_id[4..], &[0x55; 12]);
+    }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Added the experimental `temporalio-sdk-aws-lambda` integration crate.
- Added a reusable Lambda worker builder that creates a fresh Temporal client and Worker for each invocation.
- Added Lambda-oriented slot, poller, cache, eager Activity, versioning, and graceful-shutdown defaults, while allowing an explicit custom Worker tuner.
- Added client configuration loading from environment variables and Lambda-local `temporal.toml` files.
- Added absolute-deadline shutdown handling, per-invocation Worker identity, ordered shutdown hooks, tests, documentation, and changelog entries.
- Added optional Lambda OpenTelemetry setup for OTLP metrics and existing SDK spans, with ADOT-compatible endpoint and service-name defaults, AWS X-Ray-compatible trace IDs, and deadline-bounded per-invocation flushing.

## Why?
<!-- Tell your future self why have you made these changes -->

AWS Lambda invocations have a bounded execution window and need time reserved for graceful Worker shutdown, telemetry export, and final cleanup. This adapter centralizes those host-specific lifecycle concerns and applies the constrained defaults used by the other Temporal SDK Lambda integrations. A general Rust SDK OpenTelemetry plugin, including cross-process trace-context propagation, is intentionally outside this PR.

## Checklist
<!--- add/delete as needed --->

1. Closes: N/A

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

- `cargo test -p temporalio-sdk-aws-lambda`
- `cargo test -p temporalio-sdk-aws-lambda --features otel`
- `cargo lint`
- `cargo test-lint`
- `cargo +nightly fmt --check`
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p temporalio-sdk-aws-lambda --features temporalio-sdk-aws-lambda/otel --no-deps`
- `git diff --check`

An AWS Runtime Interface Emulator deployment smoke test remains as follow-up work.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

The new crate includes a README covering setup, ADOT configuration, and custom-runtime guidance. Broader docs.temporal.io coverage and a deployable sample can follow once the experimental API is validated.
