### PR TITLE
docs: update API WIT documentation

### DIFF
--- a/crates/protos/protos/api_upstream/nexus/deps/nexus-temporal-types/model.wit
+++ b/crates/protos/protos/api_upstream/nexus/deps/nexus-temporal-types/model.wit
@@ -177,8 +177,10 @@ interface model {
   ///   typescript-import="@temporalio/common"
   type workflow-id-conflict-policy = placeholder;
 
+  /// @nexus.doc "Static metadata for a workflow execution."
   /// @nexus.proto "temporal.api.sdk.v1.UserMetadata" typescript-import="@temporalio/proto"
   /// @nexus.flatten-in-api
+  /// @nexus.experimental
   record user-metadata {
     /// @nexus.doc "Single-line fixed summary for the workflow execution that may appear in UI and CLI. This can be in single-line Temporal Markdown format."
     /// @nexus.proto-field "summary"

--- a/crates/protos/protos/api_upstream/nexus/workflow-service.wit
+++ b/crates/protos/protos/api_upstream/nexus/workflow-service.wit
@@ -37,9 +37,10 @@ interface workflow-service {
     ///   python="Workflow type name or callable identifying the workflow to start."
     ///   typescript="Workflow type name or workflow function identifying the workflow to start."
     ///   dotnet="Workflow type name or workflow expression identifying the workflow to start."
+    ///   go="Workflow function identifying the workflow to start."
     /// @nexus.proto-field "workflow_type"
     workflow: workflow-function,
-    /// @nexus.doc "Unique identifier for the workflow execution."
+    /// @nexus.doc "Unique identifier for the workflow execution. Must be nonempty."
     /// @nexus.proto-field "workflow_id"
     id: string,
     /// @nexus.doc "Task queue to run the workflow on."
@@ -50,14 +51,17 @@ interface workflow-service {
     ///   dotnet="Signal name or signal expression to send with the start request."
     /// @nexus.proto-field "signal_name"
     signal: signal-function,
-    /// @nexus.doc "Total workflow execution timeout, including retries and continue-as-new."
+    /// @nexus.doc "Total workflow execution timeout, including retries and continue-as-new. Defaults to unlimited."
     /// @nexus.proto-field "workflow_execution_timeout"
+    /// @nexus.name go="WorkflowExecutionTimeout"
     execution-timeout: option<duration>,
-    /// @nexus.doc "Timeout of a single workflow run."
+    /// @nexus.doc "Timeout of a single workflow run. Defaults to the workflow execution timeout."
     /// @nexus.proto-field "workflow_run_timeout"
+    /// @nexus.name go="WorkflowRunTimeout"
     run-timeout: option<duration>,
-    /// @nexus.doc "Timeout of a single workflow task."
+    /// @nexus.doc "Timeout of a single workflow task. Defaults to 10 seconds."
     /// @nexus.proto-field "workflow_task_timeout"
+    /// @nexus.name go="WorkflowTaskTimeout"
     task-timeout: option<duration>,
     /// @nexus.omit
     identity: placeholder,
@@ -67,7 +71,7 @@ interface workflow-service {
     /// @nexus.proto-field "workflow_id_reuse_policy"
     /// @nexus.default "allow-duplicate"
     id-reuse-policy: workflow-id-reuse-policy,
-    /// @nexus.doc "Behavior when a workflow is currently running with the same ID. Set to use-existing for idempotent deduplication on workflow ID. Cannot be set if id-reuse-policy is terminate-if-running."
+    /// @nexus.doc "Behavior when a workflow is currently running with the same ID. Set to use-existing for idempotent deduplication on workflow ID. Cannot be set if id-reuse-policy is terminate-if-running. Defaults to use-existing."
     /// @nexus.proto-field "workflow_id_conflict_policy"
     id-conflict-policy: option<workflow-id-conflict-policy>,
     /// @nexus.doc "Retry policy for the workflow."
@@ -85,12 +89,15 @@ interface workflow-service {
     /// @nexus.doc "Amount of time to wait before starting the workflow. This does not work with cron-schedule."
     /// @nexus.proto-field "workflow_start_delay"
     start-delay: option<duration>,
+    /// @nexus.doc "Static metadata for the workflow execution."
     user-metadata: option<user-metadata>,
     /// @nexus.source python="workflow_namespace()" typescript="workflowNamespace()" go="workflow.GetInfo(ctx).Namespace" dotnet="TemporalWorkflowContext.WorkflowNamespace()"
+    /// @nexus.doc "Namespace of the workflow execution."
     namespace: string,
     /// @nexus.omit
     control: placeholder,
     /// @nexus.api-omit
+    /// @nexus.doc "Headers for the request."
     /// @nexus.proto-field "header"
     headers: option<header>,
     /// @nexus.omit
@@ -99,10 +106,13 @@ interface workflow-service {
     time-skipping-config: placeholder,
   }
 
+  /// @nexus.doc "Result of signaling a workflow and starting it if needed."
   /// @nexus.experimental
   /// @nexus.proto "temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionResponse" typescript-import="@temporalio/proto"
   record signal-with-start-workflow-response {
+    /// @nexus.doc "Run ID of the started workflow."
     run-id: option<string>,
+    /// @nexus.doc "Whether the workflow was started."
     started: option<bool>,
     /// @nexus.omit
     signal-link: placeholder,


### PR DESCRIPTION
Updates the api_upstream subtree with the WIT documentation required for sdk-dotnet#870 to generate documented public System Nexus API bindings.