### PR TITLE
feat(sdk): add not found variant for signal/cancel external wf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ relevant information.
 * `ActivityError`, `PayloadConversionError`, `ActivityExecutionError`,
   `ChildWorkflowStartError`, `ChildWorkflowExecutionError`, and `WorkflowSignalError` are now
   non-exhaustive. Add wildcard branches when matching these enums.
+  for use in interceptors, with `WorkflowCancelFailureError` exposing the decoded cancellation
+  failure.
 * `WorkflowSignalError::NotFound` and `CancelExternalWorkflowError::NotFound` let workflows
   distinguish a missing signal or cancellation target from other delivery failures.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ relevant information.
 * `ActivityError`, `PayloadConversionError`, `ActivityExecutionError`,
   `ChildWorkflowStartError`, `ChildWorkflowExecutionError`, and `WorkflowSignalError` are now
   non-exhaustive. Add wildcard branches when matching these enums.
+* `WorkflowSignalError::NotFound` and `CancelExternalWorkflowError::NotFound` let workflows
+  distinguish a missing signal or cancellation target from other delivery failures.
 
 ## [0.8.0] - 2026-09-02
 

--- a/crates/common-wasm/src/data_converters.rs
+++ b/crates/common-wasm/src/data_converters.rs
@@ -5,8 +5,9 @@ mod failure_converter;
 mod well_known;
 
 pub use failure_converter::{
-    ActivityExecutionDecodeHint, ChildWorkflowExecutionDecodeHint, ChildWorkflowStartDecodeHint,
-    CommonAttributes, DefaultFailureConverter, FailureConverter, FailureDecodeHint, NoopDecodeHint,
+    ActivityExecutionDecodeHint, CancelExternalWorkflowDecodeHint,
+    ChildWorkflowExecutionDecodeHint, ChildWorkflowStartDecodeHint, CommonAttributes,
+    DefaultFailureConverter, FailureConverter, FailureDecodeHint, NoopDecodeHint,
     WorkflowSignalDecodeHint,
 };
 use well_known::{BINARY_NULL_ENCODING_VAL, WellKnownType, binary_null_payload};

--- a/crates/common-wasm/src/data_converters/failure_converter.rs
+++ b/crates/common-wasm/src/data_converters/failure_converter.rs
@@ -23,7 +23,10 @@ use crate::{
         TimeoutError, WorkflowSignalError, WorkflowSignalFailureError,
     },
     protos::temporal::api::{
-        enums::v1::ApplicationErrorCategory as ProtoApplicationErrorCategory,
+        enums::v1::{
+            ApplicationErrorCategory as ProtoApplicationErrorCategory,
+            CancelExternalWorkflowExecutionFailedCause, SignalExternalWorkflowExecutionFailedCause,
+        },
         failure::v1::{
             ActivityFailureInfo, ApplicationFailureInfo, CanceledFailureInfo,
             ChildWorkflowExecutionFailureInfo, Failure, failure::FailureInfo,
@@ -204,16 +207,58 @@ impl FailureDecodeHint for ChildWorkflowExecutionDecodeHint {
 /// Decode hint for workflow signal failures.
 #[derive(Debug, Clone, Copy, Default)]
 #[non_exhaustive]
-pub struct WorkflowSignalDecodeHint;
+pub struct WorkflowSignalDecodeHint {
+    cause: SignalExternalWorkflowExecutionFailedCause,
+}
+
+impl WorkflowSignalDecodeHint {
+    /// Creates a decode hint with the server-reported signal failure cause.
+    pub fn new(cause: SignalExternalWorkflowExecutionFailedCause) -> Self {
+        Self { cause }
+    }
+}
 
 impl FailureDecodeHint for WorkflowSignalDecodeHint {
     type Output = WorkflowSignalError;
 
     fn adapt(self, normalized: IncomingError) -> Self::Output {
         let failure = normalized.failure().clone();
-        WorkflowSignalError::Failed(Box::new(WorkflowSignalFailureError::new(
-            failure, normalized,
-        )))
+        let error = Box::new(WorkflowSignalFailureError::new(failure, normalized));
+        if self.cause
+            == SignalExternalWorkflowExecutionFailedCause::ExternalWorkflowExecutionNotFound
+        {
+            WorkflowSignalError::NotFound(error)
+        } else {
+            WorkflowSignalError::Failed(error)
+        }
+    }
+}
+
+/// Decode hint for external-workflow cancellation failures.
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct CancelExternalWorkflowDecodeHint {
+    cause: CancelExternalWorkflowExecutionFailedCause,
+}
+
+impl CancelExternalWorkflowDecodeHint {
+    /// Creates a decode hint with the server-reported cancellation failure cause.
+    pub fn new(cause: CancelExternalWorkflowExecutionFailedCause) -> Self {
+        Self { cause }
+    }
+}
+
+impl FailureDecodeHint for CancelExternalWorkflowDecodeHint {
+    type Output = CancelExternalWorkflowError;
+
+    fn adapt(self, normalized: IncomingError) -> Self::Output {
+        if self.cause
+            == CancelExternalWorkflowExecutionFailedCause::ExternalWorkflowExecutionNotFound
+        {
+            CancelExternalWorkflowError::NotFound(Box::new(normalized))
+        } else {
+            CancelExternalWorkflowError::Failed(Box::new(normalized))
+        }
     }
 }
 
@@ -477,7 +522,7 @@ impl EncodeFailure for WorkflowSignalError {
         _: &SerializationContextData,
     ) -> Result<Failure, PayloadConversionError> {
         Ok(match self {
-            Self::Failed(failure) => failure.failure().clone(),
+            Self::NotFound(failure) | Self::Failed(failure) => failure.failure().clone(),
             Self::Serialization(err) => encode_generic_application_failure(err),
         })
     }
@@ -490,7 +535,7 @@ impl EncodeFailure for CancelExternalWorkflowError {
         _: &SerializationContextData,
     ) -> Result<Failure, PayloadConversionError> {
         Ok(match self {
-            Self::Failed(error) => error.failure().clone(),
+            Self::NotFound(error) | Self::Failed(error) => error.failure().clone(),
             Self::Serialization(err) => encode_generic_application_failure(err),
         })
     }
@@ -1607,6 +1652,50 @@ mod tests {
     }
 
     #[test]
+    fn workflow_signal_decode_hint_recognizes_not_found() {
+        let failure = Failure {
+            message: "workflow not found".to_owned(),
+            ..Default::default()
+        };
+        let decoded = data_converter()
+            .to_error(
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+                failure.clone(),
+                WorkflowSignalDecodeHint::new(
+                    SignalExternalWorkflowExecutionFailedCause::ExternalWorkflowExecutionNotFound,
+                ),
+            )
+            .unwrap();
+
+        let WorkflowSignalError::NotFound(decoded_failure) = decoded else {
+            panic!("expected not-found workflow signal error");
+        };
+        assert_eq!(decoded_failure.failure(), &failure);
+    }
+
+    #[test]
+    fn cancel_external_workflow_decode_hint_recognizes_not_found() {
+        let failure = Failure {
+            message: "workflow not found".to_owned(),
+            ..Default::default()
+        };
+        let decoded = data_converter()
+            .to_error(
+                &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+                failure.clone(),
+                CancelExternalWorkflowDecodeHint::new(
+                    CancelExternalWorkflowExecutionFailedCause::ExternalWorkflowExecutionNotFound,
+                ),
+            )
+            .unwrap();
+
+        let CancelExternalWorkflowError::NotFound(decoded_failure) = decoded else {
+            panic!("expected not-found external-workflow cancellation error");
+        };
+        assert_eq!(decoded_failure.failure(), &failure);
+    }
+
+    #[test]
     fn child_workflow_signal_decode_hint_preserves_failure_proto() {
         let failure = Failure {
             message: "child workflow signal failed".to_owned(),
@@ -1623,7 +1712,7 @@ mod tests {
             .to_error(
                 &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
                 failure.clone(),
-                WorkflowSignalDecodeHint,
+                WorkflowSignalDecodeHint::default(),
             )
             .unwrap();
 

--- a/crates/common-wasm/src/data_converters/failure_converter.rs
+++ b/crates/common-wasm/src/data_converters/failure_converter.rs
@@ -20,7 +20,7 @@ use crate::{
         ChildWorkflowFailureError, ChildWorkflowStartError, IncomingError,
         IncomingNexusHandlerError, IncomingNexusOperationExecutionError, OutgoingActivityError,
         OutgoingError, OutgoingWorkflowError, ResetWorkflowError, ServerError, TerminatedError,
-        TimeoutError, WorkflowSignalError, WorkflowSignalFailureError,
+        TimeoutError, WorkflowCancelFailureError, WorkflowSignalError, WorkflowSignalFailureError,
     },
     protos::temporal::api::{
         enums::v1::{
@@ -252,12 +252,14 @@ impl FailureDecodeHint for CancelExternalWorkflowDecodeHint {
     type Output = CancelExternalWorkflowError;
 
     fn adapt(self, normalized: IncomingError) -> Self::Output {
+        let failure = normalized.failure().clone();
+        let error = Box::new(WorkflowCancelFailureError::new(failure, normalized));
         if self.cause
             == CancelExternalWorkflowExecutionFailedCause::ExternalWorkflowExecutionNotFound
         {
-            CancelExternalWorkflowError::NotFound(Box::new(normalized))
+            CancelExternalWorkflowError::NotFound(error)
         } else {
-            CancelExternalWorkflowError::Failed(Box::new(normalized))
+            CancelExternalWorkflowError::Failed(error)
         }
     }
 }
@@ -1677,6 +1679,13 @@ mod tests {
     fn cancel_external_workflow_decode_hint_recognizes_not_found() {
         let failure = Failure {
             message: "workflow not found".to_owned(),
+            cause: Some(Box::new(Failure {
+                message: "timed out".to_owned(),
+                failure_info: Some(FailureInfo::TimeoutFailureInfo(
+                    TimeoutFailureInfo::default(),
+                )),
+                ..Default::default()
+            })),
             ..Default::default()
         };
         let decoded = data_converter()
@@ -1693,6 +1702,7 @@ mod tests {
             panic!("expected not-found external-workflow cancellation error");
         };
         assert_eq!(decoded_failure.failure(), &failure);
+        assert!(std::error::Error::source(&*decoded_failure).is_some());
     }
 
     #[test]

--- a/crates/common-wasm/src/error.rs
+++ b/crates/common-wasm/src/error.rs
@@ -1180,10 +1180,10 @@ pub enum WorkflowSignalError {
 pub enum CancelExternalWorkflowError {
     /// The target workflow was not found.
     #[error("Workflow not found: {}", .0.failure().message)]
-    NotFound(#[source] Box<IncomingError>),
+    NotFound(#[source] Box<WorkflowCancelFailureError>),
     /// The cancellation request failed.
     #[error("External workflow cancellation request failed: {}", .0.failure().message)]
-    Failed(#[source] Box<IncomingError>),
+    Failed(#[source] Box<WorkflowCancelFailureError>),
     /// Failed to deserialize payloads attached to the cancellation failure.
     #[error("External workflow cancellation failure conversion failed: {0}")]
     Serialization(#[from] PayloadConversionError),
@@ -1209,7 +1209,7 @@ impl CancelExternalWorkflowError {
     /// Returns the normalized cancellation failure itself, if one exists.
     pub fn reason(&self) -> Option<&IncomingError> {
         match self {
-            Self::NotFound(err) | Self::Failed(err) => Some(err),
+            Self::NotFound(err) | Self::Failed(err) => Some(err.error()),
             Self::Serialization(_) => None,
         }
     }
@@ -1295,6 +1295,51 @@ impl std::fmt::Display for WorkflowSignalFailureError {
 }
 
 impl std::error::Error for WorkflowSignalFailureError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.cause()
+            .map(|cause| cause as &(dyn std::error::Error + 'static))
+    }
+}
+
+/// A normalized external workflow cancellation failure wrapper.
+#[derive(Debug)]
+pub struct WorkflowCancelFailureError {
+    failure: Failure,
+    error: Box<IncomingError>,
+}
+
+impl WorkflowCancelFailureError {
+    /// Creates an external workflow cancellation failure wrapper.
+    pub(crate) fn new(failure: Failure, error: IncomingError) -> Self {
+        Self {
+            failure,
+            error: Box::new(error),
+        }
+    }
+
+    /// Returns the retained top-level proto failure.
+    pub fn failure(&self) -> &Failure {
+        &self.failure
+    }
+
+    /// Returns the normalized direct cause of the external workflow cancellation failure, if any.
+    pub fn cause(&self) -> Option<&IncomingError> {
+        self.error.cause()
+    }
+
+    /// Returns the direct decoded incoming error represented by the top-level proto failure.
+    pub fn error(&self) -> &IncomingError {
+        &self.error
+    }
+}
+
+impl std::fmt::Display for WorkflowCancelFailureError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.failure.fmt(f)
+    }
+}
+
+impl std::error::Error for WorkflowCancelFailureError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         self.cause()
             .map(|cause| cause as &(dyn std::error::Error + 'static))

--- a/crates/common-wasm/src/error.rs
+++ b/crates/common-wasm/src/error.rs
@@ -1164,6 +1164,9 @@ impl ChildWorkflowExecutionError {
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum WorkflowSignalError {
+    /// The target workflow was not found.
+    #[error("Workflow not found: {}", .0.failure().message)]
+    NotFound(#[source] Box<WorkflowSignalFailureError>),
     /// The signal delivery failed.
     #[error("Child workflow signal failed: {}", .0.failure().message)]
     Failed(#[source] Box<WorkflowSignalFailureError>),
@@ -1175,6 +1178,9 @@ pub enum WorkflowSignalError {
 /// Error returned when requesting cancellation of an external workflow fails.
 #[derive(Debug, thiserror::Error)]
 pub enum CancelExternalWorkflowError {
+    /// The target workflow was not found.
+    #[error("Workflow not found: {}", .0.failure().message)]
+    NotFound(#[source] Box<IncomingError>),
     /// The cancellation request failed.
     #[error("External workflow cancellation request failed: {}", .0.failure().message)]
     Failed(#[source] Box<IncomingError>),
@@ -1187,7 +1193,7 @@ impl CancelExternalWorkflowError {
     /// Returns the retained top-level cancellation failure proto, if one exists.
     pub fn failure(&self) -> Option<&Failure> {
         match self {
-            Self::Failed(err) => Some(err.failure()),
+            Self::NotFound(err) | Self::Failed(err) => Some(err.failure()),
             Self::Serialization(_) => None,
         }
     }
@@ -1195,7 +1201,7 @@ impl CancelExternalWorkflowError {
     /// Returns the normalized cause of the cancellation failure, if any.
     pub fn cause(&self) -> Option<&IncomingError> {
         match self {
-            Self::Failed(err) => err.cause(),
+            Self::NotFound(err) | Self::Failed(err) => err.cause(),
             Self::Serialization(_) => None,
         }
     }
@@ -1203,7 +1209,7 @@ impl CancelExternalWorkflowError {
     /// Returns the normalized cancellation failure itself, if one exists.
     pub fn reason(&self) -> Option<&IncomingError> {
         match self {
-            Self::Failed(err) => Some(err),
+            Self::NotFound(err) | Self::Failed(err) => Some(err),
             Self::Serialization(_) => None,
         }
     }
@@ -1218,7 +1224,9 @@ impl WorkflowSignalError {
     /// Returns the retained top-level workflow signal failure proto, if one exists.
     pub fn failure(&self) -> Option<&Failure> {
         match self {
-            WorkflowSignalError::Failed(err) => Some(err.failure()),
+            WorkflowSignalError::NotFound(err) | WorkflowSignalError::Failed(err) => {
+                Some(err.failure())
+            }
             WorkflowSignalError::Serialization(_) => None,
         }
     }
@@ -1226,7 +1234,7 @@ impl WorkflowSignalError {
     /// Returns the normalized cause of the workflow signal failure, if any.
     pub fn cause(&self) -> Option<&IncomingError> {
         match self {
-            WorkflowSignalError::Failed(err) => err.cause(),
+            WorkflowSignalError::NotFound(err) | WorkflowSignalError::Failed(err) => err.cause(),
             WorkflowSignalError::Serialization(_) => None,
         }
     }
@@ -1234,7 +1242,9 @@ impl WorkflowSignalError {
     /// Returns the underlying failure reason for wrapper-shaped signal failures.
     pub fn reason(&self) -> Option<&IncomingError> {
         match self {
-            WorkflowSignalError::Failed(err) => Some(err.error()),
+            WorkflowSignalError::NotFound(err) | WorkflowSignalError::Failed(err) => {
+                Some(err.error())
+            }
             WorkflowSignalError::Serialization(_) => None,
         }
     }

--- a/crates/protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
+++ b/crates/protos/protos/local/temporal/sdk/core/workflow_activation/workflow_activation.proto
@@ -13,6 +13,7 @@ import "google/protobuf/empty.proto";
 import "temporal/api/failure/v1/message.proto";
 import "temporal/api/update/v1/message.proto";
 import "temporal/api/common/v1/message.proto";
+import "temporal/api/enums/v1/failed_cause.proto";
 import "temporal/api/enums/v1/workflow.proto";
 import "temporal/sdk/core/activity_result/activity_result.proto";
 import "temporal/sdk/core/child_workflow/child_workflow.proto";
@@ -321,15 +322,19 @@ message ResolveSignalExternalWorkflow {
     // If populated, this signal either failed to be sent or was cancelled depending on failure
     // type / info.
     temporal.api.failure.v1.Failure failure = 2;
+    // The server-reported cause when the signal failed. Unspecified when the signal succeeded or
+    // was cancelled before being sent.
+    temporal.api.enums.v1.SignalExternalWorkflowExecutionFailedCause cause = 3;
 }
 
 message ResolveRequestCancelExternalWorkflow {
     // Sequence number as provided by lang in the corresponding
     // RequestCancelExternalWorkflowExecution command
     uint32 seq = 1;
-    // If populated, this signal either failed to be sent or was cancelled depending on failure
-    // type / info.
+    // If populated, the cancellation request failed.
     temporal.api.failure.v1.Failure failure = 2;
+    // The server-reported cause when the cancellation request failed.
+    temporal.api.enums.v1.CancelExternalWorkflowExecutionFailedCause cause = 3;
 }
 
 // Lang is requested to invoke an update handler on the workflow. Lang should invoke the update

--- a/crates/sdk-core/CHANGELOG.md
+++ b/crates/sdk-core/CHANGELOG.md
@@ -34,6 +34,8 @@ relevant information.
 ## Unreleased
 
 ### Added
+* External workflow signal and cancellation resolution activations now include the typed server
+  failure cause alongside the existing failure.
 * Language SDKs can opt in to recording local activity arguments in the local activity marker's
   `input` detail.
 * Core console logs can now be emitted as newline-delimited JSON when an SDK selects the JSON log

--- a/crates/sdk-core/src/worker/workflow/machines/cancel_external_state_machine.rs
+++ b/crates/sdk-core/src/worker/workflow/machines/cancel_external_state_machine.rs
@@ -180,6 +180,7 @@ impl WFMachinesAdapter for CancelExternalMachine {
                     ResolveRequestCancelExternalWorkflow {
                         seq: self.shared_state.seq,
                         failure: None,
+                        cause: CancelExternalWorkflowExecutionFailedCause::Unspecified as i32,
                     }
                     .into(),
                 ]
@@ -203,6 +204,7 @@ impl WFMachinesAdapter for CancelExternalMachine {
                             )),
                             ..Default::default()
                         }),
+                        cause: f as i32,
                     }
                     .into(),
                 ]

--- a/crates/sdk-core/src/worker/workflow/machines/signal_external_state_machine.rs
+++ b/crates/sdk-core/src/worker/workflow/machines/signal_external_state_machine.rs
@@ -220,6 +220,7 @@ impl WFMachinesAdapter for SignalExternalMachine {
                     ResolveSignalExternalWorkflow {
                         seq: self.shared_state.seq,
                         failure: None,
+                        cause: SignalExternalWorkflowExecutionFailedCause::Unspecified as i32,
                     }
                     .into(),
                 ]
@@ -248,6 +249,7 @@ impl WFMachinesAdapter for SignalExternalMachine {
                             )),
                             ..Default::default()
                         }),
+                        cause: f as i32,
                     }
                     .into(),
                 ]
@@ -278,6 +280,7 @@ impl SignalExternalMachine {
                             )),
                             ..Default::default()
                         }),
+                        cause: SignalExternalWorkflowExecutionFailedCause::Unspecified as i32,
                     }
                     .into(),
                 ];

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_external.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/cancel_external.rs
@@ -22,10 +22,15 @@ impl CancelSender {
     #[run]
     async fn run(
         ctx: &mut WorkflowContext<Self>,
-        (run_id, workflow_id): (String, String),
+        (run_id, workflow_id, expect_not_found): (String, String, bool),
     ) -> WorkflowResult<()> {
         let handle = ctx.external_workflow(workflow_id, Some(run_id));
-        handle.cancel(Some("cancel-reason".into())).await.unwrap();
+        let result = handle.cancel(Some("cancel-reason".into())).await;
+        if expect_not_found {
+            assert_matches!(result, Err(CancelExternalWorkflowError::NotFound(_)));
+        } else {
+            result.unwrap();
+        }
         Ok(())
     }
 }
@@ -70,7 +75,7 @@ async fn sends_cancel_to_other_wf() {
     let sender_handle = worker
         .submit_workflow(
             CancelSender::run,
-            (receiver_run_id.to_owned(), receiver_wfid.to_owned()),
+            (receiver_run_id.to_owned(), receiver_wfid.to_owned(), false),
             WorkflowStartOptions::new(task_queue, "sends-cancel-sender").build(),
         )
         .await
@@ -93,6 +98,32 @@ async fn sends_cancel_to_other_wf() {
         receiver_result.contains("cancel-reason"),
         "expected cancel reason in message, got: {receiver_result}"
     );
+}
+
+#[tokio::test]
+async fn cancel_missing_external_wf_returns_not_found() {
+    let wf_name = "cancel_missing_external_wf_returns_not_found";
+    let mut starter = CoreWfStarter::new(wf_name);
+    starter
+        .sdk_config
+        .register_workflow::<CancelSender>()
+        .unwrap();
+    let mut worker = starter.worker().await;
+
+    let task_queue = starter.get_task_queue().to_owned();
+    let handle = worker
+        .submit_workflow(
+            CancelSender::run,
+            (uuid::Uuid::new_v4().to_string(), wf_name.to_owned(), true),
+            WorkflowStartOptions::new(task_queue, wf_name).build(),
+        )
+        .await
+        .unwrap();
+    worker.run_until_done().await.unwrap();
+    handle
+        .get_result(Default::default())
+        .await
+        .expect("workflow should observe a not-found cancellation error");
 }
 
 #[workflow]

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/signals.rs
@@ -24,7 +24,7 @@ use temporalio_sdk_core::replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder};
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
     ApplicationFailure, CancellableFuture, ChildWorkflowOptions, SignalWorkflowOptions,
-    SyncWorkflowContext, WorkflowContext, WorkflowResult,
+    SyncWorkflowContext, WorkflowContext, WorkflowResult, WorkflowSignalError,
     workflow_interceptors::{
         HandleSignalInput, HandleSignalResult, WorkflowInterceptor, WorkflowInterceptorConstructor,
         WorkflowInterceptorContext, WorkflowInterceptorFuture, WorkflowNext,
@@ -56,7 +56,7 @@ impl SignalSender {
             )
             .await;
         if expect_failure {
-            assert!(sigres.is_err());
+            assert_matches!(sigres, Err(WorkflowSignalError::NotFound(_)));
         } else {
             sigres.unwrap();
         }

--- a/crates/workflow/src/runtime/instance.rs
+++ b/crates/workflow/src/runtime/instance.rs
@@ -6,7 +6,10 @@ use crate::{
         InterceptedFuturePollGuard, InterceptedFuturePollKind, InterceptedFutureStatus,
         entry::{WorkflowError, WorkflowImplementation},
         guest::WorkflowInstance,
-        model::{TimerResult, UnblockEvent, WorkflowTermination},
+        model::{
+            CancelExternalWfFailure, SignalExternalWfFailure, TimerResult, UnblockEvent,
+            WorkflowTermination,
+        },
         types::{
             ActivationJobResult, ActivationResult, MAIN_ROUTINE_ID, MainRoutineCompletion,
             QueryResponse, RoutineCompletion, RoutineId, RoutineKind, RoutinePendingState,
@@ -759,10 +762,22 @@ where
                 UnblockEvent::WorkflowComplete(event.seq, Box::new(expect_resolution(event.result)))
             }
             ActivationVariant::ResolveSignalExternalWorkflow(event) => {
-                UnblockEvent::SignalExternal(event.seq, event.failure)
+                let cause = event.cause();
+                UnblockEvent::SignalExternal(
+                    event.seq,
+                    event
+                        .failure
+                        .map(|failure| SignalExternalWfFailure { failure, cause }),
+                )
             }
             ActivationVariant::ResolveRequestCancelExternalWorkflow(event) => {
-                UnblockEvent::CancelExternal(event.seq, event.failure)
+                let cause = event.cause();
+                UnblockEvent::CancelExternal(
+                    event.seq,
+                    event
+                        .failure
+                        .map(|failure| CancelExternalWfFailure { failure, cause }),
+                )
             }
             ActivationVariant::ResolveNexusOperationStart(event) => {
                 UnblockEvent::NexusOperationStart(

--- a/crates/workflow/src/runtime/model.rs
+++ b/crates/workflow/src/runtime/model.rs
@@ -28,7 +28,13 @@ use temporalio_common_wasm::{
                 resolve_nexus_operation_start,
             },
         },
-        temporal::api::failure::v1::Failure,
+        temporal::api::{
+            enums::v1::{
+                CancelExternalWorkflowExecutionFailedCause,
+                SignalExternalWorkflowExecutionFailedCause,
+            },
+            failure::v1::Failure,
+        },
     },
 };
 
@@ -39,8 +45,8 @@ pub(crate) enum UnblockEvent {
     Activity(u32, Box<ActivityResolution>),
     WorkflowStart(u32, Box<ChildWorkflowStartStatus>),
     WorkflowComplete(u32, Box<ChildWorkflowResult>),
-    SignalExternal(u32, Option<Failure>),
-    CancelExternal(u32, Option<Failure>),
+    SignalExternal(u32, Option<SignalExternalWfFailure>),
+    CancelExternal(u32, Option<CancelExternalWfFailure>),
     NexusOperationStart(u32, Box<resolve_nexus_operation_start::Status>),
     NexusOperationComplete(u32, Box<NexusOperationResult>),
 }
@@ -57,14 +63,24 @@ pub enum TimerResult {
 /// Successful result of sending a signal to an external workflow
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct SignalExternalOk;
+#[derive(Debug)]
+pub(crate) struct SignalExternalWfFailure {
+    pub(crate) failure: Failure,
+    pub(crate) cause: SignalExternalWorkflowExecutionFailedCause,
+}
 /// Result of awaiting on sending a signal to an external workflow
-pub(crate) type SignalExternalWfResult = Result<SignalExternalOk, Failure>;
+pub(crate) type SignalExternalWfResult = Result<SignalExternalOk, SignalExternalWfFailure>;
 
 /// Distinguishes external cancellation resolutions from other command results.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct CancelExternalOk;
+#[derive(Debug)]
+pub(crate) struct CancelExternalWfFailure {
+    pub(crate) failure: Failure,
+    pub(crate) cause: CancelExternalWorkflowExecutionFailedCause,
+}
 /// Internal result delivered when an external cancellation command resolves.
-pub(crate) type CancelExternalWfResult = Result<CancelExternalOk, Failure>;
+pub(crate) type CancelExternalWfResult = Result<CancelExternalOk, CancelExternalWfFailure>;
 
 pub(crate) trait Unblockable {
     type OtherDat;

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -67,14 +67,15 @@ use std::{
 use temporalio_common_wasm::{
     ActivityDefinition, Memo, SignalDefinition, WorkflowDefinition,
     data_converters::{
-        ActivityExecutionDecodeHint, ChildWorkflowExecutionDecodeHint,
-        ChildWorkflowStartDecodeHint, DataConverter, GenericPayloadConverter, NoopDecodeHint,
-        PayloadConversionError, PayloadConverter, SerializationContext, SerializationContextData,
-        TemporalDeserializable, WorkflowSerializationContext, WorkflowSignalDecodeHint,
+        ActivityExecutionDecodeHint, CancelExternalWorkflowDecodeHint,
+        ChildWorkflowExecutionDecodeHint, ChildWorkflowStartDecodeHint, DataConverter,
+        GenericPayloadConverter, PayloadConversionError, PayloadConverter, SerializationContext,
+        SerializationContextData, TemporalDeserializable, WorkflowSerializationContext,
+        WorkflowSignalDecodeHint,
     },
     error::{
-        ActivityExecutionError, CancelExternalWorkflowError, ChildWorkflowExecutionError,
-        ChildWorkflowStartError, WorkflowSignalError,
+        ActivityExecutionError, ChildWorkflowExecutionError, ChildWorkflowStartError,
+        WorkflowSignalError,
     },
     protos::{
         coresdk::{
@@ -1459,11 +1460,14 @@ impl BaseWorkflowContext {
             WorkflowOutboundFuture::new(async move {
                 match cmd.await {
                     Ok(_) => Ok(()),
-                    Err(failure) => {
+                    Err(error) => {
                         let context =
                             SerializationContextData::Workflow(WorkflowSerializationContext::new());
-                        let error = data_converter.to_error(&context, failure, NoopDecodeHint)?;
-                        Err(CancelExternalWorkflowError::Failed(Box::new(error)))
+                        Err(data_converter.to_error(
+                            &context,
+                            error.failure,
+                            CancelExternalWorkflowDecodeHint::new(error.cause),
+                        )?)
                     }
                 }
             })
@@ -3223,10 +3227,10 @@ where
             } => match Pin::new(inner).poll(cx) {
                 Poll::Pending => Poll::Pending,
                 Poll::Ready(Ok(_)) => Poll::Ready(Ok(())),
-                Poll::Ready(Err(failure)) => Poll::Ready(Err(data_converter.to_error(
+                Poll::Ready(Err(error)) => Poll::Ready(Err(data_converter.to_error(
                     &SerializationContextData::Workflow(WorkflowSerializationContext::new()),
-                    failure,
-                    WorkflowSignalDecodeHint::default(),
+                    error.failure,
+                    WorkflowSignalDecodeHint::new(error.cause),
                 )?)),
             },
             SignalChildFut::Terminated => panic!("polled after termination"),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
### Rust
Added `NotFound` variant to signal/cancel external wf error types

### Core
Send the failure cause from core to lang for signal/cancel external wf

## Why?
Matches Go/Java behavior of surfacing the not found in a direct way instead of string matching.
## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
Updated assertions in integration test to make sure correct error variant is chosen

3. Any docs updates needed?
N/A
