### PR TITLE
feat(sdk): make fetching workflow history lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ relevant information.
   `ClientInterceptor::update_with_start_workflow`.
 
 ### Breaking Changes :boom:
+* `WorkflowHandle::fetch_history` now returns a lazy `WorkflowHistory` stream instead
+  of eagerly fetching every history page. Use `WorkflowHistory::into_events` if eager fetching
+  is desired.
+* `WorkflowHistory::to_json` is now async, `WorkflowHistoryError` reports fetch and JSON conversion failures; and the eager `events`,
+  `Clone`, and `From<WorkflowHistory> for History` APIs have been removed. Replay results expose
+  their eagerly fetched events through `ReplayHistory`.
 * The following types are now non-exhaustive: `Priority`, `WorkerDeploymentVersion`,
   `WorkerCallbacks`, `WorkflowExecutionInfo`, `ActivityCloseTimeouts`,
   `ActivityExecutionDecodeHint`, child-workflow and signal decode hints,

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -102,7 +102,7 @@ pub use tonic;
 pub use workflow_handle::{
     UntypedQuery, UntypedSignal, UntypedUpdate, UntypedWorkflow, UntypedWorkflowHandle,
     WorkflowExecutionDescription, WorkflowExecutionInfo, WorkflowExecutionResult, WorkflowHandle,
-    WorkflowHistory, WorkflowHistoryJsonError, WorkflowResultDetails, WorkflowUpdateHandle,
+    WorkflowHistory, WorkflowHistoryError, WorkflowResultDetails, WorkflowUpdateHandle,
 };
 pub use workflow_status::WorkflowExecutionStatus;
 

--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -13,8 +13,14 @@ use crate::{
     grpc::WorkflowService,
     interceptors,
 };
-use futures_util::future::BoxFuture;
-use std::{fmt::Debug, marker::PhantomData};
+use futures_util::{TryStreamExt, future::BoxFuture, stream, stream::Stream};
+use std::{
+    collections::VecDeque,
+    fmt::Debug,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
 pub use temporalio_common::UntypedWorkflow;
 use temporalio_common::{
     HasWorkflowDefinition, QueryDefinition, SignalDefinition, UpdateDefinition, WorkflowDefinition,
@@ -328,53 +334,69 @@ impl WorkflowExecutionDescription {
     }
 }
 
-// TODO [rust-sdk-branch]: Could implment stream a-la ListWorkflowsStream
-/// Workflow execution history returned by `WorkflowHandle::fetch_history`.
-#[derive(Debug, Clone)]
+/// Workflow execution history returned by [`WorkflowHandle::fetch_history`].
+///
+/// Events and their containing pages are fetched lazily as this stream is polled. Use
+/// [`into_events`](Self::into_events) to fetch and collect all events at once.
+#[derive(derive_more::Debug)]
 pub struct WorkflowHistory {
-    events: Vec<HistoryEvent>,
+    #[debug(skip)]
+    inner: Pin<Box<dyn Stream<Item = Result<HistoryEvent, WorkflowInteractionError>> + Send>>,
     workflow_id: Option<String>,
 }
-impl From<WorkflowHistory> for history::v1::History {
-    fn from(h: WorkflowHistory) -> Self {
-        Self { events: h.events }
-    }
-}
 
-/// Error converting a workflow history to or from JSON.
-#[derive(Debug, thiserror::Error)]
-#[error("failed to convert workflow history JSON: {0}")]
-pub struct WorkflowHistoryJsonError(#[from] serde_json::Error);
-
-impl WorkflowHistory {
-    fn new(events: Vec<HistoryEvent>, workflow_id: Option<String>) -> Self {
+impl From<history::v1::History> for WorkflowHistory {
+    fn from(history: history::v1::History) -> Self {
+        let workflow_id =
+            history
+                .events
+                .first()
+                .and_then(|event| match event.attributes.as_ref() {
+                    Some(Attributes::WorkflowExecutionStartedEventAttributes(attributes))
+                        if !attributes.workflow_id.is_empty() =>
+                    {
+                        Some(attributes.workflow_id.clone())
+                    }
+                    _ => None,
+                });
         Self {
-            events,
+            inner: Box::pin(stream::iter(history.events.into_iter().map(Ok))),
             workflow_id,
         }
     }
+}
 
+impl Stream for WorkflowHistory {
+    type Item = Result<HistoryEvent, WorkflowInteractionError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}
+
+/// Error fetching or converting a workflow history.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum WorkflowHistoryError {
+    /// Fetching the workflow history failed.
+    #[error("failed to fetch workflow history: {0}")]
+    Fetch(#[from] WorkflowInteractionError),
+    /// Converting the workflow history JSON failed.
+    #[error("failed to convert workflow history JSON: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+impl WorkflowHistory {
     /// Decode a workflow history from JSON bytes.
-    pub fn from_json(bytes: &[u8]) -> Result<Self, WorkflowHistoryJsonError> {
+    pub fn from_json(bytes: &[u8]) -> Result<Self, WorkflowHistoryError> {
         let history: History = serde_json::from_slice(bytes)?;
-        let workflow_id = history
-            .events
-            .first()
-            .and_then(|event| match event.attributes.as_ref() {
-                Some(Attributes::WorkflowExecutionStartedEventAttributes(attributes)) => {
-                    Some(attributes)
-                }
-                _ => None,
-            })
-            .map(|attributes| attributes.workflow_id.clone())
-            .filter(|wfid| !wfid.is_empty());
-        Ok(Self::new(history.events, workflow_id))
+        Ok(history.into())
     }
 
-    /// Encode this workflow history as JSON bytes.
-    pub fn to_json(&self) -> Result<Vec<u8>, WorkflowHistoryJsonError> {
+    /// Fetch all remaining events and encode this workflow history as JSON bytes.
+    pub async fn to_json(self) -> Result<Vec<u8>, WorkflowHistoryError> {
         Ok(serde_json::to_vec(&History {
-            events: self.events.clone(),
+            events: self.into_events().await?,
         })?)
     }
 
@@ -383,14 +405,9 @@ impl WorkflowHistory {
         self.workflow_id.as_deref()
     }
 
-    /// The history events.
-    pub fn events(&self) -> &[HistoryEvent] {
-        &self.events
-    }
-
-    /// Consume the history and return the events.
-    pub fn into_events(self) -> Vec<HistoryEvent> {
-        self.events
+    /// Fetch all remaining history pages and collect their events.
+    pub async fn into_events(self) -> Result<Vec<HistoryEvent>, WorkflowInteractionError> {
+        self.inner.try_collect().await
     }
 }
 
@@ -594,7 +611,7 @@ where
         opts: WorkflowGetResultOptions,
     ) -> Result<W::Output, WorkflowGetResultError>
     where
-        CT: WorkflowService + NamespacedClient + Clone,
+        CT: WorkflowService + NamespacedClient + Clone + 'static,
     {
         let raw = self.get_result_raw(opts).await?;
         match raw {
@@ -619,7 +636,7 @@ where
         opts: WorkflowGetResultOptions,
     ) -> Result<WorkflowExecutionResult<W::Output>, WorkflowInteractionError>
     where
-        CT: WorkflowService + NamespacedClient + Clone,
+        CT: WorkflowService + NamespacedClient + Clone + 'static,
     {
         let mut run_id = self.info.run_id.clone().unwrap_or_default();
         let fetch_opts = WorkflowFetchHistoryOptions::builder()
@@ -630,8 +647,8 @@ where
             .build();
 
         loop {
-            let history = self.fetch_history_for_run(&run_id, &fetch_opts).await?;
-            let mut events = history.into_events();
+            let history = self.fetch_history_for_run(&run_id, fetch_opts.clone());
+            let mut events = history.into_events().await?;
 
             if events.is_empty() {
                 continue;
@@ -1163,91 +1180,123 @@ where
             .await
             .map_err(WorkflowInteractionError::from)
     }
-    /// Fetch workflow execution history.
-    pub async fn fetch_history(
-        &self,
-        opts: WorkflowFetchHistoryOptions,
-    ) -> Result<WorkflowHistory, WorkflowInteractionError>
+    /// Fetch workflow execution history as a lazy stream.
+    ///
+    /// No request is sent until the returned stream is polled.
+    pub fn fetch_history(&self, opts: WorkflowFetchHistoryOptions) -> WorkflowHistory
     where
-        CT: NamespacedClient,
+        CT: NamespacedClient + 'static,
     {
         let run_id = self.info.run_id.clone().unwrap_or_default();
-        self.fetch_history_for_run(&run_id, &opts).await
+        self.fetch_history_for_run(&run_id, opts)
     }
 
-    /// Fetch history for a specific run_id, handling pagination.
-    async fn fetch_history_for_run(
+    fn fetch_history_for_run(
         &self,
         run_id: &str,
-        opts: &WorkflowFetchHistoryOptions,
-    ) -> Result<WorkflowHistory, WorkflowInteractionError>
+        opts: WorkflowFetchHistoryOptions,
+    ) -> WorkflowHistory
     where
-        CT: NamespacedClient,
+        CT: NamespacedClient + 'static,
     {
-        let mut all_events = Vec::new();
-        let mut next_page_token = vec![];
+        let client = self.client.clone();
+        let workflow_id = self.info.workflow_id.clone();
+        let history_workflow_id = workflow_id.clone();
+        let run_id = run_id.to_string();
 
-        loop {
-            let output = interceptors::call_fetch_workflow_history_page(
-                self.client.client_interceptors(),
-                FetchWorkflowHistoryPageInput {
-                    workflow_id: self.info.workflow_id.clone(),
-                    run_id: run_id.to_string(),
-                    next_page_token,
-                    options: opts.clone(),
-                },
-                Next::new({
-                    let mut client = self.client.clone();
-                    move |input: FetchWorkflowHistoryPageInput| -> BoxFuture<
-                        '_,
-                        Result<FetchWorkflowHistoryPageOutput, WorkflowInteractionError>,
-                    > {
-                        Box::pin(async move {
-                            let mut request = GetWorkflowExecutionHistoryRequest {
-                                namespace: client.namespace(),
-                                execution: Some(ProtoWorkflowExecution {
-                                    workflow_id: input.workflow_id,
-                                    run_id: input.run_id,
-                                }),
-                                next_page_token: input.next_page_token,
-                                skip_archival: input.options.skip_archival,
-                                wait_new_event: input.options.wait_new_event,
-                                history_event_filter_type: input.options.event_filter_type as i32,
-                                ..Default::default()
+        let stream = stream::unfold(
+            (Vec::new(), VecDeque::new(), false),
+            move |(mut next_page_token, mut buffer, mut exhausted)| {
+                let client = client.clone();
+                let workflow_id = workflow_id.clone();
+                let run_id = run_id.clone();
+                let opts = opts.clone();
+
+                async move {
+                    loop {
+                        if let Some(event) = buffer.pop_front() {
+                            return Some((Ok(event), (next_page_token, buffer, exhausted)));
+                        }
+
+                        if exhausted {
+                            return None;
+                        }
+
+                        let output = interceptors::call_fetch_workflow_history_page(
+                            client.client_interceptors(),
+                            FetchWorkflowHistoryPageInput {
+                                workflow_id: workflow_id.clone(),
+                                run_id: run_id.clone(),
+                                next_page_token: next_page_token.clone(),
+                                options: opts.clone(),
+                            },
+                            Next::new({
+                                let mut rpc_client = client.clone();
+                                move |input: FetchWorkflowHistoryPageInput| -> BoxFuture<
+                                    '_,
+                                    Result<
+                                        FetchWorkflowHistoryPageOutput,
+                                        WorkflowInteractionError,
+                                    >,
+                                > {
+                                    Box::pin(async move {
+                                        let mut request = GetWorkflowExecutionHistoryRequest {
+                                            namespace: rpc_client.namespace(),
+                                            execution: Some(ProtoWorkflowExecution {
+                                                workflow_id: input.workflow_id,
+                                                run_id: input.run_id,
+                                            }),
+                                            next_page_token: input.next_page_token,
+                                            skip_archival: input.options.skip_archival,
+                                            wait_new_event: input.options.wait_new_event,
+                                            history_event_filter_type: input
+                                                .options
+                                                .event_filter_type
+                                                as i32,
+                                            ..Default::default()
+                                        }
+                                        .into_request();
+                                        input.options.rpc_options.apply_to(&mut request);
+                                        let response =
+                                            WorkflowService::get_workflow_execution_history(
+                                                &mut rpc_client,
+                                                request,
+                                            )
+                                            .await
+                                            .map_err(WorkflowInteractionError::from_status)?
+                                            .into_inner();
+                                        Ok(FetchWorkflowHistoryPageOutput::new(
+                                            response
+                                                .history
+                                                .map(|history| history.events)
+                                                .unwrap_or_default(),
+                                            response.next_page_token,
+                                        ))
+                                    })
+                                }
+                            }),
+                        )
+                        .await;
+
+                        match output {
+                            Ok(output) => {
+                                exhausted = output.next_page_token.is_empty();
+                                next_page_token = output.next_page_token;
+                                buffer = output.events.into();
                             }
-                            .into_request();
-                            input.options.rpc_options.apply_to(&mut request);
-                            let response = WorkflowService::get_workflow_execution_history(
-                                &mut client,
-                                request,
-                            )
-                            .await
-                            .map_err(WorkflowInteractionError::from_status)?
-                            .into_inner();
-                            Ok(FetchWorkflowHistoryPageOutput::new(
-                                response
-                                    .history
-                                    .map(|history| history.events)
-                                    .unwrap_or_default(),
-                                response.next_page_token,
-                            ))
-                        })
+                            Err(error) => {
+                                return Some((Err(error), (next_page_token, buffer, true)));
+                            }
+                        }
                     }
-                }),
-            )
-            .await?;
+                }
+            },
+        );
 
-            all_events.extend(output.events);
-            if output.next_page_token.is_empty() {
-                break;
-            }
-            next_page_token = output.next_page_token;
+        WorkflowHistory {
+            inner: Box::pin(stream),
+            workflow_id: Some(history_workflow_id),
         }
-
-        Ok(WorkflowHistory::new(
-            all_events,
-            Some(self.info.workflow_id.clone()),
-        ))
     }
 }
 
@@ -1385,8 +1434,15 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::XorCodec;
-    use std::collections::HashMap;
+    use crate::{ClientInterceptor, test_helpers::XorCodec};
+    use futures_util::{FutureExt, StreamExt};
+    use std::{
+        collections::{HashMap, VecDeque},
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
     use temporalio_common::{
         data_converters::DefaultFailureConverter,
         protos::temporal::api::{
@@ -1395,11 +1451,13 @@ mod tests {
             history::v1::WorkflowExecutionStartedEventAttributes,
             sdk::v1::UserMetadata,
             workflow::v1::WorkflowExecutionConfig,
+            workflowservice::v1::GetWorkflowExecutionHistoryResponse,
         },
     };
+    use tonic::{Request, Response};
 
-    #[test]
-    fn workflow_history_workflow_id_roundtrips() {
+    #[tokio::test]
+    async fn workflow_history_workflow_id_roundtrips() {
         let event = HistoryEvent {
             event_id: 1,
             attributes: Some(Attributes::WorkflowExecutionStartedEventAttributes(
@@ -1411,12 +1469,156 @@ mod tests {
             )),
             ..Default::default()
         };
-        let history = WorkflowHistory::new(vec![event], None);
+        let history = WorkflowHistory {
+            inner: Box::pin(stream::iter(std::iter::once(Ok(event)))),
+            workflow_id: None,
+        };
 
-        let bytes = history.to_json().unwrap();
+        let bytes = history.to_json().await.unwrap();
 
         let decoded = WorkflowHistory::from_json(&bytes).unwrap();
         assert_eq!(decoded.workflow_id(), Some("workflow-id"));
+    }
+
+    #[derive(Clone)]
+    struct MockHistoryClient {
+        responses: Arc<Mutex<VecDeque<Result<GetWorkflowExecutionHistoryResponse, tonic::Status>>>>,
+        calls: Arc<AtomicUsize>,
+        interceptors: Vec<Arc<dyn ClientInterceptor>>,
+    }
+
+    impl NamespacedClient for MockHistoryClient {
+        fn namespace(&self) -> String {
+            "test-namespace".to_owned()
+        }
+
+        fn identity(&self) -> String {
+            "test-identity".to_owned()
+        }
+
+        fn client_interceptors(&self) -> &[Arc<dyn ClientInterceptor>] {
+            &self.interceptors
+        }
+    }
+
+    impl WorkflowService for MockHistoryClient {
+        fn get_workflow_execution_history(
+            &mut self,
+            _request: Request<GetWorkflowExecutionHistoryRequest>,
+        ) -> BoxFuture<'_, Result<Response<GetWorkflowExecutionHistoryResponse>, tonic::Status>>
+        {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let response = self.responses.lock().unwrap().pop_front().unwrap();
+            async move { response.map(Response::new) }.boxed()
+        }
+    }
+
+    struct CountingHistoryInterceptor(Arc<AtomicUsize>);
+
+    impl ClientInterceptor for CountingHistoryInterceptor {
+        fn fetch_workflow_history_page<'a>(
+            &'a self,
+            input: FetchWorkflowHistoryPageInput,
+            next: Next<
+                'a,
+                FetchWorkflowHistoryPageInput,
+                BoxFuture<'a, Result<FetchWorkflowHistoryPageOutput, WorkflowInteractionError>>,
+            >,
+        ) -> BoxFuture<'a, Result<FetchWorkflowHistoryPageOutput, WorkflowInteractionError>>
+        {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            next.run(input)
+        }
+    }
+
+    fn history_response(
+        event_ids: impl IntoIterator<Item = i64>,
+        next_page_token: &[u8],
+    ) -> GetWorkflowExecutionHistoryResponse {
+        GetWorkflowExecutionHistoryResponse {
+            history: Some(History {
+                events: event_ids
+                    .into_iter()
+                    .map(|event_id| HistoryEvent {
+                        event_id,
+                        ..Default::default()
+                    })
+                    .collect(),
+            }),
+            next_page_token: next_page_token.to_vec(),
+            ..Default::default()
+        }
+    }
+
+    fn history_handle(
+        responses: impl IntoIterator<Item = Result<GetWorkflowExecutionHistoryResponse, tonic::Status>>,
+        calls: Arc<AtomicUsize>,
+        interceptors: Vec<Arc<dyn ClientInterceptor>>,
+    ) -> WorkflowHandle<MockHistoryClient, UntypedWorkflow> {
+        WorkflowHandle::new(
+            MockHistoryClient {
+                responses: Arc::new(Mutex::new(responses.into_iter().collect())),
+                calls,
+                interceptors,
+            },
+            WorkflowExecutionInfo {
+                namespace: "test-namespace".to_owned(),
+                workflow_id: "workflow-id".to_owned(),
+                run_id: Some("run-id".to_owned()),
+                first_execution_run_id: None,
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn workflow_history_fetches_pages_lazily() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let interceptor_calls = Arc::new(AtomicUsize::new(0));
+        let handle = history_handle(
+            [
+                Ok(history_response([], b"second-page")),
+                Ok(history_response([1, 2], b"third-page")),
+                Ok(history_response([3], b"")),
+            ],
+            calls.clone(),
+            vec![Arc::new(CountingHistoryInterceptor(
+                interceptor_calls.clone(),
+            ))],
+        );
+
+        let mut history = handle.fetch_history(WorkflowFetchHistoryOptions::default());
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+        assert_eq!(history.next().await.unwrap().unwrap().event_id, 1);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(history.next().await.unwrap().unwrap().event_id, 2);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(history.next().await.unwrap().unwrap().event_id, 3);
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+        assert!(history.next().await.is_none());
+        assert_eq!(interceptor_calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn workflow_history_yields_page_error_then_ends() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let handle = history_handle(
+            [
+                Ok(history_response([1], b"second-page")),
+                Err(tonic::Status::unavailable("history unavailable")),
+            ],
+            calls.clone(),
+            Vec::new(),
+        );
+        let mut history = handle.fetch_history(WorkflowFetchHistoryOptions::default());
+
+        assert_eq!(history.next().await.unwrap().unwrap().event_id, 1);
+        assert!(matches!(
+            history.next().await.unwrap(),
+            Err(WorkflowInteractionError::Rpc(status)) if status.code() == tonic::Code::Unavailable
+        ));
+        assert!(history.next().await.is_none());
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]

--- a/crates/sdk-core/src/histfetch.rs
+++ b/crates/sdk-core/src/histfetch.rs
@@ -32,8 +32,8 @@ async fn main() -> Result<(), anyhow::Error> {
         .bind_untyped(client);
     let events = handle
         .fetch_history(WorkflowFetchHistoryOptions::default())
-        .await?
-        .into_events();
+        .into_events()
+        .await?;
     let hist = History { events };
     // Serialize history to file
     let byteified = hist.encode_to_vec();

--- a/crates/sdk-core/tests/common/mod.rs
+++ b/crates/sdk-core/tests/common/mod.rs
@@ -614,9 +614,9 @@ impl CoreWfStarter {
         let events = client
             .get_workflow_handle::<UntypedWorkflow>(self.get_wf_id())
             .fetch_history(Default::default())
+            .into_events()
             .await
-            .unwrap()
-            .into_events();
+            .unwrap();
         History { events }
     }
 
@@ -1079,7 +1079,7 @@ where
         worker: &mut TestWorker,
     ) -> Result<Option<Payload>, anyhow::Error> {
         let wf_id = self.info().workflow_id.clone();
-        let events = self.fetch_history(Default::default()).await?.into_events();
+        let events = self.fetch_history(Default::default()).into_events().await?;
         let with_id = HistoryForReplay::new(events, wf_id);
         let replay_worker = init_core_replay_preloaded(worker.inner.task_queue(), [with_id]);
         worker.inner.with_new_core_worker(Arc::new(replay_worker));

--- a/crates/sdk-core/tests/integ_tests/client_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/client_tests.rs
@@ -463,6 +463,7 @@ async fn namespace_header_attached_to_relevant_calls() {
     let _ = client
         .get_workflow_handle::<UntypedWorkflow>("hi")
         .fetch_history(Default::default())
+        .into_events()
         .await;
     let val = header_rx.recv().await.unwrap();
     assert_eq!(namespace, val);

--- a/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
@@ -441,9 +441,12 @@ async fn custom_failure_converter_fallback_applied_to_activity_panic_failures() 
     worker.run_until_done().await.unwrap();
     handle.get_result(Default::default()).await.unwrap();
 
-    let history = handle.fetch_history(Default::default()).await.unwrap();
-    let activity_failure = history
+    let history = handle
+        .fetch_history(Default::default())
         .into_events()
+        .await
+        .unwrap();
+    let activity_failure = history
         .into_iter()
         .find_map(|event| match event.attributes {
             Some(Attributes::ActivityTaskFailedEventAttributes(attrs)) => attrs.failure,
@@ -717,9 +720,9 @@ async fn multi_args_serializes_as_multiple_payloads() {
     let events = client
         .get_workflow_handle::<UntypedWorkflow>(wf_name)
         .fetch_history(Default::default())
+        .into_events()
         .await
-        .unwrap()
-        .into_events();
+        .unwrap();
 
     let workflow_started_event = events
         .iter()

--- a/crates/sdk-core/tests/integ_tests/polling_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/polling_tests.rs
@@ -323,9 +323,9 @@ async fn small_workflow_slots_and_pollers(#[values(false, true)] use_autoscaling
         .await
         .get_workflow_handle::<UntypedWorkflow>(&wf2id)
         .fetch_history(Default::default())
+        .into_events()
         .await
-        .unwrap()
-        .into_events();
+        .unwrap();
     let any_task_timeouts = events
         .iter()
         .any(|e| e.event_type() == EventType::WorkflowTaskTimedOut);

--- a/crates/sdk-core/tests/integ_tests/update_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/update_tests.rs
@@ -90,9 +90,9 @@ async fn update_workflow(#[values(FailUpdate::Yes, FailUpdate::No)] will_fail: F
     let events = client
         .get_workflow_handle::<UntypedWorkflow>(workflow_id)
         .fetch_history(Default::default())
+        .into_events()
         .await
-        .unwrap()
-        .into_events();
+        .unwrap();
     let with_id = HistoryForReplay::new(events, workflow_id.to_string());
     let replay_worker = init_core_replay_preloaded(workflow_id, [with_id]);
     // Init workflow comes by itself
@@ -170,9 +170,9 @@ async fn reapplied_updates_due_to_reset() {
         .build()
         .bind_untyped(client.clone())
         .fetch_history(Default::default())
+        .into_events()
         .await
-        .unwrap()
-        .into_events();
+        .unwrap();
     let with_id = HistoryForReplay::new(events, workflow_id.to_string());
 
     let replay_worker = init_core_replay_preloaded(workflow_id, [with_id]);
@@ -363,9 +363,9 @@ async fn update_rejection() {
     let events = client
         .get_workflow_handle::<UntypedWorkflow>(&workflow_id)
         .fetch_history(Default::default())
+        .into_events()
         .await
-        .unwrap()
-        .into_events();
+        .unwrap();
     let has_update_event = events.iter().any(|e| {
         matches!(
             e.event_type(),

--- a/crates/sdk-core/tests/integ_tests/workflow_replayer_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_replayer_tests.rs
@@ -11,7 +11,7 @@ use temporalio_client::{
     PluginError, WorkflowHistory, WorkflowQueryOptions, WorkflowStartOptions,
     WorkflowTerminateOptions, errors::WorkflowGetResultError,
 };
-use temporalio_common::protos::temporal::api::enums::v1::EventType;
+use temporalio_common::protos::temporal::api::{enums::v1::EventType, history::v1::History};
 use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
     ActivityOptions, ApplicationFailure, SimplePlugin, WorkerPlugin, WorkerRunError,
@@ -137,21 +137,29 @@ async fn workflow_replayer_replays_completed_workflow() {
         handle.get_result(Default::default()).await.unwrap(),
         "Hello, Temporal!"
     );
-    let history = handle.fetch_history(Default::default()).await.unwrap();
-    let history_from_json = WorkflowHistory::from_json(&history.to_json().unwrap()).unwrap();
-    assert_eq!(history_from_json.workflow_id(), history.workflow_id());
+    let history = handle.fetch_history(Default::default());
+    let workflow_id = history.workflow_id().map(str::to_owned);
+    let history_json = history.to_json().await.unwrap();
+    let history_from_json = WorkflowHistory::from_json(&history_json).unwrap();
+    assert_eq!(history_from_json.workflow_id(), workflow_id.as_deref());
 
     let replayer = replayer();
-    replayer
-        .replay_workflow(history_from_json.clone())
-        .await
-        .unwrap();
+    replayer.replay_workflow(history_from_json).await.unwrap();
     let results = replayer
-        .replay_workflows([history_from_json.clone(), history_from_json])
+        .replay_workflows([
+            WorkflowHistory::from_json(&history_json).unwrap(),
+            WorkflowHistory::from_json(&history_json).unwrap(),
+        ])
         .await
         .unwrap();
     assert_eq!(results.len(), 2);
     assert!(results.iter().all(|result| result.replay_failure.is_none()));
+    let cloned_result = results[0].clone();
+    assert_eq!(
+        cloned_result.history.workflow_id(),
+        Some(starter.get_wf_id())
+    );
+    assert!(!cloned_result.history.events().is_empty());
 }
 
 #[tokio::test]
@@ -192,7 +200,14 @@ async fn workflow_replayer_replays_incomplete_workflow() {
         )
         .await
         .unwrap();
-        let history = handle.fetch_history(Default::default()).await.unwrap();
+        let history: WorkflowHistory = History {
+            events: handle
+                .fetch_history(Default::default())
+                .into_events()
+                .await
+                .unwrap(),
+        }
+        .into();
         handle
             .terminate(WorkflowTerminateOptions::default())
             .await
@@ -230,7 +245,7 @@ async fn workflow_replayer_replays_failed_workflow() {
         handle.get_result(Default::default()).await,
         Err(WorkflowGetResultError::Failed(_))
     ));
-    let history = handle.fetch_history(Default::default()).await.unwrap();
+    let history = handle.fetch_history(Default::default());
 
     replayer().replay_workflow(history).await.unwrap();
 }
@@ -256,16 +271,30 @@ async fn workflow_replayer_reports_nondeterminism() {
         .unwrap();
 
     worker.run_until_done().await.unwrap();
-    let history = handle.fetch_history(Default::default()).await.unwrap();
+    let events = handle
+        .fetch_history(Default::default())
+        .into_events()
+        .await
+        .unwrap();
     let replayer = replayer();
 
     assert!(matches!(
-        replayer.replay_workflow(history.clone()).await,
+        replayer
+            .replay_workflow(
+                History {
+                    events: events.clone(),
+                }
+                .into()
+            )
+            .await,
         Err(WorkflowReplayError::Replay(
             WorkflowReplayFailure::Nondeterminism { .. }
         ))
     ));
-    let results = replayer.replay_workflows([history]).await.unwrap();
+    let results = replayer
+        .replay_workflows([History { events }.into()])
+        .await
+        .unwrap();
     assert!(matches!(
         results[0].replay_failure,
         Some(WorkflowReplayFailure::Nondeterminism { .. })
@@ -295,12 +324,15 @@ async fn workflow_replayer_replays_history_with_workflow_task_failure() {
     let fetch_failed_history = async {
         let history = eventually(
             || async {
-                let history = handle.fetch_history(Default::default()).await.unwrap();
-                history
-                    .events()
+                let events = handle
+                    .fetch_history(Default::default())
+                    .into_events()
+                    .await
+                    .unwrap();
+                events
                     .iter()
                     .any(|event| event.event_type() == EventType::WorkflowTaskFailed)
-                    .then_some(history)
+                    .then_some(History { events }.into())
                     .ok_or("workflow task failure not yet recorded")
             },
             Duration::from_secs(10),
@@ -353,14 +385,8 @@ async fn workflow_replayer_returns_ordered_results_for_multiple_histories() {
         .unwrap();
 
     worker.run_until_done().await.unwrap();
-    let successful_history = successful_handle
-        .fetch_history(Default::default())
-        .await
-        .unwrap();
-    let nondeterministic_history = nondeterministic_handle
-        .fetch_history(Default::default())
-        .await
-        .unwrap();
+    let successful_history = successful_handle.fetch_history(Default::default());
+    let nondeterministic_history = nondeterministic_handle.fetch_history(Default::default());
 
     let results = replayer()
         .replay_workflows([successful_history, nondeterministic_history])
@@ -441,7 +467,11 @@ async fn workflow_replayer_applies_plugins() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    let history = handle.fetch_history(Default::default()).await.unwrap();
+    let events = handle
+        .fetch_history(Default::default())
+        .into_events()
+        .await
+        .unwrap();
 
     let configure_calls = Arc::new(AtomicUsize::new(0));
     let replayer = WorkflowReplayer::new(
@@ -460,7 +490,15 @@ async fn workflow_replayer_applies_plugins() {
             .count(),
         1
     );
-    replayer.replay_workflow(history.clone()).await.unwrap();
+    replayer
+        .replay_workflow(
+            History {
+                events: events.clone(),
+            }
+            .into(),
+        )
+        .await
+        .unwrap();
     assert_eq!(configure_calls.load(Ordering::Relaxed), 1);
 
     let run_calls = Arc::new(AtomicUsize::new(0));
@@ -477,7 +515,16 @@ async fn workflow_replayer_applies_plugins() {
     )
     .unwrap();
     replayer
-        .replay_workflows([history.clone(), history.clone()])
+        .replay_workflows([
+            History {
+                events: events.clone(),
+            }
+            .into(),
+            History {
+                events: events.clone(),
+            }
+            .into(),
+        ])
         .await
         .unwrap();
     assert_eq!(run_calls.load(Ordering::Relaxed), 0);
@@ -495,5 +542,8 @@ async fn workflow_replayer_applies_plugins() {
             .build(),
     )
     .unwrap();
-    replayer.replay_workflow(history).await.unwrap();
+    replayer
+        .replay_workflow(History { events }.into())
+        .await
+        .unwrap();
 }

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -352,9 +352,12 @@ async fn propagated_activity_input_conversion_failure_fails_workflow_task() {
     worker.run_until_done().await.unwrap();
     handle.get_result(Default::default()).await.unwrap();
 
-    let history = handle.fetch_history(Default::default()).await.unwrap();
+    let history = handle
+        .fetch_history(Default::default())
+        .into_events()
+        .await
+        .unwrap();
     let workflow_task_failures: Vec<_> = history
-        .events()
         .iter()
         .filter(|event| event.event_type() == EventType::WorkflowTaskFailed)
         .collect();

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -284,10 +284,10 @@ async fn abandoned_child_resolves_post_cancel() {
         client.get_workflow_handle::<UntypedWorkflow>("abandoned-child-resolve-post-cancel");
     let history = child_handle
         .fetch_history(Default::default())
+        .into_events()
         .await
         .unwrap();
     let wft_failures: Vec<_> = history
-        .events()
         .iter()
         .filter(|e| {
             matches!(
@@ -1235,9 +1235,12 @@ async fn cancel_child_wf_before_started_event_real_server() {
     // Verify no unexpected workflow task failures in history. The bug manifests as a WFT failure
     // with a nondeterminism error. UnhandledCommand failures are acceptable since the server
     // may reject a cancel command if it races with the child workflow start.
-    let history = handle.fetch_history(Default::default()).await.unwrap();
+    let history = handle
+        .fetch_history(Default::default())
+        .into_events()
+        .await
+        .unwrap();
     let unexpected_wft_failures: Vec<_> = history
-        .events()
         .iter()
         .filter(|e| {
             if let Some(history_event::Attributes::WorkflowTaskFailedEventAttributes(attrs)) =

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -4384,9 +4384,9 @@ async fn replay_out_of_order_local_activity_markers_is_deterministic() {
     let workflow_id = handle.info().workflow_id.clone();
     let events = handle
         .fetch_history(Default::default())
+        .into_events()
         .await
-        .unwrap()
-        .into_events();
+        .unwrap();
     let marker_order = events
         .iter()
         .filter_map(|event| match event.attributes.as_ref() {

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/patches.rs
@@ -212,8 +212,12 @@ async fn patch_activation_callback_is_memoized_across_replay() {
         (false, false)
     );
     assert_eq!(callback_calls.load(Ordering::Relaxed), 1);
-    let history = handle.fetch_history(Default::default()).await.unwrap();
-    assert!(!history.events().iter().any(|event| matches!(
+    let history = handle
+        .fetch_history(Default::default())
+        .into_events()
+        .await
+        .unwrap();
+    assert!(!history.iter().any(|event| matches!(
         &event.attributes,
         Some(EventAttributes::MarkerRecordedEventAttributes(attrs))
             if attrs.marker_name == PATCH_MARKER_NAME
@@ -305,8 +309,12 @@ async fn declined_patch_can_roll_out_to_old_worker() {
     });
     run_result.unwrap();
     assert_eq!(callback_calls.load(Ordering::Relaxed), 1);
-    let history = handle.fetch_history(Default::default()).await.unwrap();
-    assert!(!history.events().iter().any(|event| matches!(
+    let history = handle
+        .fetch_history(Default::default())
+        .into_events()
+        .await
+        .unwrap();
+    assert!(!history.iter().any(|event| matches!(
         &event.attributes,
         Some(EventAttributes::MarkerRecordedEventAttributes(attrs))
             if attrs.marker_name == PATCH_MARKER_NAME
@@ -369,8 +377,12 @@ async fn activated_patch_replays_without_consulting_declining_callback() {
     });
     run_result.unwrap();
     assert_eq!(activated_calls.load(Ordering::Relaxed), 1);
-    let history = handle.fetch_history(Default::default()).await.unwrap();
-    assert!(history.events().iter().any(|event| matches!(
+    let history = handle
+        .fetch_history(Default::default())
+        .into_events()
+        .await
+        .unwrap();
+    assert!(history.iter().any(|event| matches!(
         &event.attributes,
         Some(EventAttributes::MarkerRecordedEventAttributes(attrs))
             if attrs.marker_name == PATCH_MARKER_NAME
@@ -1179,9 +1191,12 @@ async fn patch_marker_size_overflow_replay_is_deterministic() {
 
     // Confirm that the original execution did in fact hit the size limit: the last upsert SA
     // event in history must contain fewer than the total number of patches issued by the workflow.
-    let history = handle.fetch_history(Default::default()).await.unwrap();
+    let history = handle
+        .fetch_history(Default::default())
+        .into_events()
+        .await
+        .unwrap();
     let last_upsert_patches = history
-        .events()
         .iter()
         .rev()
         .find_map(|e| match &e.attributes {

--- a/crates/sdk-core/tests/shared_tests/mod.rs
+++ b/crates/sdk-core/tests/shared_tests/mod.rs
@@ -383,10 +383,10 @@ pub(crate) async fn shutdown_during_active_timer_activity_workflows() {
         let history = client
             .get_workflow_handle::<UntypedWorkflow>(wf_id)
             .fetch_history(WorkflowFetchHistoryOptions::default())
+            .into_events()
             .await
             .unwrap();
         let bad_events: Vec<_> = history
-            .events()
             .iter()
             .filter(|e| match &e.attributes {
                 Some(history_event::Attributes::WorkflowTaskFailedEventAttributes(f))

--- a/crates/sdk-core/tests/shared_tests/priority.rs
+++ b/crates/sdk-core/tests/shared_tests/priority.rs
@@ -135,9 +135,9 @@ pub(crate) async fn priority_values_sent_to_server() {
         .unwrap();
     let events = handle
         .fetch_history(Default::default())
+        .into_events()
         .await
-        .unwrap()
-        .into_events();
+        .unwrap();
     let workflow_init_event = events
         .iter()
         .find_map(|e| {

--- a/crates/sdk/src/workflow_replayer.rs
+++ b/crates/sdk/src/workflow_replayer.rs
@@ -12,7 +12,9 @@ use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
 };
-use temporalio_client::{ClientOptions, PluginApplyError, WorkflowHistory};
+use temporalio_client::{
+    ClientOptions, PluginApplyError, WorkflowHistory, errors::WorkflowInteractionError,
+};
 use temporalio_common::{
     WorkflowDefinition,
     data_converters::DataConverter,
@@ -21,7 +23,7 @@ use temporalio_common::{
             WorkflowActivation, remove_from_cache::EvictionReason,
             workflow_activation_job::Variant as ActivationVariant,
         },
-        temporal::api::history::v1::History,
+        temporal::api::history::v1::{History, HistoryEvent},
     },
 };
 use temporalio_sdk_core::{
@@ -258,12 +260,39 @@ pub enum WorkflowReplayFailure {
     },
 }
 
+/// Eagerly fetched workflow history returned after replay.
+#[derive(Clone, Debug)]
+pub struct ReplayHistory {
+    events: Vec<HistoryEvent>,
+    /// Workflow ID when it is known.
+    workflow_id: Option<String>,
+}
+
+impl ReplayHistory {
+    fn new(events: Vec<HistoryEvent>, workflow_id: Option<String>) -> Self {
+        Self {
+            events,
+            workflow_id,
+        }
+    }
+
+    /// The history events.
+    pub fn events(&self) -> &[HistoryEvent] {
+        &self.events
+    }
+
+    /// The history events.
+    pub fn workflow_id(&self) -> Option<&str> {
+        self.workflow_id.as_deref()
+    }
+}
+
 /// Outcome of replaying one workflow history.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct WorkflowReplayResult {
     /// History supplied to the replayer.
-    pub history: WorkflowHistory,
+    pub history: ReplayHistory,
     /// Replay failure, or `None` when the workflow code is compatible with the history.
     pub replay_failure: Option<WorkflowReplayFailure>,
 }
@@ -272,6 +301,9 @@ pub struct WorkflowReplayResult {
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum WorkflowReplayError {
+    /// Fetching a streamed workflow history failed.
+    #[error(transparent)]
+    History(#[from] WorkflowInteractionError),
     /// The replay worker could not be created or run.
     #[error(transparent)]
     Worker(#[from] WorkflowReplayWorkerError),
@@ -362,27 +394,26 @@ impl WorkflowReplayer {
             return Ok(Vec::new());
         }
 
-        let mut results = histories
-            .into_iter()
-            .map(|history| WorkflowReplayResult {
-                history,
+        let mut results = Vec::with_capacity(histories.len());
+        let mut core_histories = Vec::with_capacity(histories.len());
+        for history in histories {
+            let workflow_id = history.workflow_id().map(str::to_owned);
+            let replay_workflow_id = workflow_id
+                .as_deref()
+                .unwrap_or(DEFAULT_REPLAY_WORKFLOW_ID)
+                .to_owned();
+            let events = history.into_events().await?;
+            core_histories.push(HistoryForReplay::new(
+                History {
+                    events: events.clone(),
+                },
+                replay_workflow_id,
+            ));
+            results.push(WorkflowReplayResult {
+                history: ReplayHistory::new(events, workflow_id),
                 replay_failure: None,
-            })
-            .collect::<Vec<_>>();
-        let core_histories: Vec<_> = results
-            .iter()
-            .map(|result| {
-                HistoryForReplay::new(
-                    History {
-                        events: result.history.events().to_vec(),
-                    },
-                    result
-                        .history
-                        .workflow_id()
-                        .unwrap_or(DEFAULT_REPLAY_WORKFLOW_ID),
-                )
-            })
-            .collect();
+            });
+        }
 
         let recorded_outcomes = Arc::new(Mutex::new(Vec::new()));
         let observer = ReplayOutcomeInterceptor {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Change `WorkflowHistory` to be backed by a stream instead of an explicit events vec
- `WorkflowHistoryJsonError` renamed by `WorkflowHistoryJsonError`
- Split out workflow replayer to use its own history type that explicitly holds a complete history. Felt odd pretending history in `ReplayResult` wouldn't be completely present. Lets us keep `ReplayResult: Clone`.
- Fair amount of updates to integration tests where `.fetch_history().await.unwrap().into_events()` became `.fetch_history().into_events().await.unwrap()`

## Why?
User may not necessarily need to eagerly fetch all workflow history.

## Checklist
<!--- add/delete as needed --->

1. Closes #1213 

2. How was this tested:
Small unit tests to verify laziness/error prop.

3. Any docs updates needed?
N/A
