### PR TITLE
chore(sdk): make SdkWakeGuard private

### DIFF
--- a/crates/sdk/src/workflow_executor.rs
+++ b/crates/sdk/src/workflow_executor.rs
@@ -255,7 +255,7 @@ impl WorkflowExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use temporalio_workflow::__private::sdk::SdkWakeGuard;
+    use temporalio_workflow::WorkflowCancellationToken;
     use tokio::sync::oneshot;
 
     #[tokio::test]
@@ -344,34 +344,7 @@ mod tests {
     }
 
     #[test]
-    fn sdk_wake_guard_nesting() {
-        assert!(!is_sdk_wake());
-
-        let guard1 = SdkWakeGuard::new();
-        assert!(is_sdk_wake());
-
-        {
-            let _guard2 = SdkWakeGuard::new();
-            assert!(is_sdk_wake());
-        }
-        assert!(is_sdk_wake());
-
-        drop(guard1);
-        assert!(!is_sdk_wake());
-    }
-
-    #[test]
-    fn sdk_wake_guard_panic_safety() {
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _guard = SdkWakeGuard::new();
-            panic!("test panic");
-        }));
-        assert!(result.is_err());
-        assert!(!is_sdk_wake());
-    }
-
-    #[test]
-    fn wake_tracker_detects_non_sdk_wake() {
+    fn wake_tracker_distinguishes_sdk_wakes() {
         let tracker = WakeTracker::new();
         let noop = Waker::noop();
         let waker = tracker.new_per_poll_waker(noop);
@@ -379,23 +352,42 @@ mod tests {
         waker.wake_by_ref();
         assert!(tracker.take_non_sdk_wake());
 
-        let _guard = SdkWakeGuard::new();
-        waker.wake_by_ref();
+        // Create an SDK owned wake
+        let cancellation = WorkflowCancellationToken::new();
+        let mut cancelled = std::pin::pin!(cancellation.cancelled());
+        let mut cx = Context::from_waker(&waker);
+        assert!(cancelled.as_mut().poll(&mut cx).is_pending());
+
+        cancellation.cancel();
+
         assert!(!tracker.take_non_sdk_wake());
     }
 
+    struct CrossThreadWake(Waker);
+
+    impl Wake for CrossThreadWake {
+        fn wake(self: Arc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            let waker = self.0.clone();
+            std::thread::spawn(move || waker.wake()).join().unwrap();
+        }
+    }
     #[test]
     fn wake_tracker_cross_thread_detection() {
         let tracker = WakeTracker::new();
         let noop = Waker::noop();
-        let waker = tracker.new_per_poll_waker(noop);
+        let tracked_waker = tracker.new_per_poll_waker(noop);
+        let cross_thread_waker = Waker::from(Arc::new(CrossThreadWake(tracked_waker)));
 
-        let _guard = SdkWakeGuard::new();
+        let cancellation = WorkflowCancellationToken::new();
+        let mut cancelled = std::pin::pin!(cancellation.cancelled());
+        let mut cx = Context::from_waker(&cross_thread_waker);
+        assert!(cancelled.as_mut().poll(&mut cx).is_pending());
 
-        let handle = std::thread::spawn(move || {
-            waker.wake_by_ref();
-        });
-        handle.join().unwrap();
+        cancellation.cancel();
 
         assert!(tracker.take_non_sdk_wake());
     }

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -35,7 +35,6 @@ pub mod __private {
 
     pub mod sdk {
         pub use crate::runtime::{
-            SdkWakeGuard,
             entry::WorkflowImplementation,
             guest::WorkflowInstance,
             host::WorkflowHost,

--- a/crates/workflow/src/runtime/mod.rs
+++ b/crates/workflow/src/runtime/mod.rs
@@ -238,13 +238,13 @@ pub(crate) fn mark_intercepted_handler_ready() {
 }
 
 /// Guard that marks the current scope as an SDK-initiated wake source.
-pub struct SdkWakeGuard {
+pub(crate) struct SdkWakeGuard {
     _not_send_or_sync: PhantomData<Rc<()>>,
 }
 
 impl SdkWakeGuard {
     /// Enters an SDK wake scope until the returned guard is dropped.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         SDK_WAKE_DEPTH.with(|c| c.set(c.get() + 1));
         Self {
             _not_send_or_sync: PhantomData,
@@ -279,5 +279,45 @@ impl<F: Future + Unpin> Future for SdkGuardedFuture<F> {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let _guard = SdkWakeGuard::new();
         Pin::new(&mut self.0).poll(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sdk_wake_guard_nesting() {
+        assert!(!is_sdk_wake());
+
+        {
+            let _guard1 = SdkWakeGuard::new();
+            assert!(is_sdk_wake());
+            {
+                let _guard2 = SdkWakeGuard::new();
+                assert!(is_sdk_wake());
+            }
+            assert!(is_sdk_wake());
+        }
+        assert!(!is_sdk_wake());
+    }
+
+    #[test]
+    fn sdk_wake_guard_panic_safety() {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = SdkWakeGuard::new();
+            panic!("test panic");
+        }));
+        assert!(result.is_err());
+        assert!(!is_sdk_wake());
+    }
+
+    #[test]
+    fn sdk_wake_guard_is_thread_local() {
+        let _guard = SdkWakeGuard::new();
+        assert!(is_sdk_wake());
+
+        let child_is_sdk_wake = std::thread::spawn(is_sdk_wake).join().unwrap();
+        assert!(!child_is_sdk_wake);
     }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Make `SdkWakeGuard` private

## Why?
This was only public for testing the workflow executor behavior. With the cancellation token we now have an easy way to trigger an SDK wake.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io --> 