### PR TITLE
chore(sdk): make serialization context extensible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ relevant information.
   or constructors (`WorkerCallbacks::new`, `ActivityExecutionDecodeHint::new`, or
   `SerializationContext::new`); use `Default` for `PayloadConverter`; and add wildcard branches
   when matching enums.
+* `SerializationContextData::{Workflow, Activity, Nexus}` now contain corresponding context
+  structs. `SerializationContextData` is no longer `Copy`.
 * Renamed `ActivityCloseTimeouts::Both` to `ActivityCloseTimeouts::ScheduleAndStartToClose`.
 * Removed the unused `ActExitValue` type. Use `ActivityError::WillCompleteAsync` to mark an
   activity for asynchronous completion.

--- a/crates/client/src/activity/activity_handle.rs
+++ b/crates/client/src/activity/activity_handle.rs
@@ -7,7 +7,9 @@ use crate::{
 use std::marker::PhantomData;
 use temporalio_common::{
     ActivityDefinition,
-    data_converters::{DecodablePayloads, NoopDecodeHint, SerializationContextData},
+    data_converters::{
+        ActivitySerializationContext, DecodablePayloads, NoopDecodeHint, SerializationContextData,
+    },
     payload_visitor::decode_payloads,
     protos::temporal::api::{
         activity::v1::{ActivityExecutionOutcome, activity_execution_outcome},
@@ -99,7 +101,7 @@ where
             };
 
             let dc = client.data_converter();
-            let ctx = SerializationContextData::Activity;
+            let ctx = SerializationContextData::Activity(ActivitySerializationContext::new());
 
             return match outcome {
                 activity_execution_outcome::Value::Result(payloads) => {
@@ -156,7 +158,7 @@ where
 
         Ok(ActivityExecutionDescription::new(
             client.data_converter().clone(),
-            SerializationContextData::Activity,
+            SerializationContextData::Activity(ActivitySerializationContext::new()),
             resp,
         )
         .await?)
@@ -293,7 +295,7 @@ mod tests {
             DefaultFailureConverter::new(true),
             XorCodec,
         );
-        let context = SerializationContextData::Activity;
+        let context = SerializationContextData::Activity(ActivitySerializationContext::new());
         let mut failure = data_converter.to_failure(
             &context,
             OutgoingError::Activity(OutgoingActivityError::Application(Box::new(

--- a/crates/client/src/async_activity_handle.rs
+++ b/crates/client/src/async_activity_handle.rs
@@ -7,7 +7,10 @@ use crate::{
 };
 use futures_util::future::BoxFuture;
 use temporalio_common::{
-    data_converters::{SerializationContext, SerializationContextData, TemporalSerializable},
+    data_converters::{
+        ActivitySerializationContext, SerializationContext, SerializationContextData,
+        TemporalSerializable,
+    },
     error::{ApplicationFailure, OutgoingActivityError, OutgoingError},
     payload_visitor::encode_payloads,
     protos::{
@@ -35,14 +38,17 @@ async fn encode_optional_value(
     };
     let unencoded_payloads = {
         let payload_converter = data_converter.payload_converter();
-        let context =
-            SerializationContext::new(&SerializationContextData::Activity, payload_converter);
+        let context_data = SerializationContextData::Activity(ActivitySerializationContext::new());
+        let context = SerializationContext::new(&context_data, payload_converter);
         value.serialize_payloads(&context)?
     };
     drop(value);
     let payloads = data_converter
         .codec()
-        .encode(&SerializationContextData::Activity, unencoded_payloads)
+        .encode(
+            &SerializationContextData::Activity(ActivitySerializationContext::new()),
+            unencoded_payloads,
+        )
         .await?;
     Ok(Some(Payloads { payloads }))
 }
@@ -235,7 +241,7 @@ impl<CT: WorkflowService + NamespacedClient + Clone> AsyncActivityHandle<CT> {
                             input.into_parts();
                         let data_converter = client.data_converter().clone();
                         let mut failure = data_converter.to_failure(
-                            &SerializationContextData::Activity,
+                            &SerializationContextData::Activity(ActivitySerializationContext::new()),
                             OutgoingError::Activity(OutgoingActivityError::Application(Box::new(
                                 application_failure,
                             ))),
@@ -243,7 +249,7 @@ impl<CT: WorkflowService + NamespacedClient + Clone> AsyncActivityHandle<CT> {
                         encode_payloads(
                             &mut failure,
                             data_converter.codec(),
-                            &SerializationContextData::Activity,
+                            &SerializationContextData::Activity(ActivitySerializationContext::new()),
                         )
                         .await?;
                         let last_heartbeat_details =

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -135,7 +135,10 @@ use std::{
 };
 use temporalio_common::{
     ActivityDefinition, HasWorkflowDefinition, SignalDefinition, UntypedActivity, UpdateDefinition,
-    data_converters::{DataConverter, SerializationContext, SerializationContextData},
+    data_converters::{
+        ActivitySerializationContext, DataConverter, SerializationContext,
+        SerializationContextData, WorkflowSerializationContext,
+    },
     payload_visitor::decode_payloads,
     protos::{
         coresdk::IntoPayloadsExt,
@@ -1659,7 +1662,7 @@ impl WorkflowExecution {
         Memo::from_raw(
             self.raw.memo.clone(),
             self.data_converter.payload_converter().clone(),
-            SerializationContextData::Workflow,
+            SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
     }
 
@@ -1876,14 +1879,18 @@ where
                         let data_converter = client.data_converter().clone();
                         let unencoded_payloads = {
                             let payload_converter = data_converter.payload_converter();
-                            let context = SerializationContext::new(&SerializationContextData::Workflow, payload_converter);
+                            let context_data = SerializationContextData::Workflow(
+                                WorkflowSerializationContext::new(),
+                            );
+                            let context =
+                                SerializationContext::new(&context_data, payload_converter);
                             args.serialize_payloads(&context)
                         };
                         drop(args);
 
                         let payloads = data_converter
                             .codec()
-                            .encode(&SerializationContextData::Workflow, unencoded_payloads?)
+                            .encode(&SerializationContextData::Workflow(WorkflowSerializationContext::new()), unencoded_payloads?)
                             .await?;
                         let workflow_id = options.workflow_id.clone();
                         let memo = options.encoded_memo(&data_converter).await?;
@@ -1967,18 +1974,21 @@ where
                         ) = input.into_parts();
                         let data_converter = client.data_converter().clone();
                         let payload_converter = data_converter.payload_converter();
-                        let context = SerializationContext::new(&SerializationContextData::Workflow, payload_converter);
+                        let context_data = SerializationContextData::Workflow(
+                            WorkflowSerializationContext::new(),
+                        );
+                        let context = SerializationContext::new(&context_data, payload_converter);
                         let workflow_payloads = workflow_args.serialize_payloads(&context);
                         let signal_payloads = signal_args.serialize_payloads(&context);
                         drop(workflow_args);
                         drop(signal_args);
                         let workflow_payloads = data_converter
                             .codec()
-                            .encode(&SerializationContextData::Workflow, workflow_payloads?)
+                            .encode(&SerializationContextData::Workflow(WorkflowSerializationContext::new()), workflow_payloads?)
                             .await?;
                         let signal_payloads = data_converter
                             .codec()
-                            .encode(&SerializationContextData::Workflow, signal_payloads?)
+                            .encode(&SerializationContextData::Workflow(WorkflowSerializationContext::new()), signal_payloads?)
                             .await?;
                         let workflow_id = options.workflow_id.clone();
                         let memo = options.encoded_memo(&data_converter).await?;
@@ -2097,10 +2107,11 @@ where
                         let data_converter = client.data_converter().clone();
                         let (unencoded_workflow_payloads, unencoded_update_payloads) = {
                             let payload_converter = data_converter.payload_converter();
-                            let context = SerializationContext::new(
-                                &SerializationContextData::Workflow,
-                                payload_converter,
+                            let context_data = SerializationContextData::Workflow(
+                                WorkflowSerializationContext::new(),
                             );
+                            let context =
+                                SerializationContext::new(&context_data, payload_converter);
                             (
                                 workflow_args.serialize_payloads(&context),
                                 update_args.serialize_payloads(&context),
@@ -2112,11 +2123,15 @@ where
                         // encode both payload sets concurrently.
                         let (workflow_payloads, update_payloads) = try_join(
                             data_converter.codec().encode(
-                                &SerializationContextData::Workflow,
+                                &SerializationContextData::Workflow(
+                                    WorkflowSerializationContext::new(),
+                                ),
                                 unencoded_workflow_payloads?,
                             ),
                             data_converter.codec().encode(
-                                &SerializationContextData::Workflow,
+                                &SerializationContextData::Workflow(
+                                    WorkflowSerializationContext::new(),
+                                ),
                                 unencoded_update_payloads?,
                             ),
                         )
@@ -2364,7 +2379,9 @@ where
                                     && let Err(err) = decode_payloads(
                                         memo,
                                         data_converter.codec(),
-                                        &SerializationContextData::Workflow,
+                                        &SerializationContextData::Workflow(
+                                            WorkflowSerializationContext::new(),
+                                        ),
                                     )
                                     .await
                                 {
@@ -2460,7 +2477,7 @@ where
     {
         let mut client = self.clone();
         let dc = client.data_converter();
-        let sc = &SerializationContextData::Activity;
+        let sc = &SerializationContextData::Activity(ActivitySerializationContext::new());
 
         let user_metadata = {
             let summary = match &options.summary {
@@ -3695,13 +3712,17 @@ mod tests {
         /// Decode a sent memo the same way `describe`/`list` do, and read it back.
         async fn read_back(sent: ProtoMemo) -> Memo {
             let mut sent = sent;
-            decode_payloads(&mut sent, &XorCodec, &SerializationContextData::Workflow)
-                .await
-                .unwrap();
+            decode_payloads(
+                &mut sent,
+                &XorCodec,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+            )
+            .await
+            .unwrap();
             Memo::from_raw(
                 Some(sent),
                 PayloadConverter::default(),
-                SerializationContextData::Workflow,
+                SerializationContextData::Workflow(WorkflowSerializationContext::new()),
             )
         }
 
@@ -3856,7 +3877,10 @@ mod tests {
             };
             let replacement: String = client
                 .data_converter()
-                .from_payloads(&SerializationContextData::Workflow, payloads)
+                .from_payloads(
+                    &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+                    payloads,
+                )
                 .await
                 .unwrap();
             assert_eq!(replacement, "replacement");
@@ -4019,7 +4043,7 @@ mod tests {
             assert_eq!(
                 data_converter
                     .from_payloads::<Vec<String>>(
-                        &SerializationContextData::Workflow,
+                        &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                         workflow_payloads,
                     )
                     .await
@@ -4029,7 +4053,7 @@ mod tests {
             assert_eq!(
                 data_converter
                     .from_payloads::<Vec<String>>(
-                        &SerializationContextData::Workflow,
+                        &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                         signal_payloads,
                     )
                     .await
@@ -4184,15 +4208,18 @@ mod tests {
         ) -> ExecuteMultiOperationResponse {
             let outcome = (stage == UpdateWorkflowExecutionLifecycleStage::Completed).then(|| {
                 let payload_converter = PayloadConverter::default();
-                let result_payloads = payload_converter
-                    .to_payloads(
-                        &SerializationContext::new(
-                            &SerializationContextData::Workflow,
-                            &payload_converter,
-                        ),
-                        &"update-result".to_owned(),
-                    )
-                    .unwrap();
+                let result_payloads =
+                    payload_converter
+                        .to_payloads(
+                            &SerializationContext::new(
+                                &SerializationContextData::Workflow(
+                                    WorkflowSerializationContext::new(),
+                                ),
+                                &payload_converter,
+                            ),
+                            &"update-result".to_owned(),
+                        )
+                        .unwrap();
                 Outcome {
                     value: Some(outcome::Value::Success(Payloads {
                         payloads: result_payloads,
@@ -4324,8 +4351,9 @@ mod tests {
                 .unwrap();
 
             let payload_converter = PayloadConverter::default();
-            let context =
-                SerializationContext::new(&SerializationContextData::Workflow, &payload_converter);
+            let context_data =
+                SerializationContextData::Workflow(WorkflowSerializationContext::new());
+            let context = SerializationContext::new(&context_data, &payload_converter);
             let workflow_payloads = payload_converter
                 .to_payloads(&context, &"workflow-input".to_owned())
                 .unwrap();
@@ -4534,7 +4562,7 @@ mod tests {
             let workflow_input: String = client
                 .data_converter()
                 .from_payloads(
-                    &SerializationContextData::Workflow,
+                    &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                     start_request.input.clone().unwrap().payloads,
                 )
                 .await
@@ -4547,7 +4575,7 @@ mod tests {
             let update_input: String = client
                 .data_converter()
                 .from_payloads(
-                    &SerializationContextData::Workflow,
+                    &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                     update_request
                         .request
                         .clone()
@@ -4784,7 +4812,7 @@ mod tests {
             );
             let memo_payload = data_converter
                 .to_payload(
-                    &SerializationContextData::Workflow,
+                    &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                     &"memo-value".to_owned(),
                 )
                 .await

--- a/crates/client/src/options_structs.rs
+++ b/crates/client/src/options_structs.rs
@@ -8,7 +8,7 @@ use temporalio_common::{
     ActivityCloseTimeouts, MemoValues, RetryPolicy,
     data_converters::{
         DataConverter, GenericPayloadConverter, PayloadConversionError, PayloadConverter,
-        SerializationContext, SerializationContextData,
+        SerializationContext, SerializationContextData, WorkflowSerializationContext,
     },
     payload_visitor::encode_payloads,
     protos::temporal::api::{
@@ -466,8 +466,8 @@ impl WorkflowStartOptions {
         };
 
         let payload_converter = data_converter.payload_converter();
-        let context =
-            SerializationContext::new(&SerializationContextData::Workflow, payload_converter);
+        let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+        let context = SerializationContext::new(&context_data, payload_converter);
         let mut memo = ProtoMemo {
             fields: memo
                 .iter()
@@ -481,7 +481,7 @@ impl WorkflowStartOptions {
         encode_payloads(
             &mut memo,
             data_converter.codec(),
-            &SerializationContextData::Workflow,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
         .await?;
         Ok(Some(memo))
@@ -490,8 +490,9 @@ impl WorkflowStartOptions {
     pub(crate) fn user_metadata(&self) -> Option<UserMetadata> {
         (self.static_summary.is_some() || self.static_details.is_some()).then(|| {
             let payload_converter = PayloadConverter::default();
-            let context =
-                SerializationContext::new(&SerializationContextData::Workflow, &payload_converter);
+            let context_data =
+                SerializationContextData::Workflow(WorkflowSerializationContext::new());
+            let context = SerializationContext::new(&context_data, &payload_converter);
             UserMetadata {
                 summary: self.static_summary.as_ref().map(|summary| {
                     payload_converter

--- a/crates/client/src/schedules.rs
+++ b/crates/client/src/schedules.rs
@@ -17,7 +17,7 @@ use temporalio_common::{
     HasWorkflowDefinition,
     data_converters::{
         DataConverter, PayloadConversionError, SerializationContextData, TemporalDeserializable,
-        TemporalSerializable,
+        TemporalSerializable, WorkflowSerializationContext,
     },
     payload_visitor::decode_payloads,
     protos::{
@@ -102,7 +102,11 @@ impl ScheduleWorkflowInput {
         dc: &DataConverter,
     ) -> Result<Vec<common_proto::Payload>, PayloadConversionError> {
         let ScheduleWorkflowInputRepr::Deferred(v) = self.repr;
-        v.to_payloads(dc, &SerializationContextData::Workflow).await
+        v.to_payloads(
+            dc,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+        )
+        .await
     }
 }
 
@@ -541,7 +545,10 @@ impl ScheduleDescriptionStartWorkflowAction {
         match &self.input {
             Some(input) => self
                 .data_converter
-                .from_payloads(&SerializationContextData::Workflow, input.payloads.clone())
+                .from_payloads(
+                    &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+                    input.payloads.clone(),
+                )
                 .await
                 .map(Some),
             None => Ok(None),
@@ -726,7 +733,7 @@ impl ScheduleDescription {
         crate::Memo::from_raw(
             self.raw.memo.clone(),
             self.data_converter.payload_converter().clone(),
-            SerializationContextData::Workflow,
+            SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
     }
 
@@ -979,7 +986,7 @@ impl ScheduleSummary {
         crate::Memo::from_raw(
             self.raw.memo.clone(),
             self.data_converter.payload_converter().clone(),
-            SerializationContextData::Workflow,
+            SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
     }
 
@@ -1088,7 +1095,7 @@ where
             decode_payloads(
                 memo,
                 self.client.data_converter().codec(),
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
             )
             .await?;
         }
@@ -1143,7 +1150,7 @@ where
                         decode_payloads(
                             &mut response,
                             handle.client.data_converter().codec(),
-                            &SerializationContextData::Workflow,
+                            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                         )
                         .await?;
                         let description = ScheduleDescription::new(
@@ -1608,7 +1615,9 @@ where
                                 && let Err(err) = decode_payloads(
                                     memo,
                                     data_converter.codec(),
-                                    &SerializationContextData::Workflow,
+                                    &SerializationContextData::Workflow(
+                                        WorkflowSerializationContext::new(),
+                                    ),
                                 )
                                 .await
                             {
@@ -1969,7 +1978,7 @@ mod tests {
         let data_converter = data_converter_with_codec();
         let memo_payload = data_converter
             .to_payload(
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                 &"memo-value".to_owned(),
             )
             .await
@@ -2000,7 +2009,7 @@ mod tests {
         let data_converter = DataConverter::default();
         let memo_payload = data_converter
             .to_payload(
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                 &"memo-value".to_owned(),
             )
             .await
@@ -2509,7 +2518,10 @@ mod tests {
         let data_converter = DataConverter::default();
         let expected = MultiArgs2("hello".to_string(), 42i32);
         let payloads = data_converter
-            .to_payloads(&SerializationContextData::Workflow, &expected)
+            .to_payloads(
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+                &expected,
+            )
             .await
             .unwrap();
         let desc = ScheduleDescription::new(
@@ -2542,7 +2554,10 @@ mod tests {
         let data_converter = DataConverter::default();
         let expected: String = "not-an-int".to_string();
         let payloads = data_converter
-            .to_payloads(&SerializationContextData::Workflow, &expected)
+            .to_payloads(
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+                &expected,
+            )
             .await
             .unwrap();
         let desc = schedule_description_from_response(describe_response_with_start_workflow(Some(

--- a/crates/client/src/workflow_handle.rs
+++ b/crates/client/src/workflow_handle.rs
@@ -27,6 +27,7 @@ use temporalio_common::{
     data_converters::{
         DataConverter, DecodablePayloads, GenericPayloadConverter, PayloadConversionError,
         PayloadConverter, RawValue, SerializationContext, SerializationContextData,
+        WorkflowSerializationContext,
     },
     error::IncomingError,
     payload_visitor::decode_payloads,
@@ -99,13 +100,16 @@ impl WorkflowResultDetails {
     ) -> Result<Self, PayloadConversionError> {
         let payloads = data_converter
             .codec()
-            .decode(&SerializationContextData::Workflow, payloads)
+            .decode(
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+                payloads,
+            )
             .await?;
         Ok(Self {
             payloads: DecodablePayloads::new(
                 payloads,
                 data_converter.payload_converter().clone(),
-                SerializationContextData::Workflow,
+                SerializationContextData::Workflow(WorkflowSerializationContext::new()),
             ),
         })
     }
@@ -177,11 +181,13 @@ impl WorkflowExecutionDescription {
         decode_payloads(
             &mut raw_description,
             data_converter.codec(),
-            &SerializationContextData::Workflow,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
         .await?;
-        let decoded_metadata =
-            decode_user_metadata(&SerializationContextData::Workflow, raw_user_metadata)?;
+        let decoded_metadata = decode_user_metadata(
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+            raw_user_metadata,
+        )?;
         let history_length_raw = raw_description
             .workflow_execution_info
             .as_ref()
@@ -261,7 +267,7 @@ impl WorkflowExecutionDescription {
         crate::Memo::from_raw(
             self.workflow_info().memo.clone(),
             self.data_converter.payload_converter().clone(),
-            SerializationContextData::Workflow,
+            SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
     }
 
@@ -675,7 +681,7 @@ where
                         .and_then(|p| p.payloads.into_iter().next())
                         .unwrap_or_default();
                     let result: W::Output = dc
-                        .from_payload(&SerializationContextData::Workflow, payload)
+                        .from_payload(&SerializationContextData::Workflow(WorkflowSerializationContext::new()), payload)
                         .await?;
                     Ok(WorkflowExecutionResult::Succeeded(result))
                 }
@@ -685,13 +691,13 @@ where
                     decode_payloads(
                         &mut failure,
                         dc.codec(),
-                        &SerializationContextData::Workflow,
+                        &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                     )
                     .await?;
                     let error = dc.failure_converter().to_error(
                         failure,
                         dc.payload_converter(),
-                        &SerializationContextData::Workflow,
+                        &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                     )?;
                     Ok(WorkflowExecutionResult::Failed(error))
                 }
@@ -770,13 +776,17 @@ where
                         let data_converter = client.data_converter().clone();
                         let unencoded_payloads = {
                             let payload_converter = data_converter.payload_converter();
-                            let context = SerializationContext::new(&SerializationContextData::Workflow, payload_converter);
+                            let context_data = SerializationContextData::Workflow(
+                                WorkflowSerializationContext::new(),
+                            );
+                            let context =
+                                SerializationContext::new(&context_data, payload_converter);
                             args.serialize_payloads(&context)
                         };
                         drop(args);
                         let payloads = data_converter
                             .codec()
-                            .encode(&SerializationContextData::Workflow, unencoded_payloads?)
+                            .encode(&SerializationContextData::Workflow(WorkflowSerializationContext::new()), unencoded_payloads?)
                             .await?;
                         let mut request = SignalWorkflowExecutionRequest {
                             namespace: client.namespace(),
@@ -838,13 +848,17 @@ where
                         let data_converter = client.data_converter().clone();
                         let unencoded_payloads = {
                             let payload_converter = data_converter.payload_converter();
-                            let context = SerializationContext::new(&SerializationContextData::Workflow, payload_converter);
+                            let context_data = SerializationContextData::Workflow(
+                                WorkflowSerializationContext::new(),
+                            );
+                            let context =
+                                SerializationContext::new(&context_data, payload_converter);
                             args.serialize_payloads(&context)
                         };
                         drop(args);
                         let payloads = data_converter
                             .codec()
-                            .encode(&SerializationContextData::Workflow, unencoded_payloads?)
+                            .encode(&SerializationContextData::Workflow(WorkflowSerializationContext::new()), unencoded_payloads?)
                             .await?;
                         let mut request = QueryWorkflowRequest {
                             namespace: client.namespace(),
@@ -891,7 +905,10 @@ where
 
         self.client
             .data_converter()
-            .from_payloads(&SerializationContextData::Workflow, result_payloads)
+            .from_payloads(
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+                result_payloads,
+            )
             .await
             .map_err(WorkflowQueryError::from)
     }
@@ -948,16 +965,22 @@ where
                             let data_converter = client.data_converter().clone();
                             let unencoded_payloads = {
                                 let payload_converter = data_converter.payload_converter();
-                                let context = SerializationContext::new(
-                                    &SerializationContextData::Workflow,
-                                    payload_converter,
+                                let context_data = SerializationContextData::Workflow(
+                                    WorkflowSerializationContext::new(),
                                 );
+                                let context =
+                                    SerializationContext::new(&context_data, payload_converter);
                                 args.serialize_payloads(&context)
                             };
                             drop(args);
                             let payloads = data_converter
                                 .codec()
-                                .encode(&SerializationContextData::Workflow, unencoded_payloads?)
+                                .encode(
+                                    &SerializationContextData::Workflow(
+                                        WorkflowSerializationContext::new(),
+                                    ),
+                                    unencoded_payloads?,
+                                )
                                 .await?;
                             let update_id = options
                                 .update_id
@@ -1418,7 +1441,10 @@ where
             Some(update::v1::outcome::Value::Success(success)) => self
                 .client
                 .data_converter()
-                .from_payloads(&SerializationContextData::Workflow, success.payloads)
+                .from_payloads(
+                    &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+                    success.payloads,
+                )
                 .await
                 .map_err(WorkflowUpdateError::from),
             Some(update::v1::outcome::Value::Failure(failure)) => {
@@ -1630,7 +1656,7 @@ mod tests {
         );
         let payloads = converter
             .to_payloads(
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                 &"workflow-result-details".to_owned(),
             )
             .await
@@ -1668,7 +1694,7 @@ mod tests {
         );
         let encoded = converter
             .to_payload(
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                 &"memo-value".to_owned(),
             )
             .await
@@ -1699,19 +1725,31 @@ mod tests {
     async fn workflow_description_accessors_expose_decoded_fields() {
         let converter = DataConverter::default();
         let memo_payload = converter
-            .to_payload(&SerializationContextData::Workflow, &"memo-value")
+            .to_payload(
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+                &"memo-value",
+            )
             .await
             .unwrap();
         let search_attr_payload = converter
-            .to_payload(&SerializationContextData::Workflow, &"search-value")
+            .to_payload(
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+                &"search-value",
+            )
             .await
             .unwrap();
         let summary_payload = converter
-            .to_payload(&SerializationContextData::Workflow, &"workflow summary")
+            .to_payload(
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+                &"workflow summary",
+            )
             .await
             .unwrap();
         let details_payload = converter
-            .to_payload(&SerializationContextData::Workflow, &"workflow details")
+            .to_payload(
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+                &"workflow details",
+            )
             .await
             .unwrap();
         let description = WorkflowExecutionDescription::new(

--- a/crates/common-wasm/src/data_converters.rs
+++ b/crates/common-wasm/src/data_converters.rs
@@ -140,16 +140,61 @@ impl DataConverter {
     }
 }
 
+/// Data available when serializing in a workflow context.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct WorkflowSerializationContext {}
+
+#[allow(clippy::new_without_default)]
+impl WorkflowSerializationContext {
+    /// Creates an empty workflow serialization context.
+    ///
+    /// **Experimental:** This constructor may change when workflow context data is added.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+/// Data available when serializing in an activity context.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ActivitySerializationContext {}
+
+#[allow(clippy::new_without_default)]
+impl ActivitySerializationContext {
+    /// Creates an empty activity serialization context.
+    ///
+    /// **Experimental:** This constructor may change when activity context data is added.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+/// Data available when serializing in a Nexus context.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct NexusSerializationContext {}
+
+#[allow(clippy::new_without_default)]
+impl NexusSerializationContext {
+    /// Creates an empty Nexus serialization context.
+    ///
+    /// **Experimental:** This constructor may change when Nexus context data is added.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
 /// Data about the serialization context, indicating where the serialization is occurring.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SerializationContextData {
     /// Serialization is occurring in a workflow context.
-    Workflow,
+    Workflow(WorkflowSerializationContext),
     /// Serialization is occurring in an activity context.
-    Activity,
+    Activity(ActivitySerializationContext),
     /// Serialization is occurring in a nexus context.
-    Nexus,
+    Nexus(NexusSerializationContext),
     /// No specific serialization context.
     None,
 }
@@ -838,7 +883,8 @@ mod tests {
     #[test]
     fn unit_payloads_roundtrip() {
         let converter = PayloadConverter::serde_json();
-        let ctx = SerializationContext::new(&SerializationContextData::Workflow, &converter);
+        let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+        let ctx = SerializationContext::new(&context_data, &converter);
 
         let payloads = converter.to_payloads(&ctx, &()).unwrap();
         assert!(payloads.is_empty());
@@ -870,7 +916,8 @@ mod tests {
         T: TemporalSerializable + std::fmt::Debug + 'static,
     {
         let converter = PayloadConverter::default();
-        let ctx = SerializationContext::new(&SerializationContextData::Workflow, &converter);
+        let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+        let ctx = SerializationContext::new(&context_data, &converter);
 
         let payload = converter.to_payload(&ctx, &value).unwrap();
 
@@ -904,7 +951,8 @@ mod tests {
         T: TemporalDeserializable + std::fmt::Debug + PartialEq + 'static,
     {
         let converter = PayloadConverter::default();
-        let ctx = SerializationContext::new(&SerializationContextData::Workflow, &converter);
+        let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+        let ctx = SerializationContext::new(&context_data, &converter);
 
         let actual: T = converter
             .from_payload(
@@ -925,7 +973,8 @@ mod tests {
     #[test]
     fn use_wrappers_returns_wrong_encoding_for_standard_types() {
         let converter = PayloadConverter::UseWrappers;
-        let ctx = SerializationContext::new(&SerializationContextData::Workflow, &converter);
+        let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+        let ctx = SerializationContext::new(&context_data, &converter);
 
         let result = converter.to_payload(&ctx, &());
         assert!(
@@ -955,7 +1004,8 @@ mod tests {
     #[test]
     fn multi_args_round_trip() {
         let converter = PayloadConverter::default();
-        let ctx = SerializationContext::new(&SerializationContextData::Workflow, &converter);
+        let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+        let ctx = SerializationContext::new(&context_data, &converter);
 
         let args = MultiArgs2("hello".to_string(), 42i32);
         let payloads = converter.to_payloads(&ctx, &args).unwrap();
@@ -968,7 +1018,8 @@ mod tests {
     #[test]
     fn empty_payloads_do_not_decode_as_option() {
         let converter = PayloadConverter::default();
-        let ctx = SerializationContext::new(&SerializationContextData::Workflow, &converter);
+        let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+        let ctx = SerializationContext::new(&context_data, &converter);
 
         let result: Result<Option<String>, _> = converter.from_payloads(&ctx, vec![]);
         assert!(matches!(result, Err(PayloadConversionError::WrongEncoding)));
@@ -996,12 +1047,18 @@ mod tests {
         let converter = PayloadConverter::default();
         let payloads = converter
             .to_payloads(
-                &SerializationContext::new(&SerializationContextData::Workflow, &converter),
+                &SerializationContext::new(
+                    &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+                    &converter,
+                ),
                 &value,
             )
             .unwrap();
-        let payloads =
-            DecodablePayloads::new(payloads, converter, SerializationContextData::Workflow);
+        let payloads = DecodablePayloads::new(
+            payloads,
+            converter,
+            SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+        );
 
         let result: T = payloads.deserialize().unwrap();
         assert_eq!(result, value);

--- a/crates/common-wasm/src/data_converters/failure_converter.rs
+++ b/crates/common-wasm/src/data_converters/failure_converter.rs
@@ -597,7 +597,10 @@ fn decode_failure(
 mod tests {
     use super::*;
     use crate::{
-        data_converters::{GenericPayloadConverter, SerializationContext},
+        data_converters::{
+            ActivitySerializationContext, GenericPayloadConverter, SerializationContext,
+            WorkflowSerializationContext,
+        },
         error::ApplicationErrorCategory,
         protos::temporal::api::{
             common::v1::{Payload, Payloads},
@@ -695,7 +698,7 @@ mod tests {
         DefaultFailureConverter::default().to_failure(
             OutgoingError::Workflow(err),
             &PayloadConverter::default(),
-            &SerializationContextData::Workflow,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
     }
 
@@ -764,7 +767,10 @@ mod tests {
         let converter = PayloadConverter::default();
         let details: String = converter
             .from_payloads(
-                &SerializationContext::new(&SerializationContextData::Workflow, &converter),
+                &SerializationContext::new(
+                    &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+                    &converter,
+                ),
                 payloads,
             )
             .unwrap();
@@ -780,7 +786,7 @@ mod tests {
                     .build(),
             ))),
             &PayloadConverter::default(),
-            &SerializationContextData::Workflow,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         );
 
         assert_eq!(
@@ -794,7 +800,10 @@ mod tests {
         let converter = PayloadConverter::default();
         let payloads = converter
             .to_payloads(
-                &SerializationContext::new(&SerializationContextData::Workflow, &converter),
+                &SerializationContext::new(
+                    &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+                    &converter,
+                ),
                 &"detail",
             )
             .unwrap();
@@ -810,7 +819,11 @@ mod tests {
         };
 
         let decoded = DefaultFailureConverter::default()
-            .to_error(failure, &converter, &SerializationContextData::Workflow)
+            .to_error(
+                failure,
+                &converter,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+            )
             .unwrap();
 
         let IncomingError::Application(app) = decoded else {
@@ -957,7 +970,7 @@ mod tests {
             .to_error(
                 converted.clone(),
                 &PayloadConverter::default(),
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
             )
             .unwrap();
 
@@ -979,7 +992,7 @@ mod tests {
     fn failure_converter_encodes_and_decodes_cause_chain() {
         let payload_converter = PayloadConverter::default();
         let converter = DefaultFailureConverter::new(true);
-        let context = SerializationContextData::Workflow;
+        let context = SerializationContextData::Workflow(WorkflowSerializationContext::new());
         let failure = Failure {
             message: "outer message".to_owned(),
             stack_trace: "outer stack trace".to_owned(),
@@ -1082,7 +1095,7 @@ mod tests {
             .to_error(
                 failure.clone(),
                 &PayloadConverter::default(),
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
             )
             .unwrap();
 
@@ -1115,7 +1128,7 @@ mod tests {
             .to_error(
                 failure.clone(),
                 &PayloadConverter::default(),
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
             )
             .unwrap();
 
@@ -1141,7 +1154,7 @@ mod tests {
             .to_error(
                 failure.clone(),
                 &PayloadConverter::default(),
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
             )
             .unwrap();
 
@@ -1159,7 +1172,7 @@ mod tests {
             .to_error(
                 reencoded,
                 &PayloadConverter::default(),
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
             )
             .unwrap();
         let IncomingError::Application(roundtripped) = decoded_reencoded else {
@@ -1189,7 +1202,7 @@ mod tests {
             .to_error(
                 failure.clone(),
                 &PayloadConverter::default(),
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
             )
             .unwrap();
 
@@ -1260,7 +1273,7 @@ mod tests {
             .to_error(
                 failure.clone(),
                 &PayloadConverter::default(),
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
             )
             .unwrap();
 
@@ -1299,7 +1312,7 @@ mod tests {
 
         let decoded = data_converter
             .to_error(
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                 failure.clone(),
                 ActivityExecutionDecodeHint { cancelled: false },
             )
@@ -1350,7 +1363,7 @@ mod tests {
     ) {
         let decoded = data_converter()
             .to_error(
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                 failure.clone(),
                 ActivityExecutionDecodeHint { cancelled: true },
             )
@@ -1399,7 +1412,7 @@ mod tests {
             .to_error(
                 failure.clone(),
                 &PayloadConverter::default(),
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
             )
             .unwrap();
 
@@ -1435,7 +1448,7 @@ mod tests {
             .to_error(
                 failure.clone(),
                 &PayloadConverter::default(),
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
             )
             .unwrap();
 
@@ -1472,7 +1485,7 @@ mod tests {
         };
         let decoded = data_converter()
             .to_error(
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                 failure.clone(),
                 ChildWorkflowExecutionDecodeHint,
             )
@@ -1521,7 +1534,7 @@ mod tests {
     ) {
         let decoded = data_converter()
             .to_error(
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                 failure.clone(),
                 ChildWorkflowExecutionDecodeHint,
             )
@@ -1553,7 +1566,7 @@ mod tests {
         };
         let decoded = data_converter()
             .to_error(
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                 failure.clone(),
                 ChildWorkflowStartDecodeHint,
             )
@@ -1581,7 +1594,7 @@ mod tests {
         };
         let decoded = data_converter()
             .to_error(
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                 failure.clone(),
                 WorkflowSignalDecodeHint,
             )
@@ -1607,7 +1620,7 @@ mod tests {
         let failure = DefaultFailureConverter::default().to_failure(
             OutgoingError::Activity(OutgoingActivityError::Cancelled { details: None }),
             &PayloadConverter::default(),
-            &SerializationContextData::Activity,
+            &SerializationContextData::Activity(ActivitySerializationContext::new()),
         );
 
         assert_eq!(failure.message, "Activity cancelled");
@@ -1624,14 +1637,14 @@ mod tests {
                 details: Some("detail".to_string().into()),
             }),
             &PayloadConverter::default(),
-            &SerializationContextData::Activity,
+            &SerializationContextData::Activity(ActivitySerializationContext::new()),
         );
 
         let err = DefaultFailureConverter::default()
             .to_error(
                 failure,
                 &PayloadConverter::default(),
-                &SerializationContextData::Activity,
+                &SerializationContextData::Activity(ActivitySerializationContext::new()),
             )
             .unwrap();
         let cancelled = err.as_cancelled().unwrap();

--- a/crates/common-wasm/src/error.rs
+++ b/crates/common-wasm/src/error.rs
@@ -364,7 +364,7 @@ impl ApplicationFailure {
                 FailurePayloads::from(DecodablePayloads::new(
                     details.payloads,
                     payload_converter.clone(),
-                    *context,
+                    context.clone(),
                 ))
             }),
             failure: Some(failure),
@@ -730,7 +730,7 @@ impl TimeoutError {
             cause: cause.map(Box::new),
             timeout_type: TimeoutType::from_raw(failure_info.timeout_type),
             last_heartbeat_details: failure_info.last_heartbeat_details.map(|details| {
-                DecodablePayloads::new(details.payloads, payload_converter.clone(), *context)
+                DecodablePayloads::new(details.payloads, payload_converter.clone(), context.clone())
             }),
         }
     }
@@ -781,7 +781,7 @@ impl CancelledError {
             failure,
             cause: cause.map(Box::new),
             details: failure_info.details.map(|details| {
-                DecodablePayloads::new(details.payloads, payload_converter.clone(), *context)
+                DecodablePayloads::new(details.payloads, payload_converter.clone(), context.clone())
             }),
         }
     }
@@ -1238,7 +1238,7 @@ mod tests {
     use crate::{
         data_converters::{
             DefaultFailureConverter, FailureConverter, GenericPayloadConverter, PayloadConverter,
-            SerializationContext, SerializationContextData,
+            SerializationContext, SerializationContextData, WorkflowSerializationContext,
         },
         protos::temporal::api::{
             common::v1::Payload,
@@ -1275,7 +1275,7 @@ mod tests {
             .to_error(
                 failure,
                 &PayloadConverter::default(),
-                &SerializationContextData::Workflow,
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
             )
             .unwrap();
         let IncomingError::Activity(activity) = decoded else {

--- a/crates/common-wasm/src/memo.rs
+++ b/crates/common-wasm/src/memo.rs
@@ -165,13 +165,14 @@ impl MemoValues {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::data_converters::WorkflowSerializationContext;
     use std::collections::HashMap;
 
     #[test]
     fn memo_decodes_serialized_values() {
         let payload_converter = PayloadConverter::default();
-        let context =
-            SerializationContext::new(&SerializationContextData::Workflow, &payload_converter);
+        let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+        let context = SerializationContext::new(&context_data, &payload_converter);
         let payload = payload_converter.to_payload(&context, &7_u32).unwrap();
         let raw = ProtoMemo {
             fields: HashMap::from([("count".to_owned(), payload.clone())]),
@@ -179,7 +180,7 @@ mod tests {
         let memo = Memo::from_raw(
             Some(raw.clone()),
             payload_converter,
-            SerializationContextData::Workflow,
+            SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         );
 
         assert_eq!(memo.get::<u32>("count").unwrap(), Some(7));
@@ -191,15 +192,15 @@ mod tests {
     #[test]
     fn memo_reports_deserialization_errors() {
         let payload_converter = PayloadConverter::default();
-        let context =
-            SerializationContext::new(&SerializationContextData::Workflow, &payload_converter);
+        let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+        let context = SerializationContext::new(&context_data, &payload_converter);
         let payload = payload_converter.to_payload(&context, &7_u32).unwrap();
         let memo = Memo::from_raw(
             Some(ProtoMemo {
                 fields: HashMap::from([("count".to_owned(), payload)]),
             }),
             payload_converter,
-            SerializationContextData::Workflow,
+            SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         );
 
         assert!(memo.get::<String>("count").is_err());
@@ -213,8 +214,8 @@ mod tests {
             .insert("count", 7_u32)
             .insert("label", "hello".to_string());
 
-        let context =
-            SerializationContext::new(&SerializationContextData::Workflow, &payload_converter);
+        let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+        let context = SerializationContext::new(&context_data, &payload_converter);
         let fields = values
             .iter()
             .map(|(key, value)| {
@@ -228,7 +229,7 @@ mod tests {
         let memo = Memo::from_raw(
             Some(ProtoMemo { fields }),
             payload_converter.clone(),
-            SerializationContextData::Workflow,
+            SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         );
 
         assert_eq!(memo.get::<u32>("count").unwrap(), Some(7));

--- a/crates/common/src/payload_visitor.rs
+++ b/crates/common/src/payload_visitor.rs
@@ -208,29 +208,32 @@ include!(concat!(env!("OUT_DIR"), "/payload_visitor_impl.rs"));
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protos::{
-        coresdk::{
-            activity_result::{
-                ActivityResolution, Success, activity_resolution::Status as ActivityStatus,
+    use crate::{
+        data_converters::WorkflowSerializationContext,
+        protos::{
+            coresdk::{
+                activity_result::{
+                    ActivityResolution, Success, activity_resolution::Status as ActivityStatus,
+                },
+                workflow_activation::{
+                    InitializeWorkflow, ResolveActivity, WorkflowActivation, WorkflowActivationJob,
+                    workflow_activation_job::Variant,
+                },
+                workflow_commands::{
+                    ContinueAsNewWorkflowExecution, ScheduleActivity, StartChildWorkflowExecution,
+                    UpsertWorkflowSearchAttributes, WorkflowCommand,
+                    workflow_command::Variant as CmdVariant,
+                },
+                workflow_completion::{
+                    WorkflowActivationCompletion, workflow_activation_completion::Status,
+                },
             },
-            workflow_activation::{
-                InitializeWorkflow, ResolveActivity, WorkflowActivation, WorkflowActivationJob,
-                workflow_activation_job::Variant,
+            temporal::api::{
+                common::v1::{Memo, SearchAttributes},
+                failure::v1::failure::FailureInfo,
+                workflow::v1::WorkflowExecutionInfo,
+                workflowservice::v1::DescribeWorkflowExecutionResponse,
             },
-            workflow_commands::{
-                ContinueAsNewWorkflowExecution, ScheduleActivity, StartChildWorkflowExecution,
-                UpsertWorkflowSearchAttributes, WorkflowCommand,
-                workflow_command::Variant as CmdVariant,
-            },
-            workflow_completion::{
-                WorkflowActivationCompletion, workflow_activation_completion::Status,
-            },
-        },
-        temporal::api::{
-            common::v1::{Memo, SearchAttributes},
-            failure::v1::failure::FailureInfo,
-            workflow::v1::WorkflowExecutionInfo,
-            workflowservice::v1::DescribeWorkflowExecutionResponse,
         },
     };
     use futures::FutureExt;
@@ -438,7 +441,7 @@ mod tests {
         encode_payloads(
             &mut completion,
             &MarkingCodec,
-            &SerializationContextData::Workflow,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
         .await
         .unwrap();
@@ -482,7 +485,7 @@ mod tests {
         decode_payloads(
             &mut activation,
             &MarkingCodec,
-            &SerializationContextData::Workflow,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
         .await
         .unwrap();
@@ -521,7 +524,7 @@ mod tests {
         decode_payloads(
             &mut activation,
             &MarkingCodec,
-            &SerializationContextData::Workflow,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
         .await
         .unwrap();
@@ -620,7 +623,7 @@ mod tests {
         encode_payloads(
             &mut completion,
             &MarkingCodec,
-            &SerializationContextData::Workflow,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
         .await
         .unwrap();
@@ -698,7 +701,7 @@ mod tests {
         decode_payloads(
             &mut response,
             &MarkingCodec,
-            &SerializationContextData::Workflow,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
         .await
         .unwrap();
@@ -728,7 +731,7 @@ mod tests {
         encode_payloads(
             &mut payload,
             &MarkingCodec,
-            &SerializationContextData::Workflow,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
         .await
         .unwrap();
@@ -743,7 +746,7 @@ mod tests {
         decode_payloads(
             &mut payload,
             &MarkingCodec,
-            &SerializationContextData::Workflow,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
         .await
         .unwrap();
@@ -760,7 +763,7 @@ mod tests {
         encode_payloads(
             &mut payloads,
             &MarkingCodec,
-            &SerializationContextData::Workflow,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
         .await
         .unwrap();
@@ -787,9 +790,13 @@ mod tests {
             ..Default::default()
         };
 
-        let err = decode_payloads(&mut activation, &codec, &SerializationContextData::Workflow)
-            .await
-            .unwrap_err();
+        let err = decode_payloads(
+            &mut activation,
+            &codec,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+        )
+        .await
+        .unwrap_err();
 
         assert_eq!(err.to_string(), "Encoding error: visitor decode failed");
         assert_eq!(codec.decode_calls.load(Ordering::SeqCst), 1);
@@ -806,13 +813,13 @@ mod tests {
                     .build(),
             ))),
             &PayloadConverter::default(),
-            &SerializationContextData::Workflow,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         );
 
         encode_payloads(
             &mut failure,
             &MarkingCodec,
-            &SerializationContextData::Workflow,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
         .await
         .unwrap();

--- a/crates/macros/src/workflow_definitions.rs
+++ b/crates/macros/src/workflow_definitions.rs
@@ -75,8 +75,11 @@ fn generate_decode_arm(
 ) -> TokenStream2 {
     quote! {
         #handler_name => {
+            let context_data = ::temporalio_workflow::common::data_converters::SerializationContextData::Workflow(
+                ::temporalio_workflow::common::data_converters::WorkflowSerializationContext::new()
+            );
             let ctx = ::temporalio_workflow::common::data_converters::SerializationContext::new(
-                &::temporalio_workflow::common::data_converters::SerializationContextData::Workflow,
+                &context_data,
                 converter,
             );
             let input: #input_type = <::temporalio_workflow::common::data_converters::PayloadConverter as ::temporalio_workflow::common::data_converters::GenericPayloadConverter>::from_payloads(

--- a/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/data_converter_tests.rs
@@ -934,10 +934,10 @@ impl PayloadCodec for FailOnceCodec {
             (self.failure_point, context),
             (
                 CodecFailurePoint::WorkflowEncode,
-                SerializationContextData::Workflow
+                SerializationContextData::Workflow(_)
             ) | (
                 CodecFailurePoint::ActivityEncode,
-                SerializationContextData::Activity
+                SerializationContextData::Activity(_)
             )
         );
         let marker = if matches!(self.failure_point, CodecFailurePoint::WorkflowEncode) {
@@ -977,10 +977,10 @@ impl PayloadCodec for FailOnceCodec {
             (self.failure_point, context),
             (
                 CodecFailurePoint::WorkflowDecode,
-                SerializationContextData::Workflow
+                SerializationContextData::Workflow(_)
             ) | (
                 CodecFailurePoint::ActivityDecode,
-                SerializationContextData::Activity
+                SerializationContextData::Activity(_)
             )
         );
         let matches_payload = payloads.iter().any(|payload| {

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/nexus.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/nexus.rs
@@ -17,7 +17,7 @@ use temporalio_client::{
 use temporalio_common::{
     data_converters::{
         GenericPayloadConverter, PayloadConverter, RawValue, SerializationContext,
-        SerializationContextData,
+        SerializationContextData, WorkflowSerializationContext,
     },
     protos::{
         coresdk::{
@@ -348,7 +348,8 @@ async fn nexus_async(
 
     let submitter = worker.get_submitter_handle();
     let converter = PayloadConverter::default();
-    let ser_ctx = SerializationContext::new(&SerializationContextData::Workflow, &converter);
+    let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+    let ser_ctx = SerializationContext::new(&context_data, &converter);
     let wf_handle = worker
         .submit_workflow(
             NexusAsyncWf::run,

--- a/crates/sdk/src/activities.rs
+++ b/crates/sdk/src/activities.rs
@@ -76,9 +76,9 @@ pub use temporalio_common::ActivityError;
 use temporalio_common::{
     ActivityDefinition, HasWorkflowDefinition, RetryPolicy,
     data_converters::{
-        DataConverter, DecodablePayloads, GenericPayloadConverter, PayloadConversionError,
-        PayloadConverter, RawValue, SerializationContext, SerializationContextData,
-        TemporalDeserializable, TemporalSerializable,
+        ActivitySerializationContext, DataConverter, DecodablePayloads, GenericPayloadConverter,
+        PayloadConversionError, PayloadConverter, RawValue, SerializationContext,
+        SerializationContextData, TemporalDeserializable, TemporalSerializable,
     },
     error::ApplicationFailure,
     protos::{
@@ -132,7 +132,10 @@ impl ActivityContextBackend {
             } => {
                 let details = client_options
                     .data_converter
-                    .to_payloads(&SerializationContextData::Activity, &details)
+                    .to_payloads(
+                        &SerializationContextData::Activity(ActivitySerializationContext::new()),
+                        &details,
+                    )
                     .await?;
                 worker.record_activity_heartbeat(ActivityHeartbeat {
                     task_token: task_token.to_vec(),
@@ -356,7 +359,7 @@ impl ActivityHeartbeatDetails {
             payloads: DecodablePayloads::new(
                 payloads,
                 payload_converter,
-                SerializationContextData::Activity,
+                SerializationContextData::Activity(ActivitySerializationContext::new()),
             ),
         }
     }
@@ -573,7 +576,9 @@ impl ActivityDefinitions {
                     // Codec application happens at the SDK/Core boundary, so activity
                     // implementations work with the payload converter directly.
                     let pc = dc.payload_converter();
-                    let ctx = SerializationContext::new(&SerializationContextData::Activity, pc);
+                    let context_data =
+                        SerializationContextData::Activity(ActivitySerializationContext::new());
+                    let ctx = SerializationContext::new(&context_data, pc);
                     let input: AD::Input = pc.from_payloads(&ctx, payloads)?;
                     let input = ExecuteActivityInput::new(c, Box::new(input));
                     let leaf = activity_inbound_base::<AD>(instance);
@@ -658,11 +663,11 @@ pub(crate) fn activity_error_to_core_result(
 ) -> ActivityExecutionResult {
     match err {
         ActivityError::Application(app) => ActivityExecutionResult::fail(dc.to_failure(
-            &SerializationContextData::Activity,
+            &SerializationContextData::Activity(ActivitySerializationContext::new()),
             OutgoingError::Activity(OutgoingActivityError::Application(app)),
         )),
         ActivityError::Cancelled { details } => ActivityExecutionResult::cancel(dc.to_failure(
-            &SerializationContextData::Activity,
+            &SerializationContextData::Activity(ActivitySerializationContext::new()),
             OutgoingError::Activity(OutgoingActivityError::Cancelled { details }),
         )),
         ActivityError::WillCompleteAsync => ActivityExecutionResult::will_complete_async(),
@@ -688,7 +693,10 @@ mod test {
         let payload_converter = PayloadConverter::default();
         let payload = payload_converter
             .to_payload(
-                &SerializationContext::new(&SerializationContextData::Activity, &payload_converter),
+                &SerializationContext::new(
+                    &SerializationContextData::Activity(ActivitySerializationContext::new()),
+                    &payload_converter,
+                ),
                 &"progress".to_owned(),
             )
             .unwrap();

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -134,7 +134,10 @@ use std::{
 use temporalio_client::{Client, ClientOptions, NamespacedClient};
 use temporalio_common::{
     ActivityDefinition, WorkflowDefinition,
-    data_converters::{DataConverter, SerializationContext, SerializationContextData},
+    data_converters::{
+        ActivitySerializationContext, DataConverter, SerializationContext,
+        SerializationContextData, WorkflowSerializationContext,
+    },
     payload_visitor::{decode_payloads, encode_payloads},
     protos::{
         TaskToken,
@@ -740,7 +743,7 @@ async fn encode_workflow_completion(
     if let Err(err) = encode_payloads(
         completion,
         data_converter.codec(),
-        &SerializationContextData::Workflow,
+        &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
     )
     .await
     {
@@ -763,7 +766,7 @@ async fn encode_activity_completion(
     if let Err(err) = encode_payloads(
         completion,
         data_converter.codec(),
-        &SerializationContextData::Activity,
+        &SerializationContextData::Activity(ActivitySerializationContext::new()),
     )
     .await
     {
@@ -1016,7 +1019,7 @@ impl Worker {
                             if let Err(err) = decode_payloads(
                                 &mut activation,
                                 common.data_converter.codec(),
-                                &SerializationContextData::Workflow,
+                                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                             )
                             .await
                             {
@@ -1099,12 +1102,15 @@ impl Worker {
                             message: "activity polling failed".to_owned(),
                             source: Box::new(source),
                         })?;
-                        if let Err(err) = decode_payloads(
-                            &mut activity,
-                            common.data_converter.codec(),
-                            &SerializationContextData::Activity,
-                        )
-                        .await
+                        if let Err(err) =
+                            decode_payloads(
+                                &mut activity,
+                                common.data_converter.codec(),
+                                &SerializationContextData::Activity(
+                                    ActivitySerializationContext::new(),
+                                ),
+                            )
+                            .await
                         {
                             error!(error = %err, "Failed decoding activity task");
                             let mut completion = ActivityTaskCompletion {
@@ -1142,7 +1148,9 @@ impl Worker {
                                 task_token,
                             }) => {
                                 let failure = common.data_converter.to_failure(
-                                    &SerializationContextData::Activity,
+                                    &SerializationContextData::Activity(
+                                        ActivitySerializationContext::new(),
+                                    ),
                                     OutgoingError::Activity(OutgoingActivityError::Application(
                                         ApplicationFailure::builder(source)
                                             .type_name("NotFoundError".to_owned())
@@ -1415,8 +1423,10 @@ impl ActivityHalf {
                             // Codec application happens at the SDK/Core boundary, so activity
                             // implementations work with the payload converter directly.
                             let pc = codec_data_converter.payload_converter();
-                            let ctx =
-                                SerializationContext::new(&SerializationContextData::Activity, pc);
+                            let context_data = SerializationContextData::Activity(
+                                ActivitySerializationContext::new(),
+                            );
+                            let ctx = SerializationContext::new(&context_data, pc);
                             match output.serialize_payload(&ctx) {
                                 Ok(payload) => ActivityExecutionResult::ok(payload),
                                 Err(err) => {

--- a/crates/sdk/src/testing.rs
+++ b/crates/sdk/src/testing.rs
@@ -78,8 +78,8 @@ use temporalio_client::{
 use temporalio_common::{
     RetryPolicy,
     data_converters::{
-        GenericPayloadConverter, PayloadConversionError, PayloadConverter, SerializationContext,
-        SerializationContextData, TemporalSerializable,
+        ActivitySerializationContext, GenericPayloadConverter, PayloadConversionError,
+        PayloadConverter, SerializationContext, SerializationContextData, TemporalSerializable,
     },
     protos::temporal::api::common::v1::Payload,
 };
@@ -242,8 +242,8 @@ where
         let payload_converter = self
             .payload_converter_ref()
             .expect("payload converter must be set in builder state");
-        let context =
-            SerializationContext::new(&SerializationContextData::Activity, payload_converter);
+        let context_data = SerializationContextData::Activity(ActivitySerializationContext::new());
+        let context = SerializationContext::new(&context_data, payload_converter);
         self.heartbeat_details = payload_converter.to_payloads(&context, &details)?;
         Ok(self)
     }

--- a/crates/sdk/src/workflow_registry.rs
+++ b/crates/sdk/src/workflow_registry.rs
@@ -5,7 +5,7 @@ use temporalio_common::{
     WorkflowDefinition,
     data_converters::{
         DataConverter, GenericPayloadConverter, PayloadConverter, SerializationContext,
-        SerializationContextData,
+        SerializationContextData, WorkflowSerializationContext,
     },
     protos::{
         coresdk::workflow_activation::InitializeWorkflow, temporal::api::common::v1::Payload,
@@ -126,8 +126,9 @@ impl WorkflowDefinitions {
 
         let factory = Arc::new(move |input| {
             let (payloads, payload_converter, base_ctx) = workflow_input_parts(input);
-            let ser_ctx =
-                SerializationContext::new(&SerializationContextData::Workflow, &payload_converter);
+            let context_data =
+                SerializationContextData::Workflow(WorkflowSerializationContext::new());
+            let ser_ctx = SerializationContext::new(&context_data, &payload_converter);
             let input: <W::Run as WorkflowDefinition>::Input =
                 payload_converter.from_payloads(&ser_ctx, payloads)?;
 

--- a/crates/workflow/src/runtime/entry.rs
+++ b/crates/workflow/src/runtime/entry.rs
@@ -14,7 +14,7 @@ use temporalio_common_wasm::{
     QueryDefinition, SignalDefinition, UpdateDefinition, WorkflowDefinition,
     data_converters::{
         GenericPayloadConverter, PayloadConversionError, PayloadConverter, SerializationContext,
-        SerializationContextData, TemporalSerializable,
+        SerializationContextData, TemporalSerializable, WorkflowSerializationContext,
     },
     protos::temporal::api::{
         common::v1::{Payload, Payloads},
@@ -288,7 +288,8 @@ pub(crate) fn serialize_output<O: TemporalSerializable + 'static>(
     output: &O,
     converter: &PayloadConverter,
 ) -> Result<Payload, WorkflowError> {
-    let ctx = SerializationContext::new(&SerializationContextData::Workflow, converter);
+    let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+    let ctx = SerializationContext::new(&context_data, converter);
     converter.to_payload(&ctx, output).map_err(Into::into)
 }
 

--- a/crates/workflow/src/runtime/instance.rs
+++ b/crates/workflow/src/runtime/instance.rs
@@ -44,7 +44,7 @@ use temporalio_common_wasm::{
     WorkflowDefinition,
     data_converters::{
         GenericPayloadConverter, PayloadConversionError, PayloadConverter, SerializationContext,
-        SerializationContextData,
+        SerializationContextData, WorkflowSerializationContext,
     },
     error::{ApplicationFailure, OutgoingError, OutgoingWorkflowError},
     protos::{
@@ -367,7 +367,8 @@ where
     ) -> Result<Box<dyn WorkflowInstance>, PayloadConversionError> {
         let view = base_ctx.view();
         let interceptors = base_ctx.workflow_interceptors();
-        let ser_ctx = SerializationContext::new(&SerializationContextData::Workflow, &converter);
+        let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+        let ser_ctx = SerializationContext::new(&context_data, &converter);
         let input = converter.from_payloads(&ser_ctx, payloads)?;
         let (init_input, run_input) = if W::INIT_TAKES_INPUT {
             (Some(input), None)
@@ -450,7 +451,8 @@ where
         }
 
         let converter = PayloadConverter::default();
-        let ctx = SerializationContext::new(&SerializationContextData::Workflow, &converter);
+        let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+        let ctx = SerializationContext::new(&context_data, &converter);
         QueryResponse {
             result: converter
                 .to_payload(
@@ -480,14 +482,14 @@ where
             }
         };
         self.base_ctx.data_converter().to_failure(
-            &SerializationContextData::Workflow,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
             OutgoingError::Workflow(outgoing),
         )
     }
 
     fn message_to_failure(&self, message: String) -> Failure {
         self.base_ctx.data_converter().to_failure(
-            &SerializationContextData::Workflow,
+            &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
             OutgoingError::Workflow(OutgoingWorkflowError::Application(Box::new(
                 ApplicationFailure::new(message),
             ))),
@@ -791,7 +793,9 @@ where
                     .map(|details| {
                         (&*details as &dyn WorkflowOutputValue)
                             .serialize_payloads(&SerializationContext::new(
-                                &SerializationContextData::Workflow,
+                                &SerializationContextData::Workflow(
+                                    WorkflowSerializationContext::new(),
+                                ),
                                 self.ctx.payload_converter(),
                             ))
                             .map(|payloads| Payloads { payloads })
@@ -828,7 +832,7 @@ where
                     return Ok(TerminalOutcome::Cancelled(details));
                 }
                 let failure = self.base_ctx.data_converter().to_failure(
-                    &SerializationContextData::Workflow,
+                    &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                     temporalio_common_wasm::error::OutgoingError::Workflow(err),
                 );
                 Ok(TerminalOutcome::Failed(Box::new(failure)))

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -65,7 +65,7 @@ use temporalio_common_wasm::{
         ActivityExecutionDecodeHint, ChildWorkflowExecutionDecodeHint,
         ChildWorkflowStartDecodeHint, DataConverter, GenericPayloadConverter,
         PayloadConversionError, PayloadConverter, SerializationContext, SerializationContextData,
-        TemporalDeserializable, WorkflowSignalDecodeHint,
+        TemporalDeserializable, WorkflowSerializationContext, WorkflowSignalDecodeHint,
     },
     error::{
         ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowStartError,
@@ -858,8 +858,9 @@ impl BaseWorkflowContext {
                 }
             };
             let payload_converter = base_ctx.inner.data_converter.payload_converter();
-            let ctx =
-                SerializationContext::new(&SerializationContextData::Workflow, payload_converter);
+            let context_data =
+                SerializationContextData::Workflow(WorkflowSerializationContext::new());
+            let ctx = SerializationContext::new(&context_data, payload_converter);
             match payload_converter.to_payloads(&ctx, &input) {
                 Ok(payloads) => {
                     let cancellation_token = opts
@@ -952,8 +953,9 @@ impl BaseWorkflowContext {
                 }
             };
             let payload_converter = base_ctx.inner.data_converter.payload_converter();
-            let ctx =
-                SerializationContext::new(&SerializationContextData::Workflow, payload_converter);
+            let context_data =
+                SerializationContextData::Workflow(WorkflowSerializationContext::new());
+            let ctx = SerializationContext::new(&context_data, payload_converter);
             match payload_converter.to_payloads(&ctx, &input) {
                 Ok(payloads) => {
                     let cancellation_token = opts
@@ -1034,8 +1036,9 @@ impl BaseWorkflowContext {
                 }
             };
             let payload_converter = base_ctx.inner.data_converter.payload_converter();
-            let ctx =
-                SerializationContext::new(&SerializationContextData::Workflow, payload_converter);
+            let context_data =
+                SerializationContextData::Workflow(WorkflowSerializationContext::new());
+            let ctx = SerializationContext::new(&context_data, payload_converter);
             let payloads = match payload_converter.to_payloads(&ctx, &input) {
                 Ok(payloads) => payloads,
                 Err(err) => {
@@ -1186,8 +1189,9 @@ impl BaseWorkflowContext {
                 }
             };
             let payload_converter = base_ctx.data_converter().payload_converter();
-            let ctx =
-                SerializationContext::new(&SerializationContextData::Workflow, payload_converter);
+            let context_data =
+                SerializationContextData::Workflow(WorkflowSerializationContext::new());
+            let ctx = SerializationContext::new(&context_data, payload_converter);
             let payloads = match payload_converter.to_payloads(&ctx, &input) {
                 Ok(payloads) => payloads,
                 Err(err) => {
@@ -1419,7 +1423,7 @@ impl<W> SyncWorkflowContext<W> {
         Memo::from_raw(
             Some(self.base.inner.shared.borrow().memo.clone()),
             self.payload_converter().clone(),
-            SerializationContextData::Workflow,
+            SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
     }
 
@@ -1535,7 +1539,9 @@ impl<W> SyncWorkflowContext<W> {
                 Err(_) => return Err(outbound_type_error("continue-as-new input").into()),
             };
             let pc = base_ctx.data_converter().payload_converter();
-            let ctx = SerializationContext::new(&SerializationContextData::Workflow, pc);
+            let context_data =
+                SerializationContextData::Workflow(WorkflowSerializationContext::new());
+            let ctx = SerializationContext::new(&context_data, pc);
             let arguments = pc
                 .to_payloads(&ctx, &*input)
                 .map_err(WorkflowTermination::from)?;
@@ -1759,8 +1765,8 @@ impl<W> SyncWorkflowContext<W> {
         K: Into<String>,
     {
         let payload_converter = self.payload_converter();
-        let context =
-            SerializationContext::new(&SerializationContextData::Workflow, payload_converter);
+        let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+        let context = SerializationContext::new(&context_data, payload_converter);
         let mut fields = HashMap::new();
         let mut local_updates = Vec::new();
         for (key, value) in updates {
@@ -2653,60 +2659,72 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
-        let poll = match this {
-            ActivityFut::Errored { error, .. } => {
-                Poll::Ready(Err(*error.take().expect("polled after completion")))
-            }
-            ActivityFut::Running {
-                inner,
-                data_converter,
-                ..
-            } => match Pin::new(inner).poll(cx) {
-                Poll::Pending => Poll::Pending,
-                Poll::Ready(resolution) => Poll::Ready({
-                    let status = resolution.status.ok_or_else(|| {
-                        data_converter
-                            .to_error(
-                                &SerializationContextData::Workflow,
-                                Failure {
-                                    message: "Activity completed without a status".to_string(),
-                                    ..Default::default()
-                                },
-                                ActivityExecutionDecodeHint::new(false),
-                            )
-                            .expect("synthetic activity failure should decode")
-                    })?;
-
-                    match status {
-                        activity_resolution::Status::Completed(success) => {
-                            let payload = success.result.unwrap_or_default();
-                            let ctx = SerializationContext::new(
-                                &SerializationContextData::Workflow,
-                                data_converter.payload_converter(),
-                            );
+        let poll =
+            match this {
+                ActivityFut::Errored { error, .. } => {
+                    Poll::Ready(Err(*error.take().expect("polled after completion")))
+                }
+                ActivityFut::Running {
+                    inner,
+                    data_converter,
+                    ..
+                } => match Pin::new(inner).poll(cx) {
+                    Poll::Pending => Poll::Pending,
+                    Poll::Ready(resolution) => Poll::Ready({
+                        let status = resolution.status.ok_or_else(|| {
                             data_converter
-                                .payload_converter()
-                                .from_payload::<Output>(&ctx, payload)
-                                .map_err(ActivityExecutionError::Serialization)
+                                .to_error(
+                                    &SerializationContextData::Workflow(
+                                        WorkflowSerializationContext::new(),
+                                    ),
+                                    Failure {
+                                        message: "Activity completed without a status".to_string(),
+                                        ..Default::default()
+                                    },
+                                    ActivityExecutionDecodeHint::new(false),
+                                )
+                                .expect("synthetic activity failure should decode")
+                        })?;
+
+                        match status {
+                            activity_resolution::Status::Completed(success) => {
+                                let payload = success.result.unwrap_or_default();
+                                let context_data = SerializationContextData::Workflow(
+                                    WorkflowSerializationContext::new(),
+                                );
+                                let ctx = SerializationContext::new(
+                                    &context_data,
+                                    data_converter.payload_converter(),
+                                );
+                                data_converter
+                                    .payload_converter()
+                                    .from_payload::<Output>(&ctx, payload)
+                                    .map_err(ActivityExecutionError::Serialization)
+                            }
+                            activity_resolution::Status::Failed(f) => Err(data_converter
+                                .to_error(
+                                    &SerializationContextData::Workflow(
+                                        WorkflowSerializationContext::new(),
+                                    ),
+                                    f.failure.unwrap_or_default(),
+                                    ActivityExecutionDecodeHint::new(false),
+                                )?),
+                            activity_resolution::Status::Cancelled(c) => Err(data_converter
+                                .to_error(
+                                    &SerializationContextData::Workflow(
+                                        WorkflowSerializationContext::new(),
+                                    ),
+                                    c.failure.unwrap_or_default(),
+                                    ActivityExecutionDecodeHint::new(true),
+                                )?),
+                            activity_resolution::Status::Backoff(_) => {
+                                panic!("DoBackoff should be handled by LATimerBackoffFut")
+                            }
                         }
-                        activity_resolution::Status::Failed(f) => Err(data_converter.to_error(
-                            &SerializationContextData::Workflow,
-                            f.failure.unwrap_or_default(),
-                            ActivityExecutionDecodeHint::new(false),
-                        )?),
-                        activity_resolution::Status::Cancelled(c) => Err(data_converter.to_error(
-                            &SerializationContextData::Workflow,
-                            c.failure.unwrap_or_default(),
-                            ActivityExecutionDecodeHint::new(true),
-                        )?),
-                        activity_resolution::Status::Backoff(_) => {
-                            panic!("DoBackoff should be handled by LATimerBackoffFut")
-                        }
-                    }
-                }),
-            },
-            ActivityFut::Terminated => panic!("polled after termination"),
-        };
+                    }),
+                },
+                ActivityFut::Terminated => panic!("polled after termination"),
+            };
         if poll.is_ready() {
             *this = ActivityFut::Terminated;
         }
@@ -2838,7 +2856,9 @@ where
                     let status = result.status.ok_or_else(|| {
                         data_converter
                             .to_error(
-                                &SerializationContextData::Workflow,
+                                &SerializationContextData::Workflow(
+                                    WorkflowSerializationContext::new(),
+                                ),
                                 Failure {
                                     message: "Child workflow completed without a status"
                                         .to_string(),
@@ -2851,8 +2871,11 @@ where
                     match status {
                         child_workflow_result::Status::Completed(success) => {
                             let payloads = success.result.into_iter().collect();
+                            let context_data = SerializationContextData::Workflow(
+                                WorkflowSerializationContext::new(),
+                            );
                             let ctx = SerializationContext::new(
-                                &SerializationContextData::Workflow,
+                                &context_data,
                                 data_converter.payload_converter(),
                             );
                             data_converter
@@ -2860,14 +2883,20 @@ where
                                 .from_payloads::<Output>(&ctx, payloads)
                                 .map_err(ChildWorkflowExecutionError::Serialization)
                         }
-                        child_workflow_result::Status::Failed(f) => Err(data_converter.to_error(
-                            &SerializationContextData::Workflow,
-                            f.failure.unwrap_or_default(),
-                            ChildWorkflowExecutionDecodeHint::default(),
-                        )?),
+                        child_workflow_result::Status::Failed(f) => {
+                            Err(data_converter.to_error(
+                                &SerializationContextData::Workflow(
+                                    WorkflowSerializationContext::new(),
+                                ),
+                                f.failure.unwrap_or_default(),
+                                ChildWorkflowExecutionDecodeHint::default(),
+                            )?)
+                        }
                         child_workflow_result::Status::Cancelled(c) => Err(data_converter
                             .to_error(
-                                &SerializationContextData::Workflow,
+                                &SerializationContextData::Workflow(
+                                    WorkflowSerializationContext::new(),
+                                ),
                                 c.failure.unwrap_or_default(),
                                 ChildWorkflowExecutionDecodeHint::default(),
                             )?),
@@ -2949,55 +2978,58 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
-        let poll = match this {
-            ChildWorkflowStartFut::Errored { error, .. } => {
-                Poll::Ready(Err(*error.take().expect("polled after completion")))
-            }
-            ChildWorkflowStartFut::Running(inner) => match Pin::new(inner).poll(cx) {
-                Poll::Pending => Poll::Pending,
-                Poll::Ready(pending) => Poll::Ready(match pending.status {
-                    ChildWorkflowStartStatus::Succeeded(s) => {
-                        let ChildWfCommon {
-                            workflow_id,
-                            child_seq,
-                            result_future,
-                            base_ctx,
-                        } = pending.common;
-                        Ok(StartChildWorkflowOutput {
-                            run_id: s.run_id,
-                            result_future,
-                            workflow_id,
-                            child_seq,
-                            base_ctx,
-                        })
-                    }
-                    ChildWorkflowStartStatus::Failed(f) => {
-                        let mut result_future = pending.common.result_future;
-                        result_future.unregister_cancellation();
-                        Err(ChildWorkflowStartError::StartFailed {
-                            workflow_id: f.workflow_id,
-                            workflow_type: f.workflow_type,
-                            cause: StartChildWorkflowExecutionFailedCause::try_from(f.cause)
-                                .unwrap_or(StartChildWorkflowExecutionFailedCause::Unspecified),
-                        })
-                    }
-                    ChildWorkflowStartStatus::Cancelled(c) => {
-                        let ChildWfCommon {
-                            mut result_future,
-                            base_ctx,
-                            ..
-                        } = pending.common;
-                        result_future.unregister_cancellation();
-                        Err(base_ctx.data_converter().to_error(
-                            &SerializationContextData::Workflow,
-                            c.failure.unwrap_or_default(),
-                            ChildWorkflowStartDecodeHint::default(),
-                        )?)
-                    }
-                }),
-            },
-            ChildWorkflowStartFut::Terminated => panic!("polled after termination"),
-        };
+        let poll =
+            match this {
+                ChildWorkflowStartFut::Errored { error, .. } => {
+                    Poll::Ready(Err(*error.take().expect("polled after completion")))
+                }
+                ChildWorkflowStartFut::Running(inner) => match Pin::new(inner).poll(cx) {
+                    Poll::Pending => Poll::Pending,
+                    Poll::Ready(pending) => Poll::Ready(match pending.status {
+                        ChildWorkflowStartStatus::Succeeded(s) => {
+                            let ChildWfCommon {
+                                workflow_id,
+                                child_seq,
+                                result_future,
+                                base_ctx,
+                            } = pending.common;
+                            Ok(StartChildWorkflowOutput {
+                                run_id: s.run_id,
+                                result_future,
+                                workflow_id,
+                                child_seq,
+                                base_ctx,
+                            })
+                        }
+                        ChildWorkflowStartStatus::Failed(f) => {
+                            let mut result_future = pending.common.result_future;
+                            result_future.unregister_cancellation();
+                            Err(ChildWorkflowStartError::StartFailed {
+                                workflow_id: f.workflow_id,
+                                workflow_type: f.workflow_type,
+                                cause: StartChildWorkflowExecutionFailedCause::try_from(f.cause)
+                                    .unwrap_or(StartChildWorkflowExecutionFailedCause::Unspecified),
+                            })
+                        }
+                        ChildWorkflowStartStatus::Cancelled(c) => {
+                            let ChildWfCommon {
+                                mut result_future,
+                                base_ctx,
+                                ..
+                            } = pending.common;
+                            result_future.unregister_cancellation();
+                            Err(base_ctx.data_converter().to_error(
+                                &SerializationContextData::Workflow(
+                                    WorkflowSerializationContext::new(),
+                                ),
+                                c.failure.unwrap_or_default(),
+                                ChildWorkflowStartDecodeHint::default(),
+                            )?)
+                        }
+                    }),
+                },
+                ChildWorkflowStartFut::Terminated => panic!("polled after termination"),
+            };
         if poll.is_ready() {
             *this = ChildWorkflowStartFut::Terminated;
         }
@@ -3066,7 +3098,7 @@ where
                 Poll::Pending => Poll::Pending,
                 Poll::Ready(Ok(_)) => Poll::Ready(Ok(())),
                 Poll::Ready(Err(failure)) => Poll::Ready(Err(data_converter.to_error(
-                    &SerializationContextData::Workflow,
+                    &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                     failure,
                     WorkflowSignalDecodeHint::default(),
                 )?)),
@@ -4434,7 +4466,10 @@ mod tests {
         let payload_converter = PayloadConverter::default();
         let removal_payload = payload_converter
             .to_payload(
-                &SerializationContext::new(&SerializationContextData::Workflow, &payload_converter),
+                &SerializationContext::new(
+                    &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+                    &payload_converter,
+                ),
                 &MemoValue::new(()),
             )
             .unwrap();

--- a/crates/workflow/src/workflow_context/options.rs
+++ b/crates/workflow/src/workflow_context/options.rs
@@ -5,7 +5,7 @@ use temporalio_common_wasm::{
     ActivityCloseTimeouts, Priority, RetryPolicy,
     data_converters::{
         GenericPayloadConverter, PayloadConversionError, PayloadConverter, SerializationContext,
-        SerializationContextData,
+        SerializationContextData, WorkflowSerializationContext,
     },
     protos::{
         coresdk::{
@@ -877,8 +877,8 @@ impl ContinueAsNewOptions {
         headers: HashMap<String, Payload>,
         payload_converter: &PayloadConverter,
     ) -> Result<ContinueAsNewRequest, PayloadConversionError> {
-        let context =
-            SerializationContext::new(&SerializationContextData::Workflow, payload_converter);
+        let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+        let context = SerializationContext::new(&context_data, payload_converter);
         let memo = self
             .memo
             .map(|memo| {
@@ -941,7 +941,8 @@ fn string_user_metadata(summary: Option<String>, details: Option<String>) -> Opt
         return None;
     }
     let converter = PayloadConverter::default();
-    let context = SerializationContext::new(&SerializationContextData::Workflow, &converter);
+    let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+    let context = SerializationContext::new(&context_data, &converter);
     Some(UserMetadata {
         summary: summary.map(|value| {
             converter

--- a/crates/workflow/src/workflow_context/view.rs
+++ b/crates/workflow/src/workflow_context/view.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, SystemTime};
 
 use temporalio_common_wasm::{
     Memo, Priority, RetryPolicy, WorkflowExecution,
-    data_converters::{PayloadConverter, SerializationContextData},
+    data_converters::{PayloadConverter, SerializationContextData, WorkflowSerializationContext},
     protos::coresdk::{
         common::NamespacedWorkflowExecution, workflow_activation::InitializeWorkflow,
     },
@@ -144,7 +144,7 @@ impl WorkflowContextView {
         Memo::from_raw(
             self.raw.memo.clone(),
             self.payload_converter.clone(),
-            SerializationContextData::Workflow,
+            SerializationContextData::Workflow(WorkflowSerializationContext::new()),
         )
     }
 

--- a/crates/workflow/src/workflow_interceptors.rs
+++ b/crates/workflow/src/workflow_interceptors.rs
@@ -115,6 +115,7 @@ use temporalio_common_wasm::{
     data_converters::{
         GenericPayloadConverter, PayloadConversionError, PayloadConverter, SerializationContext,
         SerializationContextData, TemporalDeserializable, TemporalSerializable,
+        WorkflowSerializationContext,
     },
     error::{
         ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowStartError,
@@ -199,7 +200,8 @@ pub(crate) fn serialize_workflow_output(
     output: &dyn WorkflowOutputValue,
     converter: &PayloadConverter,
 ) -> Result<Payload, PayloadConversionError> {
-    let ctx = SerializationContext::new(&SerializationContextData::Workflow, converter);
+    let context_data = SerializationContextData::Workflow(WorkflowSerializationContext::new());
+    let ctx = SerializationContext::new(&context_data, converter);
     output.serialize_payload(&ctx)
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add some empty structs to the variants on the serialization context so we can add data there in the future.

Dropped `Copy` implementation since these won't be `Copy`able once they contain real data.

Constructing these is experimental as the signature will change in the future when these need data.

## Why?
At the moment adding data here would be a breaking change.

We could remove the variants and only have `None`, but that feels a little bit like throwing the baby out with the bathwater. We already have the variants wired up in the codebase.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
