### PR TITLE
chore(docs): add missing readmes

### DIFF
--- a/crates/common-wasm/README.md
+++ b/crates/common-wasm/README.md
@@ -1,0 +1,8 @@
+# `temporalio-common-wasm`
+
+[![crates.io](https://img.shields.io/crates/v/temporalio-common-wasm.svg)](https://crates.io/crates/temporalio-common-wasm)
+[![docs.rs](https://docs.rs/temporalio-common-wasm/badge.svg)](https://docs.rs/temporalio-common-wasm)
+
+Part of [Temporal](https://temporal.io)'s [Rust SDK](https://github.com/temporalio/sdk-rust).
+
+WASM-safe shared types, serialization, and protobuf support for authoring Temporal Workflows.

--- a/crates/common/README.md
+++ b/crates/common/README.md
@@ -1,0 +1,8 @@
+# `temporalio-common`
+
+[![crates.io](https://img.shields.io/crates/v/temporalio-common.svg)](https://crates.io/crates/temporalio-common)
+[![docs.rs](https://docs.rs/temporalio-common/badge.svg)](https://docs.rs/temporalio-common)
+
+Part of [Temporal](https://temporal.io)'s [Rust SDK](https://github.com/temporalio/sdk-rust).
+
+Shared types and functionality used by Temporal SDK Core, the Rust Client, and the Rust SDK.

--- a/crates/macros/README.md
+++ b/crates/macros/README.md
@@ -1,0 +1,8 @@
+# `temporalio-macros`
+
+[![crates.io](https://img.shields.io/crates/v/temporalio-macros.svg)](https://crates.io/crates/temporalio-macros)
+[![docs.rs](https://docs.rs/temporalio-macros/badge.svg)](https://docs.rs/temporalio-macros)
+
+Part of [Temporal](https://temporal.io)'s [Rust SDK](https://github.com/temporalio/sdk-rust).
+
+Procedural macros for defining Temporal Workflows and Activities in Rust.

--- a/crates/protos/README.md
+++ b/crates/protos/README.md
@@ -1,0 +1,11 @@
+# `temporalio-protos`
+
+[![crates.io](https://img.shields.io/crates/v/temporalio-protos.svg)](https://crates.io/crates/temporalio-protos)
+[![docs.rs](https://docs.rs/temporalio-protos/badge.svg)](https://docs.rs/temporalio-protos)
+
+Part of [Temporal](https://temporal.io)'s [Rust SDK](https://github.com/temporalio/sdk-rust).
+
+Compiled protobuf definitions for Temporal APIs and SDK Core protocols.
+
+Most Rust SDK users should use [`temporalio-client`](https://crates.io/crates/temporalio-client) or
+[`temporalio-sdk`](https://crates.io/crates/temporalio-sdk) instead.

--- a/crates/sdk-core/README.md
+++ b/crates/sdk-core/README.md
@@ -1,0 +1,11 @@
+# `temporalio-sdk-core`
+
+[![crates.io](https://img.shields.io/crates/v/temporalio-sdk-core.svg)](https://crates.io/crates/temporalio-sdk-core)
+[![docs.rs](https://docs.rs/temporalio-sdk-core/badge.svg)](https://docs.rs/temporalio-sdk-core)
+
+Part of [Temporal](https://temporal.io)'s [Rust SDK](https://github.com/temporalio/sdk-rust).
+
+The shared worker runtime used to build Temporal language SDKs.
+
+Its APIs are intended for SDK implementers and may change without notice. Rust application authors
+should use [`temporalio-sdk`](https://crates.io/crates/temporalio-sdk) instead.

--- a/crates/workflow/README.md
+++ b/crates/workflow/README.md
@@ -1,0 +1,8 @@
+# `temporalio-workflow`
+
+[![crates.io](https://img.shields.io/crates/v/temporalio-workflow.svg)](https://crates.io/crates/temporalio-workflow)
+[![docs.rs](https://docs.rs/temporalio-workflow/badge.svg)](https://docs.rs/temporalio-workflow)
+
+Part of [Temporal](https://temporal.io)'s [Rust SDK](https://github.com/temporalio/sdk-rust).
+
+APIs and runtime support for authoring Temporal Workflows in native Rust and WASM components.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add super small readmes for published crates that were missing them. Mirroring language from Typescript's readmes for packages that generally aren't used alone.

## Why?
Make crates.io look better

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
