### PR TITLE
chore(sdk): mark pub test utilities as experimental

### DIFF
--- a/crates/sdk-core/tests/common/mod.rs
+++ b/crates/sdk-core/tests/common/mod.rs
@@ -511,9 +511,10 @@ impl CoreWfStarter {
         let interceptor_router = TestWorkerInterceptorRouter::default();
         let mut sdk_config = self.sdk_config.clone();
         sdk_config.worker_interceptor(interceptor_router.clone());
-        let sdk = Worker::new_from_core_options(worker, client.options().clone(), sdk_config)
-            .expect("SDK worker should initialize from core worker and options");
-        let mut w = TestWorker::new_with_interceptor_router(sdk, interceptor_router);
+        let sdk =
+            Worker::new_from_core_options(worker.clone(), client.options().clone(), sdk_config)
+                .expect("SDK worker should initialize from core worker and options");
+        let mut w = TestWorker::new_with_interceptor_router(sdk, worker, interceptor_router);
         w.client = Some(client);
 
         w
@@ -690,6 +691,7 @@ impl CoreWfStarter {
 /// Provides conveniences for running integ tests with the SDK (against real server or mocks)
 pub(crate) struct TestWorker {
     inner: Worker,
+    core_worker: Arc<CoreWorker>,
     interceptor_router: Option<TestWorkerInterceptorRouter>,
     client: Option<Client>,
     pub started_workflows: Arc<Mutex<Vec<WorkflowExecutionInfo>>>,
@@ -699,9 +701,10 @@ pub(crate) struct TestWorker {
 }
 impl TestWorker {
     /// Create a new test worker
-    pub(crate) fn new(sdk: Worker) -> Self {
+    pub(crate) fn new(sdk: Worker, core_worker: Arc<CoreWorker>) -> Self {
         Self {
             inner: sdk,
+            core_worker,
             interceptor_router: None,
             client: None,
             started_workflows: Arc::new(Mutex::new(vec![])),
@@ -711,11 +714,12 @@ impl TestWorker {
 
     fn new_with_interceptor_router(
         sdk: Worker,
+        core_worker: Arc<CoreWorker>,
         interceptor_router: TestWorkerInterceptorRouter,
     ) -> Self {
         Self {
             interceptor_router: Some(interceptor_router),
-            ..Self::new(sdk)
+            ..Self::new(sdk, core_worker)
         }
     }
 
@@ -855,7 +859,7 @@ impl TestWorker {
     }
 
     pub(crate) fn core_worker(&self) -> Arc<temporalio_sdk_core::Worker> {
-        self.inner.core_worker()
+        self.core_worker.clone()
     }
 }
 
@@ -1211,7 +1215,7 @@ pub(crate) fn mock_sdk_cfg_with_options(
     poll_cfg.using_rust_sdk = true;
     let mut mock = build_mock_pollers(poll_cfg);
     mock.worker_cfg(mutator);
-    let core = mock_worker(mock);
+    let core = Arc::new(mock_worker(mock));
     let interceptor_router = TestWorkerInterceptorRouter::default();
     let client_options = ClientOptions::new(core.get_config().namespace.clone())
         .data_converter(DataConverter::default())
@@ -1220,9 +1224,9 @@ pub(crate) fn mock_sdk_cfg_with_options(
         .worker_interceptor(interceptor_router.clone())
         .build();
     options_mutator(&mut worker_options);
-    let sdk = Worker::new_from_core_options(Arc::new(core), client_options, worker_options)
+    let sdk = Worker::new_from_core_options(core.clone(), client_options, worker_options)
         .expect("mock worker options are valid");
-    TestWorker::new_with_interceptor_router(sdk, interceptor_router)
+    TestWorker::new_with_interceptor_router(sdk, core, interceptor_router)
 }
 
 #[derive(Default)]

--- a/crates/sdk-core/tests/integ_tests/plugin_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/plugin_tests.rs
@@ -114,13 +114,11 @@ async fn plugins_configure_client_and_worker() {
         .register_workflow::<SimplePluginWorkflow>()
         .unwrap()
         .build();
-    let worker = Worker::new(&runtime, client, worker_options).unwrap();
+    let _worker = Worker::new(&runtime, client, worker_options).unwrap();
 
     assert_eq!(connection_calls.load(Relaxed), 1);
     assert_eq!(client_calls.load(Relaxed), 1);
     assert_eq!(worker_calls.load(Relaxed), 1);
-    assert_eq!(worker.core_worker().get_config().max_cached_workflows, 0);
-    assert_eq!(worker.core_worker().get_config().plugins.len(), 1);
 }
 
 struct CountingPayloadCodec {
@@ -363,53 +361,4 @@ impl WorkerPlugin for FailingWorkerPlugin {
     fn configure_worker_options(&self, _options: &mut WorkerOptions) -> Result<(), PluginError> {
         Err(PluginError::new("worker failure"))
     }
-}
-
-struct ClientOnlyMetadataPlugin;
-
-impl ClientPlugin for ClientOnlyMetadataPlugin {
-    fn name(&self) -> &str {
-        "client-only-plugin"
-    }
-}
-
-struct WorkerOnlyMetadataPlugin;
-
-impl WorkerPlugin for WorkerOnlyMetadataPlugin {
-    fn name(&self) -> &str {
-        "worker-only-plugin"
-    }
-}
-
-#[tokio::test]
-async fn worker_metadata_includes_client_and_worker_plugin_names() {
-    let runtime = new_sdk_runtime();
-    let client = Client::connect(
-        get_integ_server_options(),
-        ClientOptions::new(integ_namespace())
-            .client_plugin(ClientOnlyMetadataPlugin)
-            .build(),
-    )
-    .await
-    .unwrap();
-    let worker = Worker::new(
-        &runtime,
-        client,
-        WorkerOptions::new(format!("plugin-metadata-{}", Uuid::new_v4()))
-            .register_workflow::<SimplePluginWorkflow>()
-            .unwrap()
-            .worker_plugin(WorkerOnlyMetadataPlugin)
-            .build(),
-    )
-    .unwrap();
-    let core_worker = worker.core_worker();
-    let mut names = core_worker
-        .get_config()
-        .plugins
-        .iter()
-        .map(|plugin| plugin.name.clone())
-        .collect::<Vec<_>>();
-    names.sort_unstable();
-
-    assert_eq!(names, ["client-only-plugin", "worker-only-plugin"]);
 }

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -840,6 +840,7 @@ async fn activity_tasks_from_completion_reserve_slots() {
     let mut worker = crate::common::TestWorker::new(
         temporalio_sdk::Worker::new_from_core_options(core.clone(), client_options, worker_options)
             .unwrap(),
+        core.clone(),
     );
 
     // First poll for activities twice, occupying both slots

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1309,17 +1309,6 @@ impl Worker {
         self.common.worker.worker_instance_key()
     }
 
-    #[cfg(feature = "experimental")]
-    #[doc(hidden)]
-    pub fn core_worker(&self) -> Arc<CoreWorker> {
-        self.common.worker.clone()
-    }
-
-    #[cfg(not(feature = "experimental"))]
-    pub(crate) fn core_worker(&self) -> Arc<CoreWorker> {
-        self.common.worker.clone()
-    }
-
     fn split_apart(&mut self) -> (&mut CommonWorker, &mut WorkflowHalf, &mut ActivityHalf) {
         (
             &mut self.common,

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -887,6 +887,7 @@ impl Worker {
     }
 
     // TODO [rust-sdk-branch]: Eliminate this constructor in favor of passing in fake connection
+    #[cfg(feature = "experimental")]
     #[doc(hidden)]
     pub fn new_from_core(worker: Arc<CoreWorker>, data_converter: DataConverter) -> Self {
         let client_options = ClientOptions::new(worker.get_config().namespace.clone())
@@ -904,6 +905,7 @@ impl Worker {
     }
 
     // TODO [rust-sdk-branch]: Eliminate this constructor in favor of passing in fake connection
+    #[cfg(feature = "experimental")]
     #[doc(hidden)]
     pub fn new_from_core_options(
         worker: Arc<CoreWorker>,
@@ -1307,8 +1309,14 @@ impl Worker {
         self.common.worker.worker_instance_key()
     }
 
+    #[cfg(feature = "experimental")]
     #[doc(hidden)]
     pub fn core_worker(&self) -> Arc<CoreWorker> {
+        self.common.worker.clone()
+    }
+
+    #[cfg(not(feature = "experimental"))]
+    pub(crate) fn core_worker(&self) -> Arc<CoreWorker> {
         self.common.worker.clone()
     }
 

--- a/crates/sdk/src/workflow_replayer.rs
+++ b/crates/sdk/src/workflow_replayer.rs
@@ -461,7 +461,7 @@ impl WorkflowReplayer {
         )
         .await
         {
-            let core_worker = worker.core_worker();
+            let core_worker = worker.common.worker.clone();
             core_worker.initiate_shutdown();
             core_worker.shutdown().await;
             return Err(WorkflowReplayWorkerError::Run(source).into());


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Mark remaining test utils as `experimental` in addition to doc hidden to reduce risk of anyone using them
- Fully remove `core_worker` accessor as it was only necessary for a few tests. Can get around its removal by just arc wrapping the core worker before the SDK worker construction.

## Why?
Will remove these test-only methods in the future, this just ensures that removal has no chance of breaking "stable" users.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io --> 