### PR TITLE
feat(sdk): expose proper cancel external error type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ relevant information.
 
 ## Unreleased
 
+### Added
+* `CancelExternalWorkflowError` and `workflow_interceptors::CancelExternalWorkflowResult`
+  for use in interceptors.
+
 ## [0.8.0] - 2026-09-02
 
 ### Breaking Changes
@@ -43,8 +47,6 @@ relevant information.
   SDK integrations.
 
 ### Added
-* `CancelExternalWorkflowError` and `workflow_interceptors::CancelExternalWorkflowResult`
-  for use in interceptors.
 * `DefaultFailureConverter::new(true)` moves failure messages and stack traces into encoded
   attributes so payload codecs can encrypt them.
 * `LocalActivityOptions::include_arguments_in_marker` allows Rust workflows to opt in to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ relevant information.
   SDK integrations.
 
 ### Added
+* `CancelExternalWorkflowError` and `workflow_interceptors::CancelExternalWorkflowResult`
+  for use in interceptors.
 * `DefaultFailureConverter::new(true)` moves failure messages and stack traces into encoded
   attributes so payload codecs can encrypt them.
 * `LocalActivityOptions::include_arguments_in_marker` allows Rust workflows to opt in to

--- a/crates/common-wasm/src/data_converters/failure_converter.rs
+++ b/crates/common-wasm/src/data_converters/failure_converter.rs
@@ -15,12 +15,12 @@ use super::{
 };
 use crate::{
     error::{
-        ActivityExecutionError, ActivityFailureError, ApplicationFailure, CancelledError,
-        ChildWorkflowExecutionError, ChildWorkflowFailureError, ChildWorkflowStartError,
-        IncomingError, IncomingNexusHandlerError, IncomingNexusOperationExecutionError,
-        OutgoingActivityError, OutgoingError, OutgoingWorkflowError, ResetWorkflowError,
-        ServerError, TerminatedError, TimeoutError, WorkflowSignalError,
-        WorkflowSignalFailureError,
+        ActivityExecutionError, ActivityFailureError, ApplicationFailure,
+        CancelExternalWorkflowError, CancelledError, ChildWorkflowExecutionError,
+        ChildWorkflowFailureError, ChildWorkflowStartError, IncomingError,
+        IncomingNexusHandlerError, IncomingNexusOperationExecutionError, OutgoingActivityError,
+        OutgoingError, OutgoingWorkflowError, ResetWorkflowError, ServerError, TerminatedError,
+        TimeoutError, WorkflowSignalError, WorkflowSignalFailureError,
     },
     protos::temporal::api::{
         enums::v1::ApplicationErrorCategory as ProtoApplicationErrorCategory,
@@ -247,6 +247,9 @@ impl FailureConverter for DefaultFailureConverter {
             OutgoingError::Workflow(OutgoingWorkflowError::WorkflowSignal(signal)) => {
                 signal.encode_failure(payload_converter, context)
             }
+            OutgoingError::Workflow(OutgoingWorkflowError::CancelExternalWorkflow(cancel)) => {
+                cancel.encode_failure(payload_converter, context)
+            }
         };
         let mut failure = encoded.unwrap_or_else(|converter_error| {
             Failure::application_failure(
@@ -290,6 +293,7 @@ enum ClassifiedFailure<'a> {
     ChildWorkflowExecution(&'a ChildWorkflowExecutionError),
     ChildWorkflowStart(&'a ChildWorkflowStartError),
     WorkflowSignal(&'a WorkflowSignalError),
+    CancelExternalWorkflow(&'a CancelExternalWorkflowError),
     Generic(&'a (dyn std::error::Error + 'static)),
 }
 
@@ -315,6 +319,8 @@ impl<'a> ClassifiedFailure<'a> {
             Self::ChildWorkflowStart(child)
         } else if let Some(child_signal) = err.downcast_ref::<WorkflowSignalError>() {
             Self::WorkflowSignal(child_signal)
+        } else if let Some(cancel_external) = err.downcast_ref::<CancelExternalWorkflowError>() {
+            Self::CancelExternalWorkflow(cancel_external)
         } else {
             Self::Generic(err)
         }
@@ -361,6 +367,14 @@ impl<'a> ClassifiedFailure<'a> {
                 )
                 .unwrap_or_else(|converter_error| {
                     encode_failed_error_conversion(signal, converter_error)
+                }),
+            Self::CancelExternalWorkflow(cancel) => cancel
+                .encode_failure(
+                    &PayloadConverter::default(),
+                    &SerializationContextData::None,
+                )
+                .unwrap_or_else(|converter_error| {
+                    encode_failed_error_conversion(cancel, converter_error)
                 }),
             Self::Generic(err) => encode_generic_application_failure(err),
         }
@@ -464,6 +478,19 @@ impl EncodeFailure for WorkflowSignalError {
     ) -> Result<Failure, PayloadConversionError> {
         Ok(match self {
             Self::Failed(failure) => failure.failure().clone(),
+            Self::Serialization(err) => encode_generic_application_failure(err),
+        })
+    }
+}
+
+impl EncodeFailure for CancelExternalWorkflowError {
+    fn encode_failure(
+        &self,
+        _: &PayloadConverter,
+        _: &SerializationContextData,
+    ) -> Result<Failure, PayloadConversionError> {
+        Ok(match self {
+            Self::Failed(error) => error.failure().clone(),
             Self::Serialization(err) => encode_generic_application_failure(err),
         })
     }

--- a/crates/common-wasm/src/error.rs
+++ b/crates/common-wasm/src/error.rs
@@ -449,6 +449,9 @@ pub enum OutgoingWorkflowError {
     /// A workflow failure sourced from signaling a workflow.
     #[error(transparent)]
     WorkflowSignal(#[from] Box<WorkflowSignalError>),
+    /// A workflow failure sourced from requesting cancellation of an external workflow.
+    #[error(transparent)]
+    CancelExternalWorkflow(#[from] Box<CancelExternalWorkflowError>),
 }
 
 impl OutgoingWorkflowError {
@@ -462,6 +465,7 @@ impl OutgoingWorkflowError {
             Self::ChildWorkflowExecution(err) => err.as_cancelled(),
             Self::ChildWorkflowStart(err) => err.as_cancelled(),
             Self::WorkflowSignal(err) => err.as_cancelled(),
+            Self::CancelExternalWorkflow(err) => err.as_cancelled(),
         }
     }
 }
@@ -510,6 +514,15 @@ impl From<WorkflowSignalError> for OutgoingWorkflowError {
         match value {
             WorkflowSignalError::Serialization(err) => Self::PayloadConversion(err),
             other => Self::WorkflowSignal(Box::new(other)),
+        }
+    }
+}
+
+impl From<CancelExternalWorkflowError> for OutgoingWorkflowError {
+    fn from(value: CancelExternalWorkflowError) -> Self {
+        match value {
+            CancelExternalWorkflowError::Serialization(err) => Self::PayloadConversion(err),
+            other => Self::CancelExternalWorkflow(Box::new(other)),
         }
     }
 }
@@ -1153,6 +1166,48 @@ pub enum WorkflowSignalError {
     /// Failed to serialize the signal input payload.
     #[error("Signal payload conversion failed: {0}")]
     Serialization(#[from] PayloadConversionError),
+}
+
+/// Error returned when requesting cancellation of an external workflow fails.
+#[derive(Debug, thiserror::Error)]
+pub enum CancelExternalWorkflowError {
+    /// The cancellation request failed.
+    #[error("External workflow cancellation request failed: {}", .0.failure().message)]
+    Failed(#[source] Box<IncomingError>),
+    /// Failed to deserialize payloads attached to the cancellation failure.
+    #[error("External workflow cancellation failure conversion failed: {0}")]
+    Serialization(#[from] PayloadConversionError),
+}
+
+impl CancelExternalWorkflowError {
+    /// Returns the retained top-level cancellation failure proto, if one exists.
+    pub fn failure(&self) -> Option<&Failure> {
+        match self {
+            Self::Failed(err) => Some(err.failure()),
+            Self::Serialization(_) => None,
+        }
+    }
+
+    /// Returns the normalized cause of the cancellation failure, if any.
+    pub fn cause(&self) -> Option<&IncomingError> {
+        match self {
+            Self::Failed(err) => err.cause(),
+            Self::Serialization(_) => None,
+        }
+    }
+
+    /// Returns the normalized cancellation failure itself, if one exists.
+    pub fn reason(&self) -> Option<&IncomingError> {
+        match self {
+            Self::Failed(err) => Some(err),
+            Self::Serialization(_) => None,
+        }
+    }
+
+    /// If this error was caused by cancellation, returns the associated [`CancelledError`].
+    pub fn as_cancelled(&self) -> Option<&CancelledError> {
+        self.reason()?.as_cancelled()
+    }
 }
 
 impl WorkflowSignalError {

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_external.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_external.rs
@@ -5,7 +5,9 @@ use temporalio_common::protos::{
     temporal::api::enums::v1::{CommandType, EventType},
 };
 use temporalio_macros::{workflow, workflow_methods};
-use temporalio_sdk::{ApplicationFailure, WorkflowContext, WorkflowResult};
+use temporalio_sdk::{
+    ApplicationFailure, CancelExternalWorkflowError, WorkflowContext, WorkflowResult,
+};
 use temporalio_sdk_core::{
     replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder},
     test_help::MockPollCfg,
@@ -103,10 +105,12 @@ impl CancelSenderCanned {
     async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
         let handle = ctx.external_workflow("fake_wid", Some("fake_rid".into()));
         let res = handle.cancel(None).await;
-        if res.is_err() {
-            Err(ApplicationFailure::new("Cancel fail!").into())
-        } else {
-            Ok(())
+        match res {
+            Err(CancelExternalWorkflowError::Failed(_)) => {
+                Err(ApplicationFailure::new("Cancel fail!").into())
+            }
+            Err(error) => panic!("unexpected external cancellation error: {error}"),
+            Ok(()) => Ok(()),
         }
     }
 }

--- a/crates/sdk/src/error.rs
+++ b/crates/sdk/src/error.rs
@@ -40,6 +40,7 @@ pub enum WorkerRunError {
 
 pub use temporalio_common::error::{
     ActivityExecutionError, ApplicationErrorCategory, ApplicationFailure,
-    ChildWorkflowExecutionError, ChildWorkflowStartError, OutgoingActivityError, OutgoingError,
-    OutgoingWorkflowError, RetryState, TimeoutType, WorkflowSignalError,
+    CancelExternalWorkflowError, ChildWorkflowExecutionError, ChildWorkflowStartError,
+    OutgoingActivityError, OutgoingError, OutgoingWorkflowError, RetryState, TimeoutType,
+    WorkflowSignalError,
 };

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -89,10 +89,10 @@ pub use crate::plugins::{
 };
 pub use crate::{
     error::{
-        ActivityExecutionError, ApplicationFailure, ChildWorkflowExecutionError,
-        ChildWorkflowStartError, OutgoingActivityError, OutgoingError, OutgoingWorkflowError,
-        RetryState, TimeoutType, WorkerCreateError, WorkerRunError, WorkerValidationError,
-        WorkflowRegistrationError, WorkflowSignalError,
+        ActivityExecutionError, ApplicationFailure, CancelExternalWorkflowError,
+        ChildWorkflowExecutionError, ChildWorkflowStartError, OutgoingActivityError, OutgoingError,
+        OutgoingWorkflowError, RetryState, TimeoutType, WorkerCreateError, WorkerRunError,
+        WorkerValidationError, WorkflowRegistrationError, WorkflowSignalError,
     },
     workflow_registry::WorkflowDefinitions,
 };

--- a/crates/sdk/src/workflow_executor.rs
+++ b/crates/sdk/src/workflow_executor.rs
@@ -255,7 +255,7 @@ impl WorkflowExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use temporalio_workflow::__private::sdk::SdkWakeGuard;
+    use temporalio_workflow::WorkflowCancellationToken;
     use tokio::sync::oneshot;
 
     #[tokio::test]
@@ -344,34 +344,7 @@ mod tests {
     }
 
     #[test]
-    fn sdk_wake_guard_nesting() {
-        assert!(!is_sdk_wake());
-
-        let guard1 = SdkWakeGuard::new();
-        assert!(is_sdk_wake());
-
-        {
-            let _guard2 = SdkWakeGuard::new();
-            assert!(is_sdk_wake());
-        }
-        assert!(is_sdk_wake());
-
-        drop(guard1);
-        assert!(!is_sdk_wake());
-    }
-
-    #[test]
-    fn sdk_wake_guard_panic_safety() {
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _guard = SdkWakeGuard::new();
-            panic!("test panic");
-        }));
-        assert!(result.is_err());
-        assert!(!is_sdk_wake());
-    }
-
-    #[test]
-    fn wake_tracker_detects_non_sdk_wake() {
+    fn wake_tracker_distinguishes_sdk_wakes() {
         let tracker = WakeTracker::new();
         let noop = Waker::noop();
         let waker = tracker.new_per_poll_waker(noop);
@@ -379,23 +352,42 @@ mod tests {
         waker.wake_by_ref();
         assert!(tracker.take_non_sdk_wake());
 
-        let _guard = SdkWakeGuard::new();
-        waker.wake_by_ref();
+        // Create an SDK owned wake
+        let cancellation = WorkflowCancellationToken::new();
+        let mut cancelled = std::pin::pin!(cancellation.cancelled());
+        let mut cx = Context::from_waker(&waker);
+        assert!(cancelled.as_mut().poll(&mut cx).is_pending());
+
+        cancellation.cancel();
+
         assert!(!tracker.take_non_sdk_wake());
     }
 
+    struct CrossThreadWake(Waker);
+
+    impl Wake for CrossThreadWake {
+        fn wake(self: Arc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            let waker = self.0.clone();
+            std::thread::spawn(move || waker.wake()).join().unwrap();
+        }
+    }
     #[test]
     fn wake_tracker_cross_thread_detection() {
         let tracker = WakeTracker::new();
         let noop = Waker::noop();
-        let waker = tracker.new_per_poll_waker(noop);
+        let tracked_waker = tracker.new_per_poll_waker(noop);
+        let cross_thread_waker = Waker::from(Arc::new(CrossThreadWake(tracked_waker)));
 
-        let _guard = SdkWakeGuard::new();
+        let cancellation = WorkflowCancellationToken::new();
+        let mut cancelled = std::pin::pin!(cancellation.cancelled());
+        let mut cx = Context::from_waker(&cross_thread_waker);
+        assert!(cancelled.as_mut().poll(&mut cx).is_pending());
 
-        let handle = std::thread::spawn(move || {
-            waker.wake_by_ref();
-        });
-        handle.join().unwrap();
+        cancellation.cancel();
 
         assert!(tracker.take_non_sdk_wake());
     }

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -35,7 +35,6 @@ pub mod __private {
 
     pub mod sdk {
         pub use crate::runtime::{
-            SdkWakeGuard,
             entry::WorkflowImplementation,
             guest::WorkflowInstance,
             host::WorkflowHost,

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -64,8 +64,8 @@ pub use runtime::model::{TimerResult, WorkflowResult, WorkflowTermination};
 pub use temporalio_common_wasm::{
     ActivityCloseTimeouts, Memo, MemoValue, MemoValues, RetryPolicy,
     error::{
-        ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowStartError, RetryState,
-        TimeoutType, WorkflowSignalError,
+        ActivityExecutionError, CancelExternalWorkflowError, ChildWorkflowExecutionError,
+        ChildWorkflowStartError, RetryState, TimeoutType, WorkflowSignalError,
     },
 };
 pub use workflow_context::{

--- a/crates/workflow/src/runtime/mod.rs
+++ b/crates/workflow/src/runtime/mod.rs
@@ -238,13 +238,13 @@ pub(crate) fn mark_intercepted_handler_ready() {
 }
 
 /// Guard that marks the current scope as an SDK-initiated wake source.
-pub struct SdkWakeGuard {
+pub(crate) struct SdkWakeGuard {
     _not_send_or_sync: PhantomData<Rc<()>>,
 }
 
 impl SdkWakeGuard {
     /// Enters an SDK wake scope until the returned guard is dropped.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         SDK_WAKE_DEPTH.with(|c| c.set(c.get() + 1));
         Self {
             _not_send_or_sync: PhantomData,
@@ -279,5 +279,45 @@ impl<F: Future + Unpin> Future for SdkGuardedFuture<F> {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let _guard = SdkWakeGuard::new();
         Pin::new(&mut self.0).poll(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sdk_wake_guard_nesting() {
+        assert!(!is_sdk_wake());
+
+        {
+            let _guard1 = SdkWakeGuard::new();
+            assert!(is_sdk_wake());
+            {
+                let _guard2 = SdkWakeGuard::new();
+                assert!(is_sdk_wake());
+            }
+            assert!(is_sdk_wake());
+        }
+        assert!(!is_sdk_wake());
+    }
+
+    #[test]
+    fn sdk_wake_guard_panic_safety() {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = SdkWakeGuard::new();
+            panic!("test panic");
+        }));
+        assert!(result.is_err());
+        assert!(!is_sdk_wake());
+    }
+
+    #[test]
+    fn sdk_wake_guard_is_thread_local() {
+        let _guard = SdkWakeGuard::new();
+        assert!(is_sdk_wake());
+
+        let child_is_sdk_wake = std::thread::spawn(is_sdk_wake).join().unwrap();
+        assert!(!child_is_sdk_wake);
     }
 }

--- a/crates/workflow/src/runtime/model.rs
+++ b/crates/workflow/src/runtime/model.rs
@@ -15,8 +15,8 @@ use temporalio_common_wasm::{
     WorkflowDefinition,
     data_converters::{PayloadConversionError, TemporalSerializable},
     error::{
-        ActivityExecutionError, ApplicationFailure, ChildWorkflowExecutionError,
-        ChildWorkflowStartError, WorkflowSignalError,
+        ActivityExecutionError, ApplicationFailure, CancelExternalWorkflowError,
+        ChildWorkflowExecutionError, ChildWorkflowStartError, WorkflowSignalError,
     },
     protos::{
         coresdk::{
@@ -60,11 +60,11 @@ pub(crate) struct SignalExternalOk;
 /// Result of awaiting on sending a signal to an external workflow
 pub(crate) type SignalExternalWfResult = Result<SignalExternalOk, Failure>;
 
-/// Successful result of sending a cancel request to an external workflow
+/// Distinguishes external cancellation resolutions from other command results.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct CancelExternalOk;
-/// Result of awaiting on sending a cancel request to an external workflow
-pub type CancelExternalWfResult = Result<CancelExternalOk, Failure>;
+pub(crate) struct CancelExternalOk;
+/// Internal result delivered when an external cancellation command resolves.
+pub(crate) type CancelExternalWfResult = Result<CancelExternalOk, Failure>;
 
 pub(crate) trait Unblockable {
     type OtherDat;
@@ -261,6 +261,12 @@ impl From<WorkflowSignalError> for WorkflowTermination {
     }
 }
 
+impl From<CancelExternalWorkflowError> for WorkflowTermination {
+    fn from(value: CancelExternalWorkflowError) -> Self {
+        Self::Failed(value.into())
+    }
+}
+
 impl From<ChildWorkflowStartError> for WorkflowTermination {
     fn from(value: ChildWorkflowStartError) -> Self {
         Self::Failed(value.into())
@@ -283,6 +289,7 @@ mod tests {
     #[case::child_start(ChildWorkflowStartError::Serialization(conversion_error()))]
     #[case::child_execution(ChildWorkflowExecutionError::Serialization(conversion_error()))]
     #[case::signal(WorkflowSignalError::Serialization(conversion_error()))]
+    #[case::cancel_external(CancelExternalWorkflowError::Serialization(conversion_error()))]
     fn conversion_error_is_preserved_in_workflow_termination<T: Into<WorkflowTermination>>(
         #[case] error: T,
     ) {

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -33,15 +33,15 @@ use crate::{
         types::WorkflowInit,
     },
     workflow_interceptors::{
-        CancelExternalWorkflowInput, CancellableWorkflowOutboundFuture,
-        ChildWorkflowOutboundResult, ContinueAsNewInput, ScheduleActivityInput,
-        ScheduleLocalActivityInput, SignalWorkflowInput, SignalWorkflowResult,
-        SignalWorkflowTarget, StartChildWorkflowInput, StartChildWorkflowResult, StartTimerInput,
-        WorkflowCancellationHandle, WorkflowInterceptor, WorkflowInterceptorConstructor,
-        WorkflowInterceptorContext, WorkflowNext, WorkflowOutboundFuture, WorkflowOutboundValue,
-        call_cancel_external_workflow, call_continue_as_new, call_schedule_activity,
-        call_schedule_local_activity, call_signal_workflow, call_start_child_workflow,
-        call_start_timer,
+        CancelExternalWorkflowInput, CancelExternalWorkflowResult,
+        CancellableWorkflowOutboundFuture, ChildWorkflowOutboundResult, ContinueAsNewInput,
+        ScheduleActivityInput, ScheduleLocalActivityInput, SignalWorkflowInput,
+        SignalWorkflowResult, SignalWorkflowTarget, StartChildWorkflowInput,
+        StartChildWorkflowResult, StartTimerInput, WorkflowCancellationHandle, WorkflowInterceptor,
+        WorkflowInterceptorConstructor, WorkflowInterceptorContext, WorkflowNext,
+        WorkflowOutboundFuture, WorkflowOutboundValue, call_cancel_external_workflow,
+        call_continue_as_new, call_schedule_activity, call_schedule_local_activity,
+        call_signal_workflow, call_start_child_workflow, call_start_timer,
     },
 };
 use futures_channel::oneshot;
@@ -68,13 +68,13 @@ use temporalio_common_wasm::{
     ActivityDefinition, Memo, SignalDefinition, WorkflowDefinition,
     data_converters::{
         ActivityExecutionDecodeHint, ChildWorkflowExecutionDecodeHint,
-        ChildWorkflowStartDecodeHint, DataConverter, GenericPayloadConverter,
+        ChildWorkflowStartDecodeHint, DataConverter, GenericPayloadConverter, NoopDecodeHint,
         PayloadConversionError, PayloadConverter, SerializationContext, SerializationContextData,
         TemporalDeserializable, WorkflowSerializationContext, WorkflowSignalDecodeHint,
     },
     error::{
-        ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowStartError,
-        WorkflowSignalError,
+        ActivityExecutionError, CancelExternalWorkflowError, ChildWorkflowExecutionError,
+        ChildWorkflowStartError, WorkflowSignalError,
     },
     protos::{
         coresdk::{
@@ -1428,7 +1428,7 @@ impl BaseWorkflowContext {
     fn cancel_external_workflow(
         &self,
         input: CancelExternalWorkflowInput,
-    ) -> WorkflowOutboundFuture<CancelExternalWfResult> {
+    ) -> WorkflowOutboundFuture<CancelExternalWorkflowResult> {
         let base_ctx = self.clone();
         let next = WorkflowNext::new(move |input: CancelExternalWorkflowInput| {
             let seq = base_ctx
@@ -1436,7 +1436,7 @@ impl BaseWorkflowContext {
                 .seq_nums
                 .borrow_mut()
                 .next_cancel_external_wf_seq();
-            let (cmd, unblocker) = WFCommandFut::new();
+            let (cmd, unblocker) = WFCommandFut::<CancelExternalWfResult, ()>::new();
             base_ctx
                 .inner
                 .runtime
@@ -1455,7 +1455,18 @@ impl BaseWorkflowContext {
                 )
                 .into(),
             );
-            WorkflowOutboundFuture::new(cmd)
+            let data_converter = base_ctx.data_converter().clone();
+            WorkflowOutboundFuture::new(async move {
+                match cmd.await {
+                    Ok(_) => Ok(()),
+                    Err(failure) => {
+                        let context =
+                            SerializationContextData::Workflow(WorkflowSerializationContext::new());
+                        let error = data_converter.to_error(&context, failure, NoopDecodeHint)?;
+                        Err(CancelExternalWorkflowError::Failed(Box::new(error)))
+                    }
+                }
+            })
         });
         let interceptors = self.inner.workflow_interceptors.clone();
         let future = call_cancel_external_workflow(
@@ -3349,7 +3360,7 @@ impl ExternalWorkflowHandle {
     pub fn cancel(
         &self,
         reason: Option<String>,
-    ) -> impl FusedFuture<Output = CancelExternalWfResult> {
+    ) -> impl FusedFuture<Output = CancelExternalWorkflowResult> {
         self.base_ctx
             .cancel_external_workflow(CancelExternalWorkflowInput {
                 workflow_id: self.workflow_id.clone(),
@@ -4181,9 +4192,9 @@ mod tests {
                 next: WorkflowNext<
                     'static,
                     CancelExternalWorkflowInput,
-                    WorkflowOutboundFuture<CancelExternalWfResult>,
+                    WorkflowOutboundFuture<CancelExternalWorkflowResult>,
                 >,
-            ) -> WorkflowOutboundFuture<CancelExternalWfResult> {
+            ) -> WorkflowOutboundFuture<CancelExternalWorkflowResult> {
                 input.workflow_id = "mutated-cancel-workflow".to_string();
                 input.run_id = Some("mutated-cancel-run".to_string());
                 input.reason = Some("mutated-reason".to_string());

--- a/crates/workflow/src/workflow_interceptors.rs
+++ b/crates/workflow/src/workflow_interceptors.rs
@@ -81,13 +81,12 @@
 //! # let _ = interceptor_constructor();
 //! ```
 
-#[doc(inline)]
-pub use crate::runtime::model::{CancelExternalOk, CancelExternalWfResult};
 use crate::{
-    ActivityOptions, BaseWorkflowContext, CancellableFuture, CancellableFutureWithReason,
-    ChildWorkflowOptions, ContinueAsNewOptions, ExternalWorkflowHandle, LocalActivityOptions,
-    SignalWorkflowOptions, StartChildWorkflowOutput, StartedChildWorkflow, TimerOptions,
-    WorkflowCancellationToken, WorkflowContextView, WorkflowRandomStream,
+    ActivityOptions, BaseWorkflowContext, CancelExternalWorkflowError, CancellableFuture,
+    CancellableFutureWithReason, ChildWorkflowOptions, ContinueAsNewOptions,
+    ExternalWorkflowHandle, LocalActivityOptions, SignalWorkflowOptions, StartChildWorkflowOutput,
+    StartedChildWorkflow, TimerOptions, WorkflowCancellationToken, WorkflowContextView,
+    WorkflowRandomStream,
     cancellation::WorkflowCancellationRegistration,
     runtime::{
         entry::WorkflowError,
@@ -1379,6 +1378,9 @@ pub type ChildWorkflowOutboundResult =
 /// Result of an intercepted signal call.
 pub type SignalWorkflowResult = Result<(), WorkflowSignalError>;
 
+/// Result of requesting cancellation of an external workflow.
+pub type CancelExternalWorkflowResult = Result<(), CancelExternalWorkflowError>;
+
 /// Result of an intercepted child workflow start.
 pub type StartChildWorkflowResult = Result<StartChildWorkflowOutput, ChildWorkflowStartError>;
 
@@ -1565,9 +1567,9 @@ pub trait WorkflowInterceptor: 'static {
         next: WorkflowNext<
             'static,
             CancelExternalWorkflowInput,
-            WorkflowOutboundFuture<CancelExternalWfResult>,
+            WorkflowOutboundFuture<CancelExternalWorkflowResult>,
         >,
-    ) -> WorkflowOutboundFuture<CancelExternalWfResult> {
+    ) -> WorkflowOutboundFuture<CancelExternalWorkflowResult> {
         next.run(input)
     }
 
@@ -1673,7 +1675,7 @@ outbound_chain!(
     cancel_external_workflow,
     WorkflowInterceptorContext,
     CancelExternalWorkflowInput,
-    WorkflowOutboundFuture<CancelExternalWfResult>
+    WorkflowOutboundFuture<CancelExternalWorkflowResult>
 );
 outbound_chain!(
     call_continue_as_new,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
I somehow missed this when I was doing the same for signal workflow. Making this a standard result with a proper error instead of exposing the custom types for interceptors.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io --> 