### PR TITLE
Fix flaky post-cancel abandoned child test

### DIFF
--- a/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/child_workflows.rs
@@ -198,7 +198,7 @@ async fn abandoned_child_bug_repro() {
 
 #[workflow]
 struct AbandonedChildResolvesPostCancelParent {
-    barr: Arc<Barrier>,
+    ready: Arc<Notify>,
 }
 
 #[workflow_methods(factory_only)]
@@ -217,8 +217,7 @@ impl AbandonedChildResolvesPostCancelParent {
             )
             .await
             .expect("Child should start OK");
-        let barr = ctx.state(|wf| wf.barr.clone());
-        barr.wait().await;
+        ctx.state(|wf| wf.ready.notify_one());
         ctx.cancelled().await;
         started.cancel("Die reason".to_string());
         ctx.timer(Duration::from_secs(1)).await;
@@ -242,12 +241,12 @@ impl AbandonedChildResolvesPostCancelChild {
 #[tokio::test]
 async fn abandoned_child_resolves_post_cancel() {
     let mut starter = CoreWfStarter::new("child-workflow-resolves-post-cancel");
-    let barr = Arc::new(Barrier::new(2));
-    let barr_clone = barr.clone();
+    let ready = Arc::new(Notify::new());
+    let ready_clone = ready.clone();
     starter
         .sdk_config
         .register_workflow_with_factory(move || AbandonedChildResolvesPostCancelParent {
-            barr: barr_clone.clone(),
+            ready: ready_clone.clone(),
         })
         .unwrap();
     starter
@@ -267,7 +266,7 @@ async fn abandoned_child_resolves_post_cancel() {
         .unwrap();
     let client = starter.get_core_client().await;
     let canceller = async {
-        barr.wait().await;
+        ready.notified().await;
         handle
             .cancel(WorkflowCancelOptions::builder().reason("die").build())
             .await
@@ -277,6 +276,7 @@ async fn abandoned_child_resolves_post_cancel() {
         worker.run_until_done().await.unwrap();
     };
     tokio::join!(canceller, runner);
+    handle.get_result(Default::default()).await.unwrap();
 
     // Verify no WFT failures on the child workflow. A failure here indicates
     // the child couldn't deserialize its input (e.g., sending a payload when none expected).


### PR DESCRIPTION
## What changed

- `abandoned_child_resolves_post_cancel`'s parent workflow blocked on a `tokio::sync::Barrier` to
  hand off to the canceller. Barrier rendezvous inside workflow code ties the workflow task to the
  test task, and could wedge the run until the workflow execution timeout. It now signals readiness
  with a `Notify` and doesn't block.
- The test awaits the parent's result after the worker finishes, so an execution that merely timed
  out can no longer count as a pass.

## Why

CI evidence showed both passing and failing samples running until the exact workflow execution
timeout, i.e. the test wasn't asserting the thing it was named for. The retained-permit failure in
the original reports happened during cleanup and wasn't the cause of the stuck workflow.

Occurrences (5 failed run attempts, 2026-08-25 through 2026-08-26):

- [run 32992230065](https://github.com/temporalio/sdk-rust/actions/runs/32992230065/job/98252364382)
- [run 32873733260](https://github.com/temporalio/sdk-rust/actions/runs/32873733260/job/97886610759)
- [run 32869930578](https://github.com/temporalio/sdk-rust/actions/runs/32869930578/job/97874211370)
- [run 32811867076](https://github.com/temporalio/sdk-rust/actions/runs/32811867076/job/97692587827)
- [run 32811619765](https://github.com/temporalio/sdk-rust/actions/runs/32811619765/job/97691873937)

Test-only change, so no changelog entry.

## Note

Supersedes #1533. That PR's head was `sdk-sentinel-forks/sdk-rust`, and GitHub doesn't offer
"allow edits by maintainers" for PRs from organization-owned forks, so the follow-up commit couldn't
be pushed there. This branch is the same net diff squashed onto current `main` — the core-side
shutdown-gating commits on the original branch were reverted before it landed, so they're not
included here.