### PR TITLE
chore(sdk): automate crate release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,88 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: publish-crates
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish crates
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Require a release branch
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/main" && ! "$GITHUB_REF_NAME" =~ ^releases/[0-9]+\.[0-9]+\.x$ ]]; then
+            echo "Publishing must be run from main or a releases/<major>.<minor>.x branch; got $GITHUB_REF."
+            exit 1
+          fi
+
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      # Necessary as `cargo publish` builds crates as a check before publishing
+      - name: Set up repository
+        uses: ./.github/actions/setup
+        with:
+          mise-install-args: protoc
+
+      - name: Read release metadata
+        id: release
+        shell: bash
+        run: |
+          metadata="$(cargo metadata --format-version 1 --no-deps)"
+          version="$(jq -er '[.packages[] | select(.name == "temporalio-sdk") | .version] | if length == 1 then .[0] else error("expected one temporalio-sdk package") end' <<<"$metadata")"
+
+          if [[ "$GITHUB_REF_NAME" =~ ^releases/([0-9]+)\.([0-9]+)\.x$ ]]; then
+            release_line="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+            if [[ "$version" != "$release_line".* ]]; then
+              echo "SDK version $version does not belong to release branch $GITHUB_REF_NAME."
+              exit 1
+            fi
+          fi
+
+          {
+            echo "version=$version"
+            echo "tag=v$version"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Generate release notes
+        run: |
+          previous_tag="$(git describe --tags --match 'v[0-9]*' --abbrev=0 HEAD)"
+          cargo run -p changelog-release-notes -- \
+            --from "$previous_tag" \
+            --to HEAD \
+            --changelog rust \
+            >"$RUNNER_TEMP/release-notes.md"
+
+      - name: Authenticate to crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1
+
+      - name: Publish crates
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --workspace
+
+      - name: Create draft GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_TITLE: temporalio-sdk ${{ steps.release.outputs.tag }}
+        run: |
+          gh release create "$RELEASE_TAG" \
+            --target "$GITHUB_SHA" \
+            --draft \
+            --title "$RELEASE_TITLE" \
+            --notes-file "$RUNNER_TEMP/release-notes.md"

--- a/crates/changelog-release-notes/Cargo.toml
+++ b/crates/changelog-release-notes/Cargo.toml
@@ -5,6 +5,11 @@ edition = "2024"
 license-file = { workspace = true }
 publish = false
 rust-version = "1.88.0"
+default-run = "changelog-release-notes"
+
+[dependencies]
+chrono = { version = "=0.4.45", default-features = false, features = ["clock"] }
+semver = "=1.0.28"
 
 [lints]
 workspace = true

--- a/crates/changelog-release-notes/src/bin/prepare-release.rs
+++ b/crates/changelog-release-notes/src/bin/prepare-release.rs
@@ -1,0 +1,193 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use chrono::{NaiveDate, Utc};
+use semver::Version;
+
+const CORE_CRATE: &str = "temporalio-sdk-core";
+const BRIDGE_CRATE: &str = "temporalio-sdk-core-c-bridge";
+const RELEASE_TOOL_CRATE: &str = "changelog-release-notes";
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn cargo_set_version(root: &Path, args: &[String]) -> Result<(), String> {
+    let status = Command::new("cargo")
+        .args(args)
+        .current_dir(root)
+        .status()
+        .map_err(|err| format!("failed to run `cargo {}`: {err}", args.join(" ")))?;
+    if !status.success() {
+        return Err(format!("`cargo {}` failed with {status}", args.join(" ")));
+    }
+    Ok(())
+}
+
+fn turn_over_changelog(
+    changelog: &str,
+    version: &Version,
+    date: NaiveDate,
+) -> Result<String, String> {
+    let release_prefix = format!("## [{version}]");
+    if changelog
+        .lines()
+        .any(|line| line.starts_with(&release_prefix))
+    {
+        return Err(format!("CHANGELOG.md already contains {release_prefix}"));
+    }
+
+    let header = "## Unreleased";
+    let header_start = changelog
+        .match_indices(header)
+        .find_map(|(index, _)| {
+            let at_line_start = index == 0 || changelog.as_bytes().get(index - 1) == Some(&b'\n');
+            let after = index + header.len();
+            let at_line_end = matches!(changelog.as_bytes().get(after), None | Some(b'\n'));
+            (at_line_start && at_line_end).then_some(index)
+        })
+        .ok_or("CHANGELOG.md is missing an `## Unreleased` section")?;
+    let body_start = header_start + header.len();
+    let following = &changelog[body_start..];
+    let next_heading = following
+        .find("\n## ")
+        .ok_or("CHANGELOG.md is missing a released-version section")?;
+    let body = following[..next_heading].trim();
+    let previous_releases = &following[next_heading + 1..];
+
+    let mut output = String::from(&changelog[..header_start]);
+    output.push_str(header);
+    output.push_str("\n\n");
+    output.push_str(&format!("## [{version}] - {date}"));
+    if !body.is_empty() {
+        output.push_str("\n\n");
+        output.push_str(body);
+    }
+    output.push_str("\n\n");
+    output.push_str(previous_releases.trim_start_matches('\n'));
+    Ok(output)
+}
+
+fn parse_args(args: impl IntoIterator<Item = String>) -> Result<(Version, Version), String> {
+    let mut args = args.into_iter();
+    let sdk_version = args.next().ok_or("expected <sdk-version> <core-version>")?;
+    let core_version = args.next().ok_or("expected <sdk-version> <core-version>")?;
+    if args.next().is_some() {
+        return Err("expected <sdk-version> <core-version>".into());
+    }
+    let sdk_version =
+        Version::parse(&sdk_version).map_err(|err| format!("invalid SDK version: {err}"))?;
+    let core_version =
+        Version::parse(&core_version).map_err(|err| format!("invalid Core version: {err}"))?;
+    if core_version.major != 0 {
+        return Err(format!(
+            "Core version must remain 0.x, found {core_version}"
+        ));
+    }
+    Ok((sdk_version, core_version))
+}
+
+fn main() -> Result<(), String> {
+    let (target_sdk, target_core) = parse_args(env::args().skip(1))?;
+    let root = workspace_root();
+
+    let changelog_path = root.join("CHANGELOG.md");
+    let changelog = fs::read_to_string(&changelog_path)
+        .map_err(|err| format!("failed to read {}: {err}", changelog_path.display()))?;
+    let changelog = turn_over_changelog(&changelog, &target_sdk, Utc::now().date_naive())?;
+
+    let sdk_update = vec![
+        "set-version".into(),
+        "--workspace".into(),
+        target_sdk.to_string(),
+        "--exclude".into(),
+        CORE_CRATE.into(),
+        "--exclude".into(),
+        BRIDGE_CRATE.into(),
+        "--exclude".into(),
+        RELEASE_TOOL_CRATE.into(),
+    ];
+    let core_update = vec![
+        "set-version".into(),
+        "--package".into(),
+        CORE_CRATE.into(),
+        target_core.to_string(),
+    ];
+    let mut sdk_dry_run = sdk_update.clone();
+    sdk_dry_run.push("--dry-run".into());
+    let mut core_dry_run = core_update.clone();
+    core_dry_run.push("--dry-run".into());
+    cargo_set_version(&root, &sdk_dry_run)?;
+    cargo_set_version(&root, &core_dry_run)?;
+
+    cargo_set_version(&root, &sdk_update)?;
+    cargo_set_version(&root, &core_update)?;
+    fs::write(&changelog_path, changelog)
+        .map_err(|err| format!("failed to write {}: {err}", changelog_path.display()))?;
+
+    println!("Prepared SDK {target_sdk} with Core {target_core}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn version(value: &str) -> Version {
+        Version::parse(value).unwrap()
+    }
+
+    #[test]
+    fn rejects_core_one_x() {
+        assert!(
+            parse_args(["1.0.0".into(), "1.0.0".into()])
+                .unwrap_err()
+                .contains("must remain 0.x")
+        );
+    }
+
+    #[test]
+    fn turns_over_a_populated_changelog() {
+        let input = "# Changelog\n\n## Unreleased\n\n### Added\n* Feature.\n\n## [0.7.0] - 2026-01-01\n\nOld.\n";
+        assert_eq!(
+            turn_over_changelog(
+                input,
+                &version("1.0.0"),
+                NaiveDate::from_ymd_opt(2026, 8, 27).unwrap()
+            )
+            .unwrap(),
+            "# Changelog\n\n## Unreleased\n\n## [1.0.0] - 2026-08-27\n\n### Added\n* Feature.\n\n## [0.7.0] - 2026-01-01\n\nOld.\n"
+        );
+    }
+
+    #[test]
+    fn turns_over_an_empty_changelog() {
+        let input = "# Changelog\n\n## Unreleased\n\n## [0.7.0] - 2026-01-01\n";
+        assert_eq!(
+            turn_over_changelog(
+                input,
+                &version("1.0.0-rc.1"),
+                NaiveDate::from_ymd_opt(2026, 8, 27).unwrap()
+            )
+            .unwrap(),
+            "# Changelog\n\n## Unreleased\n\n## [1.0.0-rc.1] - 2026-08-27\n\n## [0.7.0] - 2026-01-01\n"
+        );
+    }
+
+    #[test]
+    fn rejects_a_duplicate_changelog_release() {
+        let input = "# Changelog\n\n## Unreleased\n\n## [1.0.0] - 2026-01-01\n";
+        assert!(
+            turn_over_changelog(
+                input,
+                &version("1.0.0"),
+                NaiveDate::from_ymd_opt(2026, 8, 27).unwrap()
+            )
+            .unwrap_err()
+            .contains("already contains")
+        );
+    }
+}

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -61,7 +61,7 @@ serde_json = { workspace = true }
 
 [dependencies.temporalio-common]
 path = "../common"
-version = "0.7"
+version = "~0.7.0"
 default-features = false
 features = ["serde_serialize"]
 
@@ -72,8 +72,8 @@ prost = "0.14"
 prost-types = { workspace = true }
 rstest = "0.26"
 tempfile = "3"
-temporalio-macros = { path = "../macros", version = "0.7" }
-temporalio-workflow = { path = "../workflow", version = "0.7" }
+temporalio-macros = { path = "../macros", version = "~0.7.0" }
+temporalio-workflow = { path = "../workflow", version = "~0.7.0" }
 tokio = { version = "1.47", default-features = false, features = [
   "io-util",
   "macros",

--- a/crates/common-wasm/Cargo.toml
+++ b/crates/common-wasm/Cargo.toml
@@ -45,7 +45,7 @@ tracing-core = "0.1"
 url = "2.5"
 [dependencies.temporalio-protos]
 path = "../protos"
-version = "0.7"
+version = "~0.7.0"
 
 [lints]
 workspace = true

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -106,12 +106,12 @@ uuid = { version = "1.18", default-features = false, features = ["v4"] }
 
 [dependencies.temporalio-protos]
 path = "../protos"
-version = "0.7"
+version = "~0.7.0"
 features = ["grpc-clients"]
 
 [dependencies.temporalio-common-wasm]
 path = "../common-wasm"
-version = "0.7"
+version = "~0.7.0"
 
 [build-dependencies]
 prost = { workspace = true }

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -20,7 +20,7 @@ quote = "1.0"
 
 [dev-dependencies]
 # This is to enable doctests for the macros
-temporalio-common = { path = "../common" }
+temporalio-common = { path = "../common", version = "~0.7.0" }
 derive_more = { workspace = true }
 
 [package.metadata.workspaces]

--- a/crates/sdk-core-c-bridge/Cargo.toml
+++ b/crates/sdk-core-c-bridge/Cargo.toml
@@ -41,16 +41,16 @@ xz2 = { version = "0.1", optional = true }
 
 [dependencies.temporalio-client]
 path = "../client"
-version = "0.7"
+version = "~0.7.0"
 
 [dependencies.temporalio-sdk-core]
 path = "../sdk-core"
-version = "0.7"
+version = "=0.7.0"
 features = ["ephemeral-server", "otel"]
 
 [dependencies.temporalio-common]
 path = "../common"
-version = "0.7"
+version = "~0.7.0"
 features = ["core-based-sdk", "otel"]
 
 [dev-dependencies]

--- a/crates/sdk-core/Cargo.toml
+++ b/crates/sdk-core/Cargo.toml
@@ -131,19 +131,19 @@ zip = { version = "8.4", optional = true, default-features = false, features = [
 # 1st party local deps
 [dependencies.temporalio-common]
 path = "../common"
-version = "0.7"
+version = "~0.7.0"
 default-features = false
 features = ["core-telemetry-bridge", "serde_serialize"]
 
 [dependencies.temporalio-client]
 path = "../client"
-version = "0.7"
+version = "~0.7.0"
 default-features = false
 features = ["core-based-sdk"]
 
 [dependencies.temporalio-macros]
 path = "../macros"
-version = "0.7"
+version = "~0.7.0"
 
 [dev-dependencies]
 assert_matches = "1.5"
@@ -163,9 +163,10 @@ hyper-util = { version = "0.1", features = [
 ] }
 rstest = "0.26"
 semver = "1.0"
+# A registry version here creates a cycle when Cargo orders sdk-core before sdk for workspace publishing.
 temporalio-sdk = { path = "../sdk", features = ["testing", "wasm-workflows"] }
-temporalio-common = { path = "../common", version = "0.7", default-features = false }
-temporalio-workflow = { path = "../workflow" }
+temporalio-common = { path = "../common", version = "~0.7.0", default-features = false }
+temporalio-workflow = { path = "../workflow", version = "~0.7.0" }
 tokio = { version = "1.47", default-features = false, features = [
   "rt",
   "rt-multi-thread",

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -43,26 +43,26 @@ url = { version = "2.5", optional = true }
 
 [dependencies.temporalio-sdk-core]
 path = "../sdk-core"
-version = "0.7"
+version = "=0.7.0"
 default-features = false
 
 [dependencies.temporalio-workflow]
 path = "../workflow"
-version = "0.7"
+version = "~0.7.0"
 
 [dependencies.temporalio-common]
 path = "../common"
-version = "0.7"
+version = "~0.7.0"
 default-features = false
 
 [dependencies.temporalio-client]
 path = "../client"
-version = "0.7"
+version = "~0.7.0"
 default-features = false
 
 [dependencies.temporalio-macros]
 path = "../macros"
-version = "0.7"
+version = "~0.7.0"
 
 [dev-dependencies]
 futures = "0.3"

--- a/crates/workflow/Cargo.toml
+++ b/crates/workflow/Cargo.toml
@@ -33,11 +33,11 @@ wit-bindgen = { version = "0.57.1", default-features = false, features = ["macro
 
 [dependencies.temporalio-common-wasm]
 path = "../common-wasm"
-version = "0.7"
+version = "~0.7.0"
 
 [dependencies.temporalio-macros]
 path = "../macros"
-version = "0.7"
+version = "~0.7.0"
 
 [dev-dependencies]
 rstest = "0.26"

--- a/mise.toml
+++ b/mise.toml
@@ -3,3 +3,4 @@ protoc = "23.4"
 "github:temporalio/cli" = "1.8.0"
 "cargo:cargo-component" = "0.21.1"
 "cargo:cargo-msrv" = "0.19.3"
+"cargo:cargo-edit" = { version = "0.13.9", locked = true }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Add a workflow that handles publishing the crates
- A small helper script that swaps over changelog and updates crate versions.
- Updated `temporalio-*` to use `~` to limit supported versions to the same minor Could limit this to `=` exactly, but I think that might be overzealous if we can stick to semver properly. Core is an exact dependency as I think managing "patch vs minor" bumps for core is difficult.

The version bump script codifies that `temporalio-*` crates stay lockstep, except for core which will remain `0.x.y`.

(Outside this PR, I have setup our crates on crates.io to view this workflow and the `release` GH env as a trusted publishing)

## Why?
Hard to mess up running one script and clicking a button.

## Checklist
<!--- add/delete as needed --->

1. Closes #1527 

2. How was this tested:
Small unit tests, real test will be a release I run once this is merged. Can widen the `release` environment to target this branch and run a release from a non main branch as a test, but 🤷 

3. Any docs updates needed?
Update release process