### PR TITLE
chore(sdk): mark remaining error enums as non exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ relevant information.
 ### Added
 * `CancelExternalWorkflowError` and `workflow_interceptors::CancelExternalWorkflowResult`
   for use in interceptors.
+### Breaking Changes
+* `ActivityError`, `PayloadConversionError`, `ActivityExecutionError`,
+  `ChildWorkflowStartError`, `ChildWorkflowExecutionError`, and `WorkflowSignalError` are now
+  non-exhaustive. Add wildcard branches when matching these enums.
 
 ## [0.8.0] - 2026-09-02
 

--- a/crates/common-wasm/src/activity_definition.rs
+++ b/crates/common-wasm/src/activity_definition.rs
@@ -44,6 +44,7 @@ impl ActivityDefinition for UntypedActivity {
 
 /// Returned as errors from activity functions.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ActivityError {
     /// Return this error to attach application-failure metadata to an activity failure.
     Application(Box<ApplicationFailure>),

--- a/crates/common-wasm/src/data_converters.rs
+++ b/crates/common-wasm/src/data_converters.rs
@@ -256,6 +256,7 @@ impl Default for PayloadConverter {
 
 /// Errors that can occur during payload conversion.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum PayloadConversionError {
     /// The payload's encoding does not match what the converter expects.
     WrongEncoding,

--- a/crates/common-wasm/src/error.rs
+++ b/crates/common-wasm/src/error.rs
@@ -990,6 +990,7 @@ incoming_failure_wrapper!(
 
 /// Error type for activity execution outcomes.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ActivityExecutionError {
     /// The activity failed with the given failure details.
     #[error("Activity failed: {}", .0.failure().message)]
@@ -1051,6 +1052,7 @@ impl ActivityExecutionError {
 
 /// Error returned when starting a child workflow fails.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ChildWorkflowStartError {
     /// The child workflow start was cancelled before the normal execution wrapper path existed.
     #[error("Child workflow start cancelled: {}", .0.failure().message)]
@@ -1104,6 +1106,7 @@ impl ChildWorkflowStartError {
 
 /// Error returned when a child workflow execution fails.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ChildWorkflowExecutionError {
     /// The child workflow failed.
     #[error("Child workflow failed: {}", .0.failure().message)]
@@ -1159,6 +1162,7 @@ impl ChildWorkflowExecutionError {
 
 /// Error returned when signaling a workflow fails.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum WorkflowSignalError {
     /// The signal delivery failed.
     #[error("Child workflow signal failed: {}", .0.failure().message)]

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -208,6 +208,7 @@ fn activity_execution_result_status(result: &ExecuteActivityResult) -> &'static 
         Err(ActivityError::Application(_)) => "failed",
         Err(ActivityError::Cancelled { .. }) => "cancelled",
         Err(ActivityError::WillCompleteAsync) => "will_complete_async",
+        Err(_) => "unknown",
     }
 }
 

--- a/crates/sdk/src/activities.rs
+++ b/crates/sdk/src/activities.rs
@@ -672,6 +672,12 @@ pub(crate) fn activity_error_to_core_result(
             OutgoingError::Activity(OutgoingActivityError::Cancelled { details }),
         )),
         ActivityError::WillCompleteAsync => ActivityExecutionResult::will_complete_async(),
+        other => ActivityExecutionResult::fail(dc.to_failure(
+            &SerializationContextData::Activity(ActivitySerializationContext::new()),
+            OutgoingError::Activity(OutgoingActivityError::Application(Box::new(
+                ApplicationFailure::new(anyhow::anyhow!("Unsupported activity error: {other:?}")),
+            ))),
+        )),
     }
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Mark the few remaining error enums as `non_exhaustive`

## Why?
Keeps the door open if we need to expand these in the future for some reason.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
