### PR TITLE
chore(sdk): make publish idempotent

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -66,14 +66,30 @@ jobs:
             --changelog rust \
             >"$RUNNER_TEMP/release-notes.md"
 
+      - name: Plan crate publication
+        id: publish-plan
+        run: cargo run --quiet -p changelog-release-notes --bin plan-release-publish >>"$GITHUB_OUTPUT"
+
       - name: Authenticate to crates.io
+        if: steps.publish-plan.outputs.packages != '[]'
         id: auth
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1
 
       - name: Publish crates
+        if: steps.publish-plan.outputs.packages != '[]'
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        run: cargo publish --workspace
+          PUBLISH_PACKAGES: ${{ steps.publish-plan.outputs.packages }}
+        shell: bash
+        run: |
+          jq -e 'type == "array" and length > 0 and all(.[]; type == "string" and length > 0)' \
+            <<<"$PUBLISH_PACKAGES" >/dev/null
+          mapfile -t packages < <(jq -r '.[]' <<<"$PUBLISH_PACKAGES")
+          publish_args=()
+          for package in "${packages[@]}"; do
+            publish_args+=(--package "$package")
+          done
+          cargo publish "${publish_args[@]}"
 
       - name: Create draft GitHub release
         env:

--- a/crates/changelog-release-notes/Cargo.toml
+++ b/crates/changelog-release-notes/Cargo.toml
@@ -9,7 +9,10 @@ default-run = "changelog-release-notes"
 
 [dependencies]
 chrono = { version = "=0.4.45", default-features = false, features = ["clock"] }
+reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls"] }
 semver = "=1.0.28"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/changelog-release-notes/src/bin/plan-release-publish.rs
+++ b/crates/changelog-release-notes/src/bin/plan-release-publish.rs
@@ -1,0 +1,166 @@
+use std::{process::Command, time::Duration};
+
+use reqwest::{StatusCode, blocking::Client};
+use serde::Deserialize;
+
+const CRATES_IO_SPARSE_INDEX: &str = "https://index.crates.io";
+const USER_AGENT: &str =
+    "temporalio/sdk-rust release planner (https://github.com/temporalio/sdk-rust)";
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+struct Metadata {
+    packages: Vec<Package>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+struct Package {
+    name: String,
+    version: String,
+    publish: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+struct IndexEntry {
+    vers: String,
+}
+
+fn workspace_metadata() -> Result<Metadata, String> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--format-version", "1", "--no-deps"])
+        .output()
+        .map_err(|err| format!("failed to run cargo metadata: {err}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "cargo metadata failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    serde_json::from_slice(&output.stdout)
+        .map_err(|err| format!("failed to parse cargo metadata: {err}"))
+}
+
+fn crates_io_packages(metadata: Metadata) -> impl Iterator<Item = Package> {
+    metadata.packages.into_iter().filter(|package| {
+        package
+            .publish
+            .as_ref()
+            .is_none_or(|registries| registries.iter().any(|registry| registry == "crates-io"))
+    })
+}
+
+fn sparse_index_path(name: &str) -> String {
+    let name = name.to_ascii_lowercase();
+    // See https://doc.rust-lang.org/cargo/reference/registry-index.html#index-files
+    match name.len() {
+        1 => format!("1/{name}"),
+        2 => format!("2/{name}"),
+        3 => format!("3/{}/{name}", &name[..1]),
+        _ => format!("{}/{}/{name}", &name[..2], &name[2..4]),
+    }
+}
+
+fn version_in_index(index: &str, version: &str) -> Result<bool, String> {
+    for line in index.lines() {
+        let entry: IndexEntry = serde_json::from_str(line)
+            .map_err(|err| format!("failed to parse sparse index entry: {err}"))?;
+        if entry.vers == version {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn version_is_published(client: &Client, package: &Package) -> Result<bool, String> {
+    let url = format!(
+        "{CRATES_IO_SPARSE_INDEX}/{}",
+        sparse_index_path(&package.name)
+    );
+    let response = client.get(&url).send().map_err(|err| {
+        format!(
+            "failed to check {}@{}: {err}",
+            package.name, package.version
+        )
+    })?;
+    match response.status() {
+        StatusCode::OK => {
+            let index = response.text().map_err(|err| {
+                format!(
+                    "failed to check {}@{}: failed to read sparse index entry: {err}",
+                    package.name, package.version
+                )
+            })?;
+            version_in_index(&index, &package.version).map_err(|err| {
+                format!(
+                    "failed to check {}@{}: {err}",
+                    package.name, package.version
+                )
+            })
+        }
+        StatusCode::NOT_FOUND => Ok(false),
+        status => Err(format!(
+            "failed to check {}@{}: sparse index returned unexpected HTTP status {status}",
+            package.name, package.version
+        )),
+    }
+}
+
+fn main() -> Result<(), String> {
+    let client = Client::builder()
+        .user_agent(USER_AGENT)
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|err| format!("failed to create crates.io client: {err}"))?;
+
+    let mut unpublished = Vec::new();
+    for package in crates_io_packages(workspace_metadata()?) {
+        if version_is_published(&client, &package)? {
+            eprintln!(
+                "{}@{} is already published; skipping.",
+                package.name, package.version
+            );
+        } else {
+            unpublished.push(package.name);
+        }
+    }
+    println!(
+        "packages={}",
+        serde_json::to_string(&unpublished)
+            .map_err(|err| format!("failed to serialize publish plan: {err}"))?
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selects_packages_publishable_to_crates_io() {
+        let packages = crates_io_packages(workspace_metadata().expect("workspace metadata"))
+            .map(|package| package.name)
+            .collect::<Vec<_>>();
+
+        assert!(packages.iter().any(|package| package == "temporalio-sdk"));
+        assert!(
+            !packages
+                .iter()
+                .any(|package| package == "temporalio-sdk-core-c-bridge")
+        );
+    }
+
+    #[test]
+    fn builds_sparse_index_paths() {
+        assert_eq!(sparse_index_path("temporalio-sdk"), "te/mp/temporalio-sdk");
+    }
+
+    #[test]
+    fn finds_versions_in_sparse_index_entries() {
+        let index = r#"{"vers":"0.7.0","yanked":true}
+{"vers":"0.8.0","yanked":false}"#;
+
+        assert_eq!(version_in_index(index, "0.7.0"), Ok(true));
+        assert_eq!(version_in_index(index, "0.8.0"), Ok(true));
+        assert_eq!(version_in_index(index, "0.9.0"), Ok(false));
+        assert!(version_in_index("not json", "0.7.0").is_err());
+    }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Update release workflow to be idempotent, currently if it fails partially through the workflow it would be unable to recover since `cargo publish --workspace` hard errors if it encounters an already published crate.
- Added utility script to find unreleased crates for the actual `cargo publish` command

## Why?
`cargo publish --workspace --idempotent` remains a [feature request](https://github.com/rust-lang/cargo/issues/13397) and I don't especially want to use a 3rd party dep for the release process unless absoluetly necessary.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
