### PR TITLE
:boom: Make SdkWakeGuard !Send and !Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ relevant information.
 ## Unreleased
 
 ### Breaking Changes
+* `SdkWakeGuard` is no longer `Send` or `Sync`, preventing the thread-local guard from being moved
+  to or referenced from another thread.
 * `WorkflowContextView` and the containing `PatchActivationInput` are no longer `Send` or `Sync`
   because workflow context views now share single-threaded workflow randomness with replay-sensitive
   SDK integrations.

--- a/crates/workflow/src/runtime/mod.rs
+++ b/crates/workflow/src/runtime/mod.rs
@@ -7,6 +7,7 @@ use crate::runtime::types::RoutinePendingState;
 use std::{
     cell::{Cell, RefCell},
     future::Future,
+    marker::PhantomData,
     pin::Pin,
     rc::Rc,
     task::{Context, Poll},
@@ -239,14 +240,16 @@ pub(crate) fn mark_intercepted_handler_ready() {
 /// Guard that marks the current scope as an SDK-initiated wake source.
 #[doc(hidden)]
 pub struct SdkWakeGuard {
-    _priv: (),
+    _not_send_or_sync: PhantomData<Rc<()>>,
 }
 
 impl SdkWakeGuard {
     #[doc(hidden)]
     pub fn new() -> Self {
         SDK_WAKE_DEPTH.with(|c| c.set(c.get() + 1));
-        Self { _priv: () }
+        Self {
+            _not_send_or_sync: PhantomData,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- make `SdkWakeGuard` `!Send` and `!Sync`


## Testing
- `cargo test -p temporalio-workflow --lib`
- `cargo lint`
- `cargo +nightly fmt`