### PR TITLE
Add named deterministic workflow random streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ relevant information.
 * `DefaultFailureConverter::new(true)` moves failure messages and stack traces into encoded
   attributes so payload codecs can encrypt them.
 * `LocalActivityOptions::include_arguments_in_marker` allows Rust workflows to opt in to
+* `WorkflowContext::random_stream`, `SyncWorkflowContext::random_stream`, and
+  `WorkflowInterceptorContext::random_stream` provide deterministic, workflow-run-scoped
+  pseudo-random streams isolated by a stable caller-supplied name. Repeated lookup continues a
+  named stream without consuming the workflow's default randomness or any other named stream.
+* `LocalActivityOptions::include_arguments_into_marker` allows Rust workflows to opt in to
   recording local activity arguments in Workflow history.
 * `WorkflowHandle::get_update_handle` creates a typed handle for an existing Workflow Update from
   its update ID, allowing callers to wait for the result independently of the original handle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,12 +37,11 @@ relevant information.
 * `DefaultFailureConverter::new(true)` moves failure messages and stack traces into encoded
   attributes so payload codecs can encrypt them.
 * `LocalActivityOptions::include_arguments_in_marker` allows Rust workflows to opt in to
+  recording local activity arguments in Workflow history.
 * `WorkflowContext::random_stream`, `SyncWorkflowContext::random_stream`, and
   `WorkflowInterceptorContext::random_stream` provide deterministic, workflow-run-scoped
   pseudo-random streams isolated by a stable caller-supplied name. Repeated lookup continues a
   named stream without consuming the workflow's default randomness or any other named stream.
-* `LocalActivityOptions::include_arguments_into_marker` allows Rust workflows to opt in to
-  recording local activity arguments in Workflow history.
 * `WorkflowHandle::get_update_handle` creates a typed handle for an existing Workflow Update from
   its update ID, allowing callers to wait for the result independently of the original handle.
 * `WorkflowContext::all_handlers_finished` and `SyncWorkflowContext::all_handlers_finished` let

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/continue_as_new.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/continue_as_new.rs
@@ -1,5 +1,11 @@
 use crate::common::{CoreWfStarter, SEARCH_ATTR_TXT};
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 use temporalio_client::WorkflowStartOptions;
 use temporalio_common::{
     protos::temporal::api::{
@@ -58,6 +64,62 @@ async fn continue_as_new_happy_path() {
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
+}
+
+#[workflow]
+struct ContinueAsNewRandomWf {
+    saw_independent_stream: Arc<AtomicBool>,
+}
+
+#[workflow_methods(factory_only)]
+impl ContinueAsNewRandomWf {
+    #[run]
+    async fn run(
+        ctx: &mut WorkflowContext<Self>,
+        (run, previous_value): (u8, Option<u64>),
+    ) -> WorkflowResult<()> {
+        let value = ctx.random_stream("continue-as-new-test").random::<u64>();
+        if run == 1 {
+            ctx.continue_as_new((2, Some(value)), ContinueAsNewOptions::default())?;
+        } else {
+            ctx.state(|wf| {
+                assert_ne!(
+                    value,
+                    previous_value.expect("first run should pass its stream value"),
+                    "continue-as-new should independently seed named streams"
+                );
+                wf.saw_independent_stream.store(true, Ordering::Relaxed);
+            });
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn continue_as_new_reseeds_named_random_streams() {
+    let wf_name = "continue_as_new_reseeds_named_random_streams";
+    let mut starter = CoreWfStarter::new(wf_name);
+    let saw_independent_stream = Arc::new(AtomicBool::new(false));
+    let saw_independent_stream_for_wf = saw_independent_stream.clone();
+    starter
+        .sdk_config
+        .register_workflow_with_factory(move || ContinueAsNewRandomWf {
+            saw_independent_stream: saw_independent_stream_for_wf.clone(),
+        })
+        .unwrap();
+    let mut worker = starter.worker().await;
+
+    let task_queue = starter.get_task_queue().to_owned();
+    worker
+        .submit_workflow(
+            ContinueAsNewRandomWf::run,
+            (1, None),
+            WorkflowStartOptions::new(task_queue, wf_name).build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+    assert!(saw_independent_stream.load(Ordering::Relaxed));
 }
 
 #[tokio::test]

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/continue_as_new.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/continue_as_new.rs
@@ -1,11 +1,5 @@
 use crate::common::{CoreWfStarter, SEARCH_ATTR_TXT};
-use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 use temporalio_client::WorkflowStartOptions;
 use temporalio_common::{
     protos::temporal::api::{
@@ -67,31 +61,24 @@ async fn continue_as_new_happy_path() {
 }
 
 #[workflow]
-struct ContinueAsNewRandomWf {
-    saw_independent_stream: Arc<AtomicBool>,
-}
+#[derive(Default)]
+struct ContinueAsNewRandomWf;
 
-#[workflow_methods(factory_only)]
+#[workflow_methods]
 impl ContinueAsNewRandomWf {
     #[run]
     async fn run(
         ctx: &mut WorkflowContext<Self>,
-        (run, previous_value): (u8, Option<u64>),
-    ) -> WorkflowResult<()> {
+        previous_value: Option<u64>,
+    ) -> WorkflowResult<(u64, u64)> {
         let value = ctx.random_stream("continue-as-new-test").random::<u64>();
-        if run == 1 {
-            ctx.continue_as_new((2, Some(value)), ContinueAsNewOptions::default())?;
-        } else {
-            ctx.state(|wf| {
-                assert_ne!(
-                    value,
-                    previous_value.expect("first run should pass its stream value"),
-                    "continue-as-new should independently seed named streams"
-                );
-                wf.saw_independent_stream.store(true, Ordering::Relaxed);
-            });
+        if ctx.info().continued_from_run_id().is_none() {
+            ctx.continue_as_new(Some(value), ContinueAsNewOptions::default())?;
         }
-        Ok(())
+        Ok((
+            previous_value.expect("first run should pass its stream value"),
+            value,
+        ))
     }
 }
 
@@ -99,27 +86,27 @@ impl ContinueAsNewRandomWf {
 async fn continue_as_new_reseeds_named_random_streams() {
     let wf_name = "continue_as_new_reseeds_named_random_streams";
     let mut starter = CoreWfStarter::new(wf_name);
-    let saw_independent_stream = Arc::new(AtomicBool::new(false));
-    let saw_independent_stream_for_wf = saw_independent_stream.clone();
     starter
         .sdk_config
-        .register_workflow_with_factory(move || ContinueAsNewRandomWf {
-            saw_independent_stream: saw_independent_stream_for_wf.clone(),
-        })
+        .register_workflow::<ContinueAsNewRandomWf>()
         .unwrap();
     let mut worker = starter.worker().await;
 
     let task_queue = starter.get_task_queue().to_owned();
-    worker
+    let handle = worker
         .submit_workflow(
             ContinueAsNewRandomWf::run,
-            (1, None),
+            None,
             WorkflowStartOptions::new(task_queue, wf_name).build(),
         )
         .await
         .unwrap();
     worker.run_until_done().await.unwrap();
-    assert!(saw_independent_stream.load(Ordering::Relaxed));
+    let (first_value, continued_value) = handle.get_result(Default::default()).await.unwrap();
+    assert_ne!(
+        first_value, continued_value,
+        "continue-as-new should independently seed named streams"
+    );
 }
 
 #[tokio::test]

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/determinism.rs
@@ -152,7 +152,15 @@ struct RandomReplayWf;
 impl RandomReplayWf {
     #[run]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<String> {
-        Ok(format!("{}:{}", ctx.random::<u64>(), ctx.uuid4()))
+        let orders = ctx.random_stream("example.com/orders");
+        let first_order = orders.random::<u64>();
+        let _ = ctx.random_stream("example.com/telemetry").random::<u64>();
+        let second_order = ctx.random_stream("example.com/orders").random::<u64>();
+        Ok(format!(
+            "{}:{}:{first_order}:{second_order}",
+            ctx.random::<u64>(),
+            ctx.uuid4()
+        ))
     }
 }
 

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/resets.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/resets.rs
@@ -116,6 +116,7 @@ async fn reset_workflow() {
 struct ResetRandomseedWf {
     did_fail: Arc<AtomicBool>,
     initial_random: Arc<OnceLock<u128>>,
+    initial_named_random: Arc<OnceLock<u128>>,
     reset_started: Arc<AtomicBool>,
     saw_updated_random: Arc<AtomicBool>,
     notify: Arc<Notify>,
@@ -127,10 +128,13 @@ struct ResetRandomseedWf {
 impl ResetRandomseedWf {
     #[run(name = "reset_randomseed")]
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+        let named_random = ctx.random_stream("reset-test");
         if ctx.state(|wf| !wf.reset_started.load(Ordering::Relaxed)) {
             let initial_random = ctx.random::<u128>();
+            let initial_named_random = named_random.random::<u128>();
             ctx.state(|wf| {
                 let _ = wf.initial_random.set(initial_random);
+                let _ = wf.initial_named_random.set(initial_named_random);
             });
         }
         ctx.timer(Duration::from_millis(100)).await;
@@ -156,6 +160,16 @@ impl ResetRandomseedWf {
                 ctx.random::<u128>(),
                 initial_random,
                 "random stream should be reseeded after reset"
+            );
+            let initial_named_random = ctx.state(|wf| {
+                *wf.initial_named_random
+                    .get()
+                    .expect("initial named random value should be recorded")
+            });
+            assert_ne!(
+                named_random.random::<u128>(),
+                initial_named_random,
+                "named random stream should be reseeded after reset"
             );
             ctx.state(|wf| {
                 wf.saw_updated_random.store(true, Ordering::Relaxed);
@@ -194,10 +208,12 @@ async fn reset_randomseed() {
 
     let did_fail = Arc::new(AtomicBool::new(false));
     let initial_random = Arc::new(OnceLock::new());
+    let initial_named_random = Arc::new(OnceLock::new());
     let reset_started = Arc::new(AtomicBool::new(false));
     let saw_updated_random = Arc::new(AtomicBool::new(false));
     let notify = Arc::new(Notify::new());
     let notify_clone = notify.clone();
+    let initial_named_random_for_wf = initial_named_random.clone();
     let reset_started_for_wf = reset_started.clone();
     let saw_updated_random_for_wf = saw_updated_random.clone();
     starter
@@ -205,6 +221,7 @@ async fn reset_randomseed() {
         .register_workflow_with_factory(move || ResetRandomseedWf {
             did_fail: did_fail.clone(),
             initial_random: initial_random.clone(),
+            initial_named_random: initial_named_random_for_wf.clone(),
             reset_started: reset_started_for_wf.clone(),
             saw_updated_random: saw_updated_random_for_wf.clone(),
             notify: notify_clone.clone(),

--- a/crates/workflow/Cargo.toml
+++ b/crates/workflow/Cargo.toml
@@ -27,6 +27,7 @@ prost-types = { workspace = true }
 rand = { version = "0.10", default-features = false }
 rand_pcg = "0.10"
 serde = { version = "1.0", features = ["derive"] }
+siphasher = "1.0"
 thiserror = "2"
 uuid = { version = "1.18", default-features = false }
 wit-bindgen = { version = "0.57.1", default-features = false, features = ["macros", "std", "realloc", "bitflags"] }

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -45,7 +45,7 @@ pub use workflow_context::{
     StartChildWorkflowExecutionFailedCause, StartChildWorkflowOutput, StartedChildWorkflow,
     StartedNexusOperation, SyncWorkflowContext, TimerOptions, VersioningIntent,
     WaitConditionOptions, WorkflowContext, WorkflowContextView, WorkflowIdReusePolicy,
-    WorkflowRandomValue,
+    WorkflowRandomStream, WorkflowRandomValue,
 };
 #[doc(hidden)]
 pub use workflow_context::{PatchActivationCallback, PatchActivationCaller};

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -184,8 +184,8 @@ impl WorkflowRandomStream {
 }
 
 fn named_random_seed(randomness_seed: u64, name: &str) -> u64 {
-    // The fixed "temporal" key domain-separates this derivation, and together with explicit byte
-    // writes forms a replay compatibility contract independent of Rust's Hash implementations.
+    // 0x7465_6d70_6f72_616c is ASCII "temporal", used as a fixed second SipHash key for domain
+    // separation. It and the explicit byte writes are part of the replay compatibility contract.
     let mut hasher =
         SipHasher13::new_with_keys(randomness_seed, randomness_seed ^ 0x7465_6d70_6f72_616c);
     hasher.write(b"temporal-rust-workflow-random-stream\0");

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -184,10 +184,9 @@ impl WorkflowRandomStream {
 }
 
 fn named_random_seed(randomness_seed: u64, name: &str) -> u64 {
-    // 0x7465_6d70_6f72_616c is ASCII "temporal", used as a fixed second SipHash key for domain
-    // separation. It and the explicit byte writes are part of the replay compatibility contract.
-    let mut hasher =
-        SipHasher13::new_with_keys(randomness_seed, randomness_seed ^ 0x7465_6d70_6f72_616c);
+    // The fixed second key provides domain separation and is part of replay compatibility.
+    let second_key = randomness_seed ^ u64::from_be_bytes(*b"temporal");
+    let mut hasher = SipHasher13::new_with_keys(randomness_seed, second_key);
     hasher.write(b"temporal-rust-workflow-random-stream\0");
     hasher.write(name.as_bytes());
     hasher.finish()

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -45,10 +45,12 @@ use futures_util::{
 };
 use rand::SeedableRng;
 use rand_pcg::Pcg64Mcg;
+use siphasher::sip::SipHasher13;
 use std::{
     cell::{Cell, RefCell},
     collections::{HashMap, HashSet},
     future::{self, Future},
+    hash::Hasher,
     marker::PhantomData,
     pin::Pin,
     rc::Rc,
@@ -138,6 +140,57 @@ macro_rules! impl_random_value {
 }
 
 impl_random_value!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64);
+
+/// A deterministic pseudo-random stream private to a stable caller-supplied name.
+///
+/// Obtain a stream with [`WorkflowContext::random_stream`],
+/// [`SyncWorkflowContext::random_stream`], or
+/// [`crate::workflow_interceptors::WorkflowInterceptorContext::random_stream`]. Looking up the
+/// same name again continues the same stream, while different names and the context's default
+/// [`WorkflowContext::random`] stream do not consume one another. Clones of this value refer to the
+/// same named stream.
+///
+/// Draws advance workflow state without recording individual values in history, so replaying code
+/// must draw from a given name in the same order. Adding or removing draws from one name does not
+/// change any other name.
+///
+/// Workflow reset replays the original sequence through the reset point. When Core supplies the
+/// reset run's new randomness seed, all named streams start new sequences for work after that
+/// point. Continue-as-new creates a new workflow run and independently seeds all streams.
+///
+/// Random streams are deliberately unavailable from [`WorkflowContextView`], which is used by
+/// read-only init, query, and update-validator handlers.
+#[derive(Clone)]
+pub struct WorkflowRandomStream {
+    base: BaseWorkflowContext,
+    name: String,
+}
+
+impl WorkflowRandomStream {
+    /// Generates the next deterministic pseudo-random value from this named stream.
+    ///
+    /// This generator is not cryptographically secure.
+    pub fn random<T>(&self) -> T
+    where
+        T: WorkflowRandomValue,
+    {
+        self.base.named_random(&self.name)
+    }
+
+    /// Returns the stable name associated with this stream.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+fn named_random_seed(randomness_seed: u64, name: &str) -> u64 {
+    // Fixed keys and explicit byte writes keep stream derivation stable across Rust versions.
+    let mut hasher =
+        SipHasher13::new_with_keys(randomness_seed, randomness_seed ^ 0x7465_6d70_6f72_616c);
+    hasher.write(b"temporal-rust-workflow-random-stream\0");
+    hasher.write(name.as_bytes());
+    hasher.finish()
+}
 
 /// Non-generic base context containing all workflow execution infrastructure.
 ///
@@ -235,6 +288,8 @@ impl BaseWorkflowContext {
             _ => None,
         }) {
             shared.random = Pcg64Mcg::seed_from_u64(seed);
+            shared.randomness_seed = seed;
+            shared.named_random.clear();
         }
     }
 
@@ -244,6 +299,26 @@ impl BaseWorkflowContext {
     {
         let random = &mut self.inner.shared.borrow_mut().random;
         <T as private::Sealed>::sample(random)
+    }
+
+    fn named_random<T>(&self, name: &str) -> T
+    where
+        T: WorkflowRandomValue,
+    {
+        let mut shared = self.inner.shared.borrow_mut();
+        let seed = shared.randomness_seed;
+        let random = shared
+            .named_random
+            .entry(name.to_owned())
+            .or_insert_with(|| Pcg64Mcg::seed_from_u64(named_random_seed(seed, name)));
+        <T as private::Sealed>::sample(random)
+    }
+
+    pub(crate) fn random_stream(&self, name: impl Into<String>) -> WorkflowRandomStream {
+        WorkflowRandomStream {
+            base: self.clone(),
+            name: name.into(),
+        }
     }
 
     fn uuid4(&self) -> String {
@@ -612,6 +687,8 @@ impl BaseWorkflowContext {
                 run_id,
                 shared: RefCell::new(WorkflowContextSharedData {
                     random: Pcg64Mcg::seed_from_u64(init_workflow_job.randomness_seed),
+                    randomness_seed: init_workflow_job.randomness_seed,
+                    named_random: HashMap::new(),
                     memo: init_workflow_job.memo.clone().unwrap_or_default(),
                     search_attributes: init_workflow_job
                         .search_attributes
@@ -1445,6 +1522,25 @@ impl<W> SyncWorkflowContext<W> {
         self.base.uuid4()
     }
 
+    /// Returns the deterministic pseudo-random stream associated with `name`.
+    ///
+    /// Repeated lookup of the same name continues the prior stream. Different names are isolated
+    /// from one another and from [`Self::random`]. Keep the name stable across workflow replays.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use temporalio_workflow::{SyncWorkflowContext, WorkflowRandomStream};
+    /// # fn choose<W>(ctx: &SyncWorkflowContext<W>) {
+    /// let stream: WorkflowRandomStream = ctx.random_stream("example.com/orders/tiebreaker");
+    /// let choice = stream.random::<u64>();
+    /// # let _ = choice;
+    /// # }
+    /// ```
+    pub fn random_stream(&self, name: impl Into<String>) -> WorkflowRandomStream {
+        self.base.random_stream(name)
+    }
+
     /// Returns true if the current workflow task is happening under replay
     pub fn is_replaying(&self) -> bool {
         self.base.inner.shared.borrow().activation.is_replaying
@@ -1936,6 +2032,13 @@ impl<W> WorkflowContext<W> {
         self.sync.uuid4()
     }
 
+    /// Returns the deterministic pseudo-random stream associated with `name`.
+    ///
+    /// See [`SyncWorkflowContext::random_stream`].
+    pub fn random_stream(&self, name: impl Into<String>) -> WorkflowRandomStream {
+        self.sync.random_stream(name)
+    }
+
     /// Returns true if the current workflow task is happening under replay
     pub fn is_replaying(&self) -> bool {
         self.sync.is_replaying()
@@ -2296,6 +2399,8 @@ struct WorkflowContextSharedData {
     is_replaying_history_events: bool,
     search_attributes: ProtoSearchAttributes,
     random: Pcg64Mcg,
+    randomness_seed: u64,
+    named_random: HashMap<String, Pcg64Mcg>,
     /// Current details string, surfaced via the workflow metadata query.
     current_details: String,
 }
@@ -3914,6 +4019,93 @@ mod tests {
         ctx.sync.base.apply_activation_context(&activation, false);
 
         assert_eq!(ctx.random::<u64>(), expected);
+    }
+
+    #[test]
+    fn named_random_lookup_continues_the_same_stream() {
+        let ctx = test_context_with_seed(42);
+        let first_lookup = ctx.random_stream("orders");
+        let first = first_lookup.random::<u64>();
+        let second = ctx.random_stream("orders").random::<u64>();
+
+        let expected = test_context_with_seed(42).random_stream("orders");
+        assert_eq!(first, expected.random::<u64>());
+        assert_eq!(second, expected.random::<u64>());
+    }
+
+    #[test]
+    fn named_random_sequence_is_stable() {
+        let stream = test_context_with_seed(42).random_stream("example.com/orders");
+
+        // Changing seed derivation or the generator would break existing workflow replays.
+        assert_eq!(stream.random::<u64>(), 18_054_372_068_998_079_507);
+    }
+
+    #[test]
+    fn named_random_streams_are_isolated() {
+        let ctx = test_context_with_seed(42);
+        let alpha = ctx.random_stream("alpha");
+        let first_alpha = alpha.random::<u64>();
+        let _ = ctx.random_stream("beta").random::<u64>();
+        let second_alpha = alpha.random::<u64>();
+
+        let expected_ctx = test_context_with_seed(42);
+        let expected_alpha = expected_ctx.random_stream("alpha");
+        assert_eq!(first_alpha, expected_alpha.random::<u64>());
+        assert_eq!(second_alpha, expected_alpha.random::<u64>());
+        assert_ne!(
+            test_context_with_seed(42)
+                .random_stream("alpha")
+                .random::<u64>(),
+            test_context_with_seed(42)
+                .random_stream("beta")
+                .random::<u64>()
+        );
+    }
+
+    #[test]
+    fn named_random_does_not_advance_default_randomness() {
+        let ctx = test_context_with_seed(42);
+        let first = ctx.random::<u64>();
+        let _ = ctx.random_stream("plugin").random::<u64>();
+        let second = ctx.random::<u64>();
+
+        let expected = test_context_with_seed(42);
+        assert_eq!(first, expected.random::<u64>());
+        assert_eq!(second, expected.random::<u64>());
+    }
+
+    #[test]
+    fn interceptor_context_shares_named_random_stream_state() {
+        let ctx = test_context_with_seed(42);
+        let first = ctx.random_stream("plugin").random::<u64>();
+        let interceptor_ctx =
+            crate::workflow_interceptors::WorkflowInterceptorContext::new(ctx.sync.base.clone());
+        let second = interceptor_ctx.random_stream("plugin").random::<u64>();
+
+        let expected = test_context_with_seed(42).random_stream("plugin");
+        assert_eq!(first, expected.random::<u64>());
+        assert_eq!(second, expected.random::<u64>());
+    }
+
+    #[test]
+    fn named_random_streams_are_reseeded_by_activation() {
+        let ctx = test_context_with_seed(123);
+        let stream = ctx.random_stream("orders");
+        let _ = stream.random::<u64>();
+        let activation = CoreWorkflowActivation {
+            jobs: vec![WorkflowActivationJob {
+                variant: Some(ActivationVariant::UpdateRandomSeed(UpdateRandomSeed {
+                    randomness_seed: 456,
+                })),
+            }],
+            ..Default::default()
+        };
+
+        ctx.sync.base.apply_activation_context(&activation, false);
+
+        let expected = test_context_with_seed(456).random_stream("orders");
+        assert_eq!(stream.random::<u64>(), expected.random::<u64>());
     }
 
     struct MutatingRemainingOutboundInterceptor;

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -184,7 +184,8 @@ impl WorkflowRandomStream {
 }
 
 fn named_random_seed(randomness_seed: u64, name: &str) -> u64 {
-    // Fixed keys and explicit byte writes keep stream derivation stable across Rust versions.
+    // The fixed "temporal" key domain-separates this derivation, and together with explicit byte
+    // writes forms a replay compatibility contract independent of Rust's Hash implementations.
     let mut hasher =
         SipHasher13::new_with_keys(randomness_seed, randomness_seed ^ 0x7465_6d70_6f72_616c);
     hasher.write(b"temporal-rust-workflow-random-stream\0");

--- a/crates/workflow/src/workflow_interceptors.rs
+++ b/crates/workflow/src/workflow_interceptors.rs
@@ -86,6 +86,7 @@ use crate::{
     ChildWorkflowOptions, ContinueAsNewOptions, ExternalWorkflowHandle, LocalActivityOptions,
     NexusOperationOptions, SignalWorkflowOptions, StartChildWorkflowOutput, StartedChildWorkflow,
     StartedNexusOperation, TimerOptions, WorkflowCancellationToken, WorkflowContextView,
+    WorkflowRandomStream,
     cancellation::WorkflowCancellationRegistration,
     runtime::{
         entry::WorkflowError,
@@ -335,6 +336,16 @@ impl WorkflowInterceptorContext {
     /// Return the workflow's root cancellation token.
     pub fn cancellation_token(&self) -> WorkflowCancellationToken {
         self.base.cancellation_token()
+    }
+
+    /// Returns the deterministic pseudo-random stream associated with `name`.
+    ///
+    /// Named streams let interceptors consume replay-safe randomness without changing the
+    /// workflow's default random sequence or another interceptor's named sequence. Query and
+    /// update-validator interceptors receive [`SyncWorkflowInterceptorContext`], which does not
+    /// expose random streams because those handlers are read-only.
+    pub fn random_stream(&self, name: impl Into<String>) -> WorkflowRandomStream {
+        self.base.random_stream(name)
     }
 
     /// Request to create a timer through the workflow outbound interceptor chain.


### PR DESCRIPTION
## What was changed

- Add `random_stream()` method on workflow and workflow-interceptor contexts, which creates or retrieves a separate stream of randomness per name.

## Why?

Workflow code, plugins, and interceptors sometimes need replay-safe entropy without advancing the main workflow RNG. 

## Checklist

1. Closes: N/A
2. How was this tested:
   - `cargo test -p temporalio-workflow random`
   - `cargo integ-test random_workflow_replays`
   - `cargo integ-test reset_randomseed`
   - `cargo integ-test continue_as_new_reseeds_named_random_streams`
   - `cargo lint`
   - `cargo test-lint`
   - `cargo +nightly fmt --check`
   - `git diff --check`
3. Any docs updates needed?
   - Public rustdoc and an example are included, along with the required root Unreleased changelog entry. No docs.temporal.io update is needed for this SDK-specific primitive.
