### PR TITLE
chore(core): remove doc hidden from runtime opts

### DIFF
--- a/crates/sdk-core/src/lib.rs
+++ b/crates/sdk-core/src/lib.rs
@@ -194,14 +194,12 @@ pub struct RuntimeOptions {
     #[builder(default)]
     disable_environment_info: bool,
     /// Runtime information supplied by language SDK bridges.
-    #[doc(hidden)]
     #[builder(skip = vec![environment::native_runtime()])]
     runtimes: Vec<Runtime>,
 }
 
 impl RuntimeOptions {
     /// Supplies runtime information from a language SDK bridge.
-    #[doc(hidden)]
     pub fn with_runtimes(mut self, runtimes: Vec<Runtime>) -> Self {
         self.runtimes = runtimes;
         self


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Remove doc hidden from these

## Why?
Rust SDK doesn't expose the core runtime options struct but has its own. We already declare the sdk-core will not be stable so I don't think it makes much sense to mark methods as doc hidden.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io --> 