### PR TITLE
fix(sdk): ensure memo/search attribute keys are determistic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ relevant information.
 * `WorkflowSignalError::NotFound` and `CancelExternalWorkflowError::NotFound` let workflows
   distinguish a missing signal or cancellation target from other delivery failures.
 
+### Fixed
+* `Memo::keys` and `SearchAttributes::keys` now iterate in lexicographic order so workflow
+  decisions based on collection traversal remain deterministic during replay.
+
 ## [0.8.0] - 2026-09-02
 
 ### Breaking Changes

--- a/crates/common-wasm/src/memo.rs
+++ b/crates/common-wasm/src/memo.rs
@@ -12,6 +12,7 @@ use std::{collections::BTreeMap, sync::Arc};
 #[non_exhaustive]
 pub struct Memo {
     raw: ProtoMemo,
+    ordered_keys: BTreeMap<String, ()>,
     payload_converter: PayloadConverter,
     context: SerializationContextData,
 }
@@ -24,8 +25,11 @@ impl Memo {
         payload_converter: PayloadConverter,
         context: SerializationContextData,
     ) -> Self {
+        let raw = raw.unwrap_or_default();
+        let ordered_keys = raw.fields.keys().cloned().map(|key| (key, ())).collect();
         Self {
-            raw: raw.unwrap_or_default(),
+            raw,
+            ordered_keys,
             payload_converter,
             context,
         }
@@ -62,9 +66,9 @@ impl Memo {
         self.raw.fields.is_empty()
     }
 
-    /// Iterates over memo keys.
+    /// Iterates over memo keys in lexicographic order.
     pub fn keys(&self) -> impl Iterator<Item = &str> {
-        self.raw.fields.keys().map(String::as_str)
+        self.ordered_keys.keys().map(String::as_str)
     }
 
     /// Returns the underlying payload without applying payload conversion.
@@ -203,6 +207,26 @@ mod tests {
         );
 
         assert!(memo.get::<String>("count").is_err());
+    }
+
+    #[test]
+    fn memo_keys_have_replay_stable_order() {
+        let memo = Memo::from_raw(
+            Some(ProtoMemo {
+                fields: HashMap::from([
+                    ("zebra".to_owned(), Payload::default()),
+                    ("alpha".to_owned(), Payload::default()),
+                    ("middle".to_owned(), Payload::default()),
+                ]),
+            }),
+            PayloadConverter::default(),
+            SerializationContextData::Workflow(WorkflowSerializationContext::new()),
+        );
+
+        assert_eq!(
+            memo.keys().collect::<Vec<_>>(),
+            vec!["alpha", "middle", "zebra"]
+        );
     }
 
     #[test]

--- a/crates/common-wasm/src/search_attributes.rs
+++ b/crates/common-wasm/src/search_attributes.rs
@@ -17,7 +17,10 @@
 //! let unset = MY_KW.value_unset();
 //! ```
 
-use std::{collections::HashMap, marker::PhantomData};
+use std::{
+    collections::{BTreeMap, HashMap},
+    marker::PhantomData,
+};
 
 use tracing::warn;
 
@@ -565,7 +568,7 @@ impl SearchAttributeUpdate {
 /// [`SearchAttributeKey`].
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct SearchAttributes {
-    fields: HashMap<String, Payload>,
+    fields: BTreeMap<String, Payload>,
 }
 
 impl SearchAttributes {
@@ -573,7 +576,7 @@ impl SearchAttributes {
     ///
     /// Updates with `None` payloads remove any existing entry for that key.
     pub fn new(updates: impl IntoIterator<Item = SearchAttributeUpdate>) -> Self {
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         for update in updates {
             match update.payload {
                 Some(payload) => {
@@ -647,7 +650,7 @@ impl SearchAttributes {
         self.fields.len()
     }
 
-    /// Returns an iterator over the attribute names in this collection.
+    /// Returns an iterator over the attribute names in lexicographic order.
     pub fn keys(&self) -> impl Iterator<Item = &str> {
         self.fields.keys().map(|s| s.as_str())
     }
@@ -662,7 +665,7 @@ impl SearchAttributes {
     /// Convert to the proto wire representation.
     pub fn to_proto(&self) -> ProtoSearchAttributes {
         ProtoSearchAttributes {
-            indexed_fields: self.fields.clone(),
+            indexed_fields: self.fields.clone().into_iter().collect(),
         }
     }
 
@@ -670,14 +673,14 @@ impl SearchAttributes {
     /// cloning.
     pub fn into_proto(self) -> ProtoSearchAttributes {
         ProtoSearchAttributes {
-            indexed_fields: self.fields,
+            indexed_fields: self.fields.into_iter().collect(),
         }
     }
 
     /// Construct from the proto wire representation by cloning the inner map.
     pub fn from_proto(attrs: &ProtoSearchAttributes) -> Self {
         Self {
-            fields: attrs.indexed_fields.clone(),
+            fields: attrs.indexed_fields.clone().into_iter().collect(),
         }
     }
 }
@@ -686,7 +689,7 @@ impl From<ProtoSearchAttributes> for SearchAttributes {
     /// Construct from an owned proto, moving the inner map without cloning.
     fn from(attrs: ProtoSearchAttributes) -> Self {
         Self {
-            fields: attrs.indexed_fields,
+            fields: attrs.indexed_fields.into_iter().collect(),
         }
     }
 }
@@ -1120,11 +1123,19 @@ mod tests {
     }
 
     #[test]
-    fn keys_returns_attribute_names() {
-        let attrs = SearchAttributes::new([BOOL_KEY.value_set(true), INT_KEY.value_set(42)]);
-        let mut keys: Vec<&str> = attrs.keys().collect();
-        keys.sort();
-        assert_eq!(keys, vec!["my_bool", "my_int"]);
+    fn search_attribute_keys_have_replay_stable_order() {
+        let attrs = SearchAttributes::from(ProtoSearchAttributes {
+            indexed_fields: HashMap::from([
+                ("zebra".to_owned(), Payload::default()),
+                ("alpha".to_owned(), Payload::default()),
+                ("middle".to_owned(), Payload::default()),
+            ]),
+        });
+
+        assert_eq!(
+            attrs.keys().collect::<Vec<_>>(),
+            vec!["alpha", "middle", "zebra"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
use btreemap over hashmap for memo/SA storage so iterating over the keys is determisitic

## Why?
These types are used for clients and inside workflow contexts. In the latter we want these to be deterministic if for whatever reason the ordering of these would result in differing commands being emitted for the activation.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Update test to assert ordering is stable.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io --> 