### PR TITLE
chore(sdk): rename local activity argument inclusion option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ relevant information.
 ### Added
 * `DefaultFailureConverter::new(true)` moves failure messages and stack traces into encoded
   attributes so payload codecs can encrypt them.
-* `LocalActivityOptions::include_arguments_into_marker` allows Rust workflows to opt in to
+* `LocalActivityOptions::include_arguments_in_marker` allows Rust workflows to opt in to
   recording local activity arguments in Workflow history.
 * `WorkflowHandle::get_update_handle` creates a typed handle for an existing Workflow Update from
   its update ID, allowing callers to wait for the result independently of the original handle.

--- a/crates/protos/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
+++ b/crates/protos/protos/local/temporal/sdk/core/workflow_commands/workflow_commands.proto
@@ -151,7 +151,7 @@ message ScheduleLocalActivity {
     // If set, the local activity arguments will be included in the resulting marker under the
     // `input` key. This is disabled by default to avoid increasing history size unless the lang
     // SDK explicitly chooses to expose it.
-    bool include_arguments_into_marker = 14;
+    bool include_arguments_in_marker = 14;
 }
 
 enum ActivityCancellationType {

--- a/crates/sdk-core/src/protosext/mod.rs
+++ b/crates/sdk-core/src/protosext/mod.rs
@@ -322,7 +322,7 @@ pub(crate) struct ValidScheduleLA {
     pub(crate) retry_policy: ValidatedRetryPolicy,
     pub(crate) local_retry_threshold: Duration,
     pub(crate) cancellation_type: ActivityCancellationType,
-    pub(crate) include_arguments_into_marker: bool,
+    pub(crate) include_arguments_in_marker: bool,
     pub(crate) user_metadata: Option<UserMetadata>,
     pub(crate) event_group_markers: Vec<EventGroupMarker>,
 }
@@ -433,7 +433,7 @@ impl ValidScheduleLA {
             retry_policy,
             local_retry_threshold,
             cancellation_type,
-            include_arguments_into_marker: v.include_arguments_into_marker,
+            include_arguments_in_marker: v.include_arguments_in_marker,
             user_metadata,
             event_group_markers,
         })

--- a/crates/sdk-core/src/worker/workflow/machines/local_activity_state_machine.rs
+++ b/crates/sdk-core/src/worker/workflow/machines/local_activity_state_machine.rs
@@ -726,7 +726,7 @@ impl WFMachinesAdapter for LocalActivityMachine {
                         },
                         maybe_ok_result,
                     );
-                    if self.shared_state.attrs.include_arguments_into_marker {
+                    if self.shared_state.attrs.include_arguments_in_marker {
                         details.insert(
                             "input".to_string(),
                             Payloads {

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -3022,7 +3022,7 @@ async fn local_activity_marker_optionally_includes_arguments(#[case] include_arg
             activity_type: "test_act".to_string(),
             arguments,
             start_to_close_timeout: Some(prost_dur!(from_secs(30))),
-            include_arguments_into_marker: include_arguments,
+            include_arguments_in_marker: include_arguments,
             ..Default::default()
         }
         .into(),

--- a/crates/workflow/src/workflow_context/options.rs
+++ b/crates/workflow/src/workflow_context/options.rs
@@ -431,7 +431,7 @@ pub struct LocalActivityOptions {
     /// Enabling this makes the arguments visible in Workflow history and increases its size.
     /// Defaults to `false`.
     #[builder(default)]
-    pub include_arguments_into_marker: bool,
+    pub include_arguments_in_marker: bool,
     /// Cancellation token for this local activity. `None` inherits workflow cancellation.
     pub cancellation_token: Option<WorkflowCancellationToken>,
     /// Indicates how long the caller is willing to wait for local activity completion. Limits how
@@ -492,7 +492,7 @@ impl LocalActivityOptions {
                     .timer_backoff_threshold
                     .and_then(|duration| duration.try_into().ok()),
                 cancellation_type: ProtoActivityCancellationType::from(self.cancel_type).into(),
-                include_arguments_into_marker: self.include_arguments_into_marker,
+                include_arguments_in_marker: self.include_arguments_in_marker,
                 schedule_to_close_timeout: self
                     .schedule_to_close_timeout
                     .and_then(|duration| duration.try_into().ok()),
@@ -1088,7 +1088,7 @@ mod tests {
             HashMap::new(),
         );
         let enabled_command = LocalActivityOptions::builder()
-            .include_arguments_into_marker(true)
+            .include_arguments_in_marker(true)
             .build()
             .into_command(1, "test".to_string(), vec![], HashMap::new());
 
@@ -1102,8 +1102,8 @@ mod tests {
         else {
             panic!("expected ScheduleLocalActivity command");
         };
-        assert!(!default_command.include_arguments_into_marker);
-        assert!(enabled_command.include_arguments_into_marker);
+        assert!(!default_command.include_arguments_in_marker);
+        assert!(enabled_command.include_arguments_in_marker);
     }
 
     #[test]


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Rename `include_arguments_into_marker` to `include_arguments_in_marker`.

## Why?

More grammatically correct name.