### PR TITLE
chore(sdk): add SDK owned types over using core directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,19 @@ relevant information.
 * `WorkflowSignalError::NotFound` and `CancelExternalWorkflowError::NotFound` let workflows
   distinguish a missing signal or cancellation target from other delivery failures.
 
+### Breaking Changes
+* `temporalio-sdk` now owns its runtime, polling, workflow-error, worker-validation, and local test
+  server configuration types instead of re-exporting their `temporalio-sdk-core` equivalents.
+  `TokioRuntimeBuilder` is non-exhaustive and provides a builder for construction. Unrelated Core
+  worker configuration and replay helpers are no longer re-exported by the SDK.
+  `PollerBehavior::Autoscaling` now holds builder-created `AutoscalingOptions`.
+* `Runtime::from_current_tokio` replaces `Runtime::new_assume_tokio` as the preferred constructor.
+  The old name remains as a deprecated alias, but now returns `RuntimeError` instead of
+  `anyhow::Error`.
+
 ### Fixed
+* `Runtime::from_current_tokio` now returns `RuntimeError::NoCurrentTokioRuntime` when called
+  without an active Tokio runtime instead of panicking.
 * `Memo::keys` and `SearchAttributes::keys` now iterate in lexicographic order so workflow
   decisions based on collection traversal remain deterministic during replay.
 

--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -1845,6 +1845,8 @@ pub enum WorkflowErrorType {
     Nondeterminism,
 }
 
+// The Rust SDK intentionally re-exports this trait and the slot-supplier family below, so Core
+// changes to these APIs must preserve the Rust SDK's stability guarantees.
 /// This trait allows users to customize the performance characteristics of workers dynamically.
 /// For more, see the docstrings of the traits in the return types of its functions.
 pub trait WorkerTuner {

--- a/crates/sdk-core/src/worker/tuner.rs
+++ b/crates/sdk-core/src/worker/tuner.rs
@@ -1,6 +1,8 @@
 mod fixed_size;
 mod resource_based;
 
+// The Rust SDK intentionally re-exports this module's public tuner configuration types. Changes
+// here must preserve that stable user-facing API even while sdk-core itself remains pre-1.0.
 pub use fixed_size::FixedSizeSlotSupplier;
 pub(crate) use resource_based::{RealSysInfo, SystemResourceInfo};
 pub use resource_based::{

--- a/crates/sdk-core/tests/heavy_tests.rs
+++ b/crates/sdk-core/tests/heavy_tests.rs
@@ -40,11 +40,10 @@ use temporalio_common::{
 use temporalio_sdk::{
     ActivityOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
+    runtime::{AutoscalingOptions, PollerBehavior},
     workflows,
 };
-use temporalio_sdk_core::{
-    CoreRuntime, PollerBehavior, ResourceBasedTuner, ResourceSlotOptions, TunerHolder,
-};
+use temporalio_sdk_core::{CoreRuntime, ResourceBasedTuner, ResourceSlotOptions, TunerHolder};
 
 #[workflow]
 #[derive(Clone, Default)]
@@ -468,16 +467,20 @@ async fn poller_autoscaling_basic_loadtest() {
     let mut starter = CoreWfStarter::new("poller_load");
     starter.sdk_config.max_cached_workflows = 5000;
     starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(1000, 1000, 100, 1));
-    starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling {
-        minimum: 1,
-        maximum: 200,
-        initial: 5,
-    });
-    starter.sdk_config.activity_task_poller_behavior = Some(PollerBehavior::Autoscaling {
-        minimum: 1,
-        maximum: 200,
-        initial: 5,
-    });
+    starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling(
+        AutoscalingOptions::builder()
+            .minimum(1)
+            .maximum(200)
+            .initial(5)
+            .build(),
+    ));
+    starter.sdk_config.activity_task_poller_behavior = Some(PollerBehavior::Autoscaling(
+        AutoscalingOptions::builder()
+            .minimum(1)
+            .maximum(200)
+            .initial(5)
+            .build(),
+    ));
 
     starter.sdk_config.register_activities(JitteryActivities);
     starter

--- a/crates/sdk-core/tests/integ_tests/ephemeral_server_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/ephemeral_server_tests.rs
@@ -37,7 +37,7 @@ async fn test_workflow_environment_local() {
     let env = WorkflowEnvironment::start_local(LocalWorkflowEnvironmentOptions::default())
         .await
         .unwrap();
-    let runtime = Runtime::new_assume_tokio(Default::default()).unwrap();
+    let runtime = Runtime::from_current_tokio(Default::default()).unwrap();
     let worker_options = WorkerOptions::new(format!("test-env-{}", rand_6_chars()))
         .register_workflow::<TestEnvironmentWorkflow>()
         .unwrap()

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -78,12 +78,13 @@ use temporalio_sdk::{
     ActivityOptions, CancellableFuture, LocalActivityOptions, NexusOperationOptions,
     WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
+    runtime::{AutoscalingOptions, PollerBehavior},
 };
 use temporalio_sdk_core::{
-    ActivitySlotKind, CoreRuntime, FixedSizeSlotSupplier, PollError, PollerBehavior, SlotKind,
-    SlotMarkUsedContext, SlotReleaseContext, SlotReservationContext, SlotSupplier,
-    SlotSupplierPermit, TokioRuntimeBuilder, TunerBuilder, WorkerConfig, WorkerVersioningStrategy,
-    WorkflowSlotKind, init_worker, prost_dur,
+    ActivitySlotKind, CoreRuntime, FixedSizeSlotSupplier, PollError,
+    PollerBehavior as CorePollerBehavior, SlotKind, SlotMarkUsedContext, SlotReleaseContext,
+    SlotReservationContext, SlotSupplier, SlotSupplierPermit, TokioRuntimeBuilder, TunerBuilder,
+    WorkerConfig, WorkerVersioningStrategy, WorkflowSlotKind, init_worker, prost_dur,
     replay::TestHistoryBuilder,
     test_help::{
         MockPollCfg, MocksHolder, ResponseType, TemporalMeter, WorkerExt, WorkerTestHelpers,
@@ -194,7 +195,7 @@ async fn one_slot_worker_reports_available_slot() {
         // Need to use two for WFTs because there are a minimum of 2 pollers b/c of sticky polling
         .max_outstanding_workflow_tasks(2_usize)
         .max_outstanding_nexus_tasks(1_usize)
-        .workflow_task_poller_behavior(PollerBehavior::SimpleMaximum(2_usize))
+        .workflow_task_poller_behavior(CorePollerBehavior::SimpleMaximum(2_usize))
         .task_types(WorkerTaskTypes::all())
         .build()
         .unwrap();
@@ -483,11 +484,13 @@ async fn idle_activity_worker_reports_zero_slots_used() {
     let rt = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
     let mut starter =
         CoreWfStarter::new_with_runtime("idle_activity_worker_reports_zero_slots_used", rt);
-    starter.sdk_config.activity_task_poller_behavior = Some(PollerBehavior::Autoscaling {
-        minimum: 1,
-        maximum: 1,
-        initial: 1,
-    });
+    starter.sdk_config.activity_task_poller_behavior = Some(PollerBehavior::Autoscaling(
+        AutoscalingOptions::builder()
+            .minimum(1)
+            .maximum(1)
+            .initial(1)
+            .build(),
+    ));
     let activity_slots = Arc::new(ReservationTrackingActivitySlotSupplier::new(3));
     let mut tuner = TunerBuilder::default();
     tuner.activity_slot_supplier(activity_slots.clone());

--- a/crates/sdk-core/tests/integ_tests/plugin_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/plugin_tests.rs
@@ -36,7 +36,7 @@ use url::Url;
 use uuid::Uuid;
 
 fn new_sdk_runtime() -> Runtime {
-    Runtime::new_assume_tokio(
+    Runtime::from_current_tokio(
         RuntimeOptions::builder()
             .telemetry_options(get_integ_telem_options())
             .build()

--- a/crates/sdk-core/tests/integ_tests/polling_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/polling_tests.rs
@@ -32,9 +32,12 @@ use temporalio_common::{
     telemetry::{CoreLogStreamConsumer, Logger, TelemetryOptions},
 };
 use temporalio_macros::{workflow, workflow_methods};
-use temporalio_sdk::{ActivityOptions, WorkflowContext, WorkflowResult};
+use temporalio_sdk::{
+    ActivityOptions, WorkflowContext, WorkflowResult,
+    runtime::{AutoscalingOptions, PollerBehavior},
+};
 use temporalio_sdk_core::{
-    CoreRuntime, PollerBehavior, RuntimeOptions, TunerHolder,
+    CoreRuntime, RuntimeOptions, TunerHolder,
     ephemeral_server::{TemporalDevServerConfig, default_cached_download},
     init_worker, prost_dur,
     test_help::{NAMESPACE, WorkerTestHelpers, drain_pollers_and_shutdown, schedule_activity_cmd},
@@ -275,11 +278,13 @@ async fn small_workflow_slots_and_pollers(#[values(false, true)] use_autoscaling
     let wf_name = "only_one_workflow_slot_and_two_pollers";
     let mut starter = CoreWfStarter::new(wf_name);
     if use_autoscaling {
-        starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling {
-            minimum: 1,
-            maximum: 5,
-            initial: 1,
-        });
+        starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling(
+            AutoscalingOptions::builder()
+                .minimum(1)
+                .maximum(5)
+                .initial(1)
+                .build(),
+        ));
     } else {
         starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::SimpleMaximum(2));
     }

--- a/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
@@ -42,10 +42,10 @@ use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
     ActivityOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
+    runtime::{AutoscalingOptions, PollerBehavior},
 };
 use temporalio_sdk_core::{
-    CoreRuntime, PollerBehavior, ResourceBasedTuner, ResourceSlotOptions, RuntimeOptions,
-    TunerHolder, prost_dur,
+    CoreRuntime, ResourceBasedTuner, ResourceSlotOptions, RuntimeOptions, TunerHolder, prost_dur,
 };
 use tokio::{sync::Notify, time::sleep};
 use tonic::IntoRequest;
@@ -407,16 +407,20 @@ async fn docker_worker_heartbeat_tuner() {
     tuner
         .with_workflow_slots_options(ResourceSlotOptions::new(2, 10, Duration::from_millis(0)))
         .with_activity_slots_options(ResourceSlotOptions::new(5, 10, Duration::from_millis(50)));
-    starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling {
-        minimum: 1,
-        maximum: 200,
-        initial: 5,
-    });
-    starter.sdk_config.nexus_task_poller_behavior = Some(PollerBehavior::Autoscaling {
-        minimum: 1,
-        maximum: 200,
-        initial: 5,
-    });
+    starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling(
+        AutoscalingOptions::builder()
+            .minimum(1)
+            .maximum(200)
+            .initial(5)
+            .build(),
+    ));
+    starter.sdk_config.nexus_task_poller_behavior = Some(PollerBehavior::Autoscaling(
+        AutoscalingOptions::builder()
+            .minimum(1)
+            .maximum(200)
+            .initial(5)
+            .build(),
+    ));
     starter.sdk_config.tuner = Arc::new(tuner);
     starter.sdk_config.register_activities(StdActivities);
 

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -61,13 +61,13 @@ use temporalio_sdk::{
     ActivityOptions, LocalActivityOptions, WorkerOptions, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
     interceptors::WorkerInterceptor,
+    runtime::PollerBehavior,
 };
 use temporalio_sdk_core::{
-    ActivitySlotKind, CoreRuntime, LocalActivitySlotKind, PollError, PollerBehavior,
-    ResourceBasedTuner, ResourceSlotOptions, SlotInfo, SlotInfoTrait, SlotMarkUsedContext,
-    SlotReleaseContext, SlotReservationContext, SlotSupplier, SlotSupplierPermit, TunerBuilder,
-    WorkerConfig, WorkerValidationError, WorkerVersioningStrategy, WorkflowSlotKind, init_worker,
-    prost_dur,
+    ActivitySlotKind, CoreRuntime, LocalActivitySlotKind, PollError, ResourceBasedTuner,
+    ResourceSlotOptions, SlotInfo, SlotInfoTrait, SlotMarkUsedContext, SlotReleaseContext,
+    SlotReservationContext, SlotSupplier, SlotSupplierPermit, TunerBuilder, WorkerConfig,
+    WorkerValidationError, WorkerVersioningStrategy, WorkflowSlotKind, init_worker, prost_dur,
     replay::{DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, canned_histories},
     test_help::{
         FakeWfResponses, MockPollCfg, ResponseType, build_mock_pollers, drain_pollers_and_shutdown,

--- a/crates/sdk-core/tests/integ_tests/workflow_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests.rs
@@ -68,9 +68,10 @@ use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
     ActivityOptions, LocalActivityOptions, TimerOptions, WorkflowContext, WorkflowResult,
     interceptors::WorkerInterceptor,
+    runtime::{PollerBehavior, WorkflowErrorType},
 };
 use temporalio_sdk_core::{
-    CoreRuntime, PollError, PollerBehavior, TunerHolder, WorkflowErrorType, prost_dur,
+    CoreRuntime, PollError, TunerHolder, prost_dur,
     replay::{DEFAULT_WORKFLOW_TYPE, HistoryForReplay, canned_histories},
     test_help::{
         MockPollCfg, WorkerTestHelpers, drain_pollers_and_shutdown, schedule_activity_cmd,

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/activities.rs
@@ -58,9 +58,10 @@ use temporalio_sdk::{
         ActivityInboundInterceptor, ExecuteActivityInput, ExecuteActivityOutput,
         ExecuteActivityResult, Next,
     },
+    runtime::{AutoscalingOptions, PollerBehavior},
 };
 use temporalio_sdk_core::{
-    PollerBehavior, prost_dur,
+    prost_dur,
     replay::{DEFAULT_ACTIVITY_TYPE, DEFAULT_WORKFLOW_TYPE, TestHistoryBuilder, canned_histories},
     test_help::{
         MockPollCfg, ResponseType, WorkerTestHelpers, drain_pollers_and_shutdown,
@@ -2134,16 +2135,20 @@ async fn activity_can_be_cancelled_by_local_timeout() {
 async fn long_activity_timeout_repro() {
     let wf_name = "long_activity_timeout_repro";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling {
-        minimum: 1,
-        maximum: 10,
-        initial: 5,
-    });
-    starter.sdk_config.activity_task_poller_behavior = Some(PollerBehavior::Autoscaling {
-        minimum: 1,
-        maximum: 10,
-        initial: 5,
-    });
+    starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling(
+        AutoscalingOptions::builder()
+            .minimum(1)
+            .maximum(10)
+            .initial(5)
+            .build(),
+    ));
+    starter.sdk_config.activity_task_poller_behavior = Some(PollerBehavior::Autoscaling(
+        AutoscalingOptions::builder()
+            .minimum(1)
+            .maximum(10)
+            .initial(5)
+            .build(),
+    ));
     starter
         .set_core_cfg_mutator(|m| m.local_timeout_buffer_for_activities = Duration::from_secs(0));
     starter.sdk_config.register_activities(StdActivities);

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/stickyness.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/stickyness.rs
@@ -9,8 +9,8 @@ use std::{
 use temporalio_client::WorkflowStartOptions;
 use temporalio_common::protos::temporal::api::enums::v1::EventType;
 use temporalio_macros::{workflow, workflow_methods};
-use temporalio_sdk::{WorkflowContext, WorkflowResult};
-use temporalio_sdk_core::{PollerBehavior, TunerHolder};
+use temporalio_sdk::{WorkflowContext, WorkflowResult, runtime::PollerBehavior};
+use temporalio_sdk_core::TunerHolder;
 use tokio::sync::Barrier;
 
 #[tokio::test]

--- a/crates/sdk-core/tests/manual_tests.rs
+++ b/crates/sdk-core/tests/manual_tests.rs
@@ -29,8 +29,9 @@ use temporalio_macros::{activities, workflow, workflow_methods};
 use temporalio_sdk::{
     ActivityOptions, SyncWorkflowContext, WorkflowContext, WorkflowResult,
     activities::{ActivityContext, ActivityError},
+    runtime::{AutoscalingOptions, PollerBehavior},
 };
-use temporalio_sdk_core::{CoreRuntime, PollerBehavior, TunerHolder};
+use temporalio_sdk_core::{CoreRuntime, TunerHolder};
 use tracing::info;
 
 struct JitteryEchoActivities;
@@ -134,16 +135,20 @@ async fn poller_load_spiky() {
     let mut starter = CoreWfStarter::new_with_runtime("poller_load", rt);
     starter.sdk_config.max_cached_workflows = 5000;
     starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(1000, 1000, 100, 100));
-    starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling {
-        minimum: 1,
-        maximum: 200,
-        initial: 5,
-    });
-    starter.sdk_config.activity_task_poller_behavior = Some(PollerBehavior::Autoscaling {
-        minimum: 1,
-        maximum: 200,
-        initial: 5,
-    });
+    starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling(
+        AutoscalingOptions::builder()
+            .minimum(1)
+            .maximum(200)
+            .initial(5)
+            .build(),
+    ));
+    starter.sdk_config.activity_task_poller_behavior = Some(PollerBehavior::Autoscaling(
+        AutoscalingOptions::builder()
+            .minimum(1)
+            .maximum(200)
+            .initial(5)
+            .build(),
+    ));
     starter
         .sdk_config
         .register_activities(JitteryEchoActivities)
@@ -276,11 +281,13 @@ async fn poller_load_sustained() {
     let mut starter = CoreWfStarter::new_with_runtime("poller_load", rt);
     starter.sdk_config.max_cached_workflows = 5000;
     starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(1000, 100, 100, 100));
-    starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling {
-        minimum: 1,
-        maximum: 200,
-        initial: 5,
-    });
+    starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling(
+        AutoscalingOptions::builder()
+            .minimum(1)
+            .maximum(200)
+            .initial(5)
+            .build(),
+    ));
     starter
         .sdk_config
         .register_workflow::<PollerLoadSustainedWf>()
@@ -352,16 +359,20 @@ async fn poller_load_spike_then_sustained() {
     let mut starter = CoreWfStarter::new_with_runtime("poller_load", rt);
     starter.sdk_config.max_cached_workflows = 5000;
     starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(1000, 100, 100, 100));
-    starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling {
-        minimum: 1,
-        maximum: 200,
-        initial: 5,
-    });
-    starter.sdk_config.activity_task_poller_behavior = Some(PollerBehavior::Autoscaling {
-        minimum: 1,
-        maximum: 200,
-        initial: 5,
-    });
+    starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling(
+        AutoscalingOptions::builder()
+            .minimum(1)
+            .maximum(200)
+            .initial(5)
+            .build(),
+    ));
+    starter.sdk_config.activity_task_poller_behavior = Some(PollerBehavior::Autoscaling(
+        AutoscalingOptions::builder()
+            .minimum(1)
+            .maximum(200)
+            .initial(5)
+            .build(),
+    ));
     starter
         .sdk_config
         .register_activities(JitteryEchoActivities)

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -88,7 +88,7 @@ use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
     let (conn_options, client_options) = ClientOptions::load_from_config(
         LoadClientConfigProfileOptions::default()
     )?;

--- a/crates/sdk/examples/activity_heartbeating/worker.rs
+++ b/crates/sdk/examples/activity_heartbeating/worker.rs
@@ -8,7 +8,7 @@ use workflows::{HeartbeatingActivities, HeartbeatingWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/activity_interceptor/worker.rs
+++ b/crates/sdk/examples/activity_interceptor/worker.rs
@@ -52,7 +52,7 @@ impl ActivityInboundInterceptor for LoggingActivityInterceptor {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/cancellation/worker.rs
+++ b/crates/sdk/examples/cancellation/worker.rs
@@ -8,7 +8,7 @@ use workflows::{CancellationActivities, CancellationWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/child_workflows/worker.rs
+++ b/crates/sdk/examples/child_workflows/worker.rs
@@ -8,7 +8,7 @@ use workflows::{GreetingChildWorkflow, ParentWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/continue_as_new/worker.rs
+++ b/crates/sdk/examples/continue_as_new/worker.rs
@@ -8,7 +8,7 @@ use workflows::ContinueAsNewWorkflow;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/hello_world/worker.rs
+++ b/crates/sdk/examples/hello_world/worker.rs
@@ -8,7 +8,7 @@ use workflows::{GreetingActivities, HelloWorldWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/local_activities/worker.rs
+++ b/crates/sdk/examples/local_activities/worker.rs
@@ -8,7 +8,7 @@ use workflows::{GreetingActivities, LocalActivitiesWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/message_passing/worker.rs
+++ b/crates/sdk/examples/message_passing/worker.rs
@@ -8,7 +8,7 @@ use workflows::MessagePassingWorkflow;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/polling/worker.rs
+++ b/crates/sdk/examples/polling/worker.rs
@@ -8,7 +8,7 @@ use workflows::{PollingActivities, PollingWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/saga/worker.rs
+++ b/crates/sdk/examples/saga/worker.rs
@@ -8,7 +8,7 @@ use workflows::{BookingActivities, SagaWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/schedules/worker.rs
+++ b/crates/sdk/examples/schedules/worker.rs
@@ -8,7 +8,7 @@ use workflows::{ScheduledActivities, ScheduledWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/search_attributes/worker.rs
+++ b/crates/sdk/examples/search_attributes/worker.rs
@@ -8,7 +8,7 @@ use workflows::SearchAttributesWorkflow;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/timer_examples/worker.rs
+++ b/crates/sdk/examples/timer_examples/worker.rs
@@ -8,7 +8,7 @@ use workflows::{TimerActivities, TimerWorkflow};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/examples/updatable_timer/worker.rs
+++ b/crates/sdk/examples/updatable_timer/worker.rs
@@ -8,7 +8,7 @@ use workflows::UpdatableTimerWorkflow;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/crates/sdk/src/error.rs
+++ b/crates/sdk/src/error.rs
@@ -3,7 +3,50 @@
 pub use crate::workflow_registry::WorkflowRegistrationError;
 #[cfg(feature = "experimental")]
 use temporalio_client::PluginApplyError;
-pub use temporalio_sdk_core::WorkerValidationError;
+use temporalio_sdk_core::WorkerValidationError as CoreWorkerValidationError;
+
+/// Errors that can occur while creating an SDK runtime.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum RuntimeError {
+    /// Runtime initialization failed.
+    #[error("runtime initialization failed: {0}")]
+    Initialization(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    /// No Tokio runtime is active on the current thread.
+    #[error("no Tokio runtime is active on the current thread")]
+    NoCurrentTokioRuntime,
+}
+
+impl RuntimeError {
+    pub(crate) fn from_core(error: anyhow::Error) -> Self {
+        Self::Initialization(error.into_boxed_dyn_error())
+    }
+}
+
+/// Errors encountered while validating a worker before polling begins.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum WorkerValidationError {
+    /// The configured namespace could not be described.
+    #[error("namespace {namespace} was not found or otherwise could not be described: {source}")]
+    NamespaceDescribeError {
+        /// The underlying server error.
+        #[source]
+        source: temporalio_client::tonic::Status,
+        /// The namespace that could not be described.
+        namespace: String,
+    },
+}
+
+impl WorkerValidationError {
+    pub(crate) fn from_core(error: CoreWorkerValidationError) -> Self {
+        match error {
+            CoreWorkerValidationError::NamespaceDescribeError { source, namespace } => {
+                Self::NamespaceDescribeError { source, namespace }
+            }
+        }
+    }
+}
 
 /// Errors that can occur while creating a worker.
 ///

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -36,7 +36,7 @@
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let connection_options =
 //!         ConnectionOptions::new(Url::from_str("http://localhost:7233")?).build();
-//!     let runtime = Runtime::new_assume_tokio(Default::default())?;
+//!     let runtime = Runtime::from_current_tokio(Default::default())?;
 //!     let connection = Connection::connect(connection_options).await?;
 //!     let client = Client::new(connection, ClientOptions::new("my_namespace").build())?;
 //!
@@ -91,8 +91,8 @@ pub use crate::{
     error::{
         ActivityExecutionError, ApplicationFailure, CancelExternalWorkflowError,
         ChildWorkflowExecutionError, ChildWorkflowStartError, OutgoingActivityError, OutgoingError,
-        OutgoingWorkflowError, RetryState, TimeoutType, WorkerCreateError, WorkerRunError,
-        WorkerValidationError, WorkflowRegistrationError, WorkflowSignalError,
+        OutgoingWorkflowError, RetryState, RuntimeError, TimeoutType, WorkerCreateError,
+        WorkerRunError, WorkerValidationError, WorkflowRegistrationError, WorkflowSignalError,
     },
     workflow_registry::WorkflowDefinitions,
 };
@@ -162,7 +162,7 @@ use temporalio_common::{
     },
     worker::{WorkerDeploymentOptions, WorkerTaskTypes, build_id_from_current_exe},
 };
-use temporalio_sdk_core::{PollError, init_worker};
+use temporalio_sdk_core::{PollError, WorkerVersioningStrategy, init_worker};
 use temporalio_workflow::{InternalPatchActivationCallback, workflows::WorkflowImplementation};
 use tokio::sync::{
     Notify,
@@ -174,8 +174,7 @@ use tracing::{Instrument, Span, field};
 use uuid::Uuid;
 
 use crate::runtime::{
-    CoreWorker, PollerBehavior, TunerBuilder, WorkerConfig, WorkerTuner, WorkerVersioningStrategy,
-    WorkflowErrorType,
+    CoreWorker, PollerBehavior, TunerBuilder, WorkerConfig, WorkerTuner, WorkflowErrorType,
 };
 
 /// Contains options for configuring a worker.
@@ -704,9 +703,18 @@ impl WorkerOptions {
             }))
             .max_cached_workflows(self.max_cached_workflows)
             .tuner(self.tuner.clone())
-            .maybe_workflow_task_poller_behavior(self.workflow_task_poller_behavior)
-            .maybe_activity_task_poller_behavior(self.activity_task_poller_behavior)
-            .maybe_nexus_task_poller_behavior(self.nexus_task_poller_behavior)
+            .maybe_workflow_task_poller_behavior(
+                self.workflow_task_poller_behavior
+                    .map(PollerBehavior::into_core),
+            )
+            .maybe_activity_task_poller_behavior(
+                self.activity_task_poller_behavior
+                    .map(PollerBehavior::into_core),
+            )
+            .maybe_nexus_task_poller_behavior(
+                self.nexus_task_poller_behavior
+                    .map(PollerBehavior::into_core),
+            )
             .task_types(WorkerTaskTypes {
                 enable_workflows: workflows_registered,
                 enable_local_activities: workflows_registered && activities_registered,
@@ -725,8 +733,28 @@ impl WorkerOptions {
             .versioning_strategy(WorkerVersioningStrategy::WorkerDeploymentBased(
                 self.deployment_options.clone(),
             ))
-            .workflow_failure_errors(self.workflow_failure_errors.clone())
-            .workflow_types_to_failure_errors(self.workflow_types_to_failure_errors.clone())
+            .workflow_failure_errors(
+                self.workflow_failure_errors
+                    .iter()
+                    .cloned()
+                    .map(WorkflowErrorType::into_core)
+                    .collect(),
+            )
+            .workflow_types_to_failure_errors(
+                self.workflow_types_to_failure_errors
+                    .iter()
+                    .map(|(workflow_type, error_types)| {
+                        (
+                            workflow_type.clone(),
+                            error_types
+                                .iter()
+                                .cloned()
+                                .map(WorkflowErrorType::into_core)
+                                .collect(),
+                        )
+                    })
+                    .collect(),
+            )
             .plugins(plugin_info)
             .disable_payload_error_limit(disable_payload_error_limit)
             .build()
@@ -881,7 +909,7 @@ impl Worker {
         let wc = options
             .to_core_options(client.namespace(), client.identity())
             .map_err(|error| WorkerCreateError::Initialization(anyhow!(error)))?;
-        let core = init_worker(runtime, wc, client.connection().clone())
+        let core = init_worker(runtime.core(), wc, client.connection().clone())
             .map_err(WorkerCreateError::Initialization)?;
         Self::new_from_core_options_prepared(Arc::new(core), client.options().clone(), options)
     }
@@ -1027,6 +1055,7 @@ impl Worker {
             .worker
             .validate()
             .await
+            .map_err(WorkerValidationError::from_core)
             .map_err(WorkerRunError::Validation)?;
         let shutdown_token = CancellationToken::new();
         let (common, wf_half, act_half) = self.split_apart();

--- a/crates/sdk/src/runtime.rs
+++ b/crates/sdk/src/runtime.rs
@@ -4,24 +4,111 @@
 //! primary workflow and activity APIs. Create a [`crate::Runtime`] before connecting a client,
 //! then pass it to [`crate::Worker::new`].
 
-use std::{
-    ops::{Deref, DerefMut},
-    time::Duration,
+use std::time::Duration;
+
+use temporalio_common::telemetry::TelemetryOptions;
+use temporalio_sdk_core::{
+    CoreRuntime, PollerBehavior as CorePollerBehavior, RuntimeOptions as CoreRuntimeOptions,
+    TokioRuntimeBuilder as CoreTokioRuntimeBuilder, WorkflowErrorType as CoreWorkflowErrorType,
 };
 
-use temporalio_common::telemetry::{TelemetryInstance, TelemetryOptions};
-use temporalio_sdk_core::{CoreRuntime, RuntimeOptions as CoreRuntimeOptions};
+use crate::error::RuntimeError;
 
+// These tuner types are intentionally part of the Rust SDK's public API. Changes to their Core
+// definitions must preserve the SDK's stability guarantees until the SDK owns this surface.
 pub use temporalio_sdk_core::{
-    ActivitySlotKind, FixedSizeSlotSupplier, LocalActivitySlotKind, NexusSlotKind, PollerBehavior,
+    ActivitySlotKind, FixedSizeSlotSupplier, LocalActivitySlotKind, NexusSlotKind,
     ResourceBasedSlotsOptions, ResourceBasedSlotsOptionsBuilder, ResourceBasedTuner,
     ResourceBasedTunerConfig, ResourceController, ResourceSlotOptions, SlotInfo, SlotInfoTrait,
     SlotKind, SlotKindType, SlotMarkUsedContext, SlotReleaseContext, SlotReservationContext,
-    SlotSupplier, SlotSupplierOptions, SlotSupplierPermit, TokioRuntimeBuilder, TunerBuilder,
-    TunerHolder, TunerHolderOptions, TunerHolderOptionsBuilder, Worker as CoreWorker, WorkerConfig,
-    WorkerConfigBuilder, WorkerTuner, WorkerVersioningStrategy, WorkflowErrorType,
-    WorkflowSlotKind, init_replay_worker, replay,
+    SlotSupplier, SlotSupplierOptions, SlotSupplierPermit, TunerBuilder, TunerHolder,
+    TunerHolderOptions, TunerHolderOptionsBuilder, WorkerTuner, WorkflowSlotKind,
 };
+
+// These remain public only for the raw-worker APIs that are being migrated separately.
+pub use temporalio_sdk_core::{Worker as CoreWorker, WorkerConfig};
+
+/// Wraps a Tokio runtime builder so the SDK can install its per-thread telemetry state.
+#[derive(bon::Builder)]
+#[builder(state_mod(vis = "pub"))]
+#[non_exhaustive]
+pub struct TokioRuntimeBuilder {
+    /// The Tokio runtime builder used to create the runtime.
+    pub inner: tokio::runtime::Builder,
+}
+
+impl Default for TokioRuntimeBuilder {
+    fn default() -> Self {
+        Self {
+            inner: tokio::runtime::Builder::new_multi_thread(),
+        }
+    }
+}
+
+impl TokioRuntimeBuilder {
+    fn into_core(self) -> CoreTokioRuntimeBuilder<Box<dyn Fn() + Send + Sync>> {
+        CoreTokioRuntimeBuilder {
+            inner: self.inner,
+            lang_on_thread_start: None,
+        }
+    }
+}
+
+/// Options for automatically scaling the number of concurrent task polls.
+#[derive(bon::Builder, Clone, Copy, Debug, PartialEq)]
+#[builder(state_mod(vis = "pub"))]
+#[non_exhaustive]
+pub struct AutoscalingOptions {
+    /// Minimum number of concurrent polls. Cannot be zero.
+    pub minimum: usize,
+    /// Maximum number of concurrent polls. Must be at least `minimum`.
+    pub maximum: usize,
+    /// Initial number of concurrent polls. Must be between `minimum` and `maximum`.
+    pub initial: usize,
+}
+
+/// Controls how many concurrent task polls a worker issues.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum PollerBehavior {
+    /// Poll whenever a slot is available, up to the supplied maximum.
+    SimpleMaximum(usize),
+    /// Adjust concurrent polls using feedback from the server.
+    Autoscaling(AutoscalingOptions),
+}
+
+impl PollerBehavior {
+    pub(crate) fn into_core(self) -> CorePollerBehavior {
+        match self {
+            PollerBehavior::SimpleMaximum(maximum) => CorePollerBehavior::SimpleMaximum(maximum),
+            PollerBehavior::Autoscaling(AutoscalingOptions {
+                minimum,
+                maximum,
+                initial,
+            }) => CorePollerBehavior::Autoscaling {
+                minimum,
+                maximum,
+                initial,
+            },
+        }
+    }
+}
+
+/// Workflow-processing errors that may be configured to fail the workflow execution.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[non_exhaustive]
+pub enum WorkflowErrorType {
+    /// A workflow produced commands that do not match its recorded history.
+    Nondeterminism,
+}
+
+impl WorkflowErrorType {
+    pub(crate) fn into_core(self) -> CoreWorkflowErrorType {
+        match self {
+            WorkflowErrorType::Nondeterminism => CoreWorkflowErrorType::Nondeterminism,
+        }
+    }
+}
 
 /// Configuration for the Rust SDK runtime. Construct with [`RuntimeOptions::builder`].
 #[derive(bon::Builder)]
@@ -66,12 +153,12 @@ impl<S: runtime_options_builder::State> RuntimeOptionsBuilder<S> {
     }
 }
 
-impl From<RuntimeOptions> for CoreRuntimeOptions {
-    fn from(options: RuntimeOptions) -> Self {
+impl RuntimeOptions {
+    fn into_core(self) -> CoreRuntimeOptions {
         CoreRuntimeOptions::builder()
-            .telemetry_options(options.telemetry_options)
-            .heartbeat_interval(options.heartbeat_interval)
-            .disable_environment_info(options.disable_environment_info)
+            .telemetry_options(self.telemetry_options)
+            .heartbeat_interval(self.heartbeat_interval)
+            .disable_environment_info(self.disable_environment_info)
             .build()
             .expect("SDK runtime options have already been validated")
     }
@@ -82,50 +169,62 @@ pub struct Runtime(CoreRuntime);
 
 impl Runtime {
     /// Creates a runtime with a newly constructed Tokio runtime.
-    pub fn new<F>(
+    ///
+    /// # Errors
+    /// Returns an error if telemetry or the Tokio runtime cannot be initialized.
+    pub fn new(
         options: RuntimeOptions,
-        tokio_builder: TokioRuntimeBuilder<F>,
-    ) -> Result<Self, anyhow::Error>
-    where
-        F: Fn() + Send + Sync + 'static,
-    {
-        CoreRuntime::new(options.into(), tokio_builder).map(Self)
+        tokio_builder: TokioRuntimeBuilder,
+    ) -> Result<Self, RuntimeError> {
+        CoreRuntime::new(options.into_core(), tokio_builder.into_core())
+            .map(Self)
+            .map_err(RuntimeError::from_core)
     }
 
     /// Creates a runtime using the currently active Tokio runtime.
     ///
-    /// # Panics
-    /// Panics if there is no currently active Tokio runtime.
-    pub fn new_assume_tokio(options: RuntimeOptions) -> Result<Self, anyhow::Error> {
-        CoreRuntime::new_assume_tokio(options.into()).map(Self)
+    /// # Errors
+    /// Returns [`RuntimeError::NoCurrentTokioRuntime`] if there is no currently active Tokio
+    /// runtime, or [`RuntimeError::Initialization`] if telemetry cannot be initialized.
+    pub fn from_current_tokio(options: RuntimeOptions) -> Result<Self, RuntimeError> {
+        tokio::runtime::Handle::try_current().map_err(|_| RuntimeError::NoCurrentTokioRuntime)?;
+        CoreRuntime::new_assume_tokio(options.into_core())
+            .map(Self)
+            .map_err(RuntimeError::from_core)
     }
 
-    /// Creates a runtime from an initialized telemetry instance using the currently active Tokio
-    /// runtime.
+    /// Creates a runtime using the currently active Tokio runtime.
     ///
-    /// # Panics
-    /// Panics if there is no currently active Tokio runtime.
-    pub fn new_assume_tokio_initialized_telem(
-        telemetry: TelemetryInstance,
-        heartbeat_interval: Option<Duration>,
-    ) -> Self {
-        Self(CoreRuntime::new_assume_tokio_initialized_telem(
-            telemetry,
-            heartbeat_interval,
-        ))
+    /// # Errors
+    /// Returns [`RuntimeError::NoCurrentTokioRuntime`] if there is no currently active Tokio
+    /// runtime, or [`RuntimeError::Initialization`] if telemetry cannot be initialized.
+    #[deprecated(note = "use `Runtime::from_current_tokio` instead")]
+    pub fn new_assume_tokio(options: RuntimeOptions) -> Result<Self, RuntimeError> {
+        Self::from_current_tokio(options)
     }
-}
 
-impl Deref for Runtime {
-    type Target = CoreRuntime;
-
-    fn deref(&self) -> &Self::Target {
+    pub(crate) fn core(&self) -> &CoreRuntime {
         &self.0
     }
 }
 
-impl DerefMut for Runtime {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+#[cfg(test)]
+mod tests {
+    use super::{Runtime, TokioRuntimeBuilder};
+    use crate::error::RuntimeError;
+
+    #[test]
+    fn from_current_tokio_without_runtime_returns_error() {
+        assert!(matches!(
+            Runtime::from_current_tokio(Default::default()),
+            Err(RuntimeError::NoCurrentTokioRuntime)
+        ));
+    }
+
+    #[test]
+    fn tokio_runtime_builder_constructs_with_an_inner_builder() {
+        let _builder = TokioRuntimeBuilder::builder()
+            .inner(tokio::runtime::Builder::new_current_thread())
+            .build();
     }
 }

--- a/crates/sdk/src/testing.rs
+++ b/crates/sdk/src/testing.rs
@@ -86,14 +86,89 @@ use temporalio_common::{
 use tokio_util::sync::CancellationToken;
 use url::Url;
 
-pub use temporalio_sdk_core::ephemeral_server::{
-    EphemeralExe, EphemeralExeVersion, EphemeralServerError,
-};
 use temporalio_sdk_core::ephemeral_server::{
-    EphemeralServer, TemporalDevServerConfig, default_cached_download,
+    EphemeralExe as CoreEphemeralExe, EphemeralExeVersion as CoreEphemeralExeVersion,
+    EphemeralServer, EphemeralServerError as CoreEphemeralServerError, TemporalDevServerConfig,
 };
 
 type ActivityImplementers = HashMap<String, Arc<dyn Any + Send + Sync>>;
+
+/// Where to find the Temporal server executable used by a local workflow environment.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum EphemeralExe {
+    /// Use an existing executable at this path.
+    ExistingPath(String),
+    /// Download and cache an executable when necessary.
+    CachedDownload {
+        /// Version to download.
+        version: EphemeralExeVersion,
+        /// Cache directory, or the operating system's temporary directory when absent.
+        dest_dir: Option<String>,
+        /// Maximum cache age, or no expiration when absent.
+        ttl: Option<Duration>,
+    },
+}
+
+impl EphemeralExe {
+    fn into_core(self) -> CoreEphemeralExe {
+        match self {
+            EphemeralExe::ExistingPath(path) => CoreEphemeralExe::ExistingPath(path),
+            EphemeralExe::CachedDownload {
+                version,
+                dest_dir,
+                ttl,
+            } => CoreEphemeralExe::CachedDownload {
+                version: version.into_core(),
+                dest_dir,
+                ttl,
+            },
+        }
+    }
+}
+
+impl Default for EphemeralExe {
+    fn default() -> Self {
+        EphemeralExe::CachedDownload {
+            version: EphemeralExeVersion::Default,
+            dest_dir: None,
+            ttl: Some(Duration::from_secs(60 * 60 * 24 * 15)),
+        }
+    }
+}
+
+/// Version of a downloadable Temporal server executable.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum EphemeralExeVersion {
+    /// Resolve the server version selected for this SDK release.
+    Default,
+    /// Download a specific server version.
+    Fixed(String),
+}
+
+impl EphemeralExeVersion {
+    fn into_core(self) -> CoreEphemeralExeVersion {
+        match self {
+            EphemeralExeVersion::Default => CoreEphemeralExeVersion::SDKDefault {
+                sdk_name: "sdk-rust".to_owned(),
+                sdk_version: env!("CARGO_PKG_VERSION").to_owned(),
+            },
+            EphemeralExeVersion::Fixed(version) => CoreEphemeralExeVersion::Fixed(version),
+        }
+    }
+}
+
+/// Errors encountered while downloading, starting, or stopping a local Temporal server.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct EphemeralServerError(CoreEphemeralServerError);
+
+impl EphemeralServerError {
+    fn from_core(error: CoreEphemeralServerError) -> Self {
+        Self(error)
+    }
+}
 
 /// Options for constructing [`ActivityInfo`] with defaults suitable for an activity test.
 #[derive(bon::Builder)]
@@ -363,7 +438,7 @@ pub struct LocalWorkflowEnvironmentOptions {
     #[builder(default = ClientOptions::new("default").build())]
     pub client_options: ClientOptions,
     /// Existing or downloadable Temporal CLI executable.
-    #[builder(default = default_cached_download())]
+    #[builder(default)]
     pub server_executable: EphemeralExe,
     /// Fixed frontend port, or an OS-selected port when absent.
     pub port: Option<u16>,
@@ -446,7 +521,7 @@ impl WorkflowEnvironment<LocalServer> {
             })
             .transpose()?;
         let server_config = TemporalDevServerConfig::builder()
-            .exe(options.server_executable)
+            .exe(options.server_executable.into_core())
             .namespace(options.client_options.namespace.clone())
             .maybe_port(options.port)
             .ui(options.ui)
@@ -461,6 +536,7 @@ impl WorkflowEnvironment<LocalServer> {
         let mut server = server_config
             .start_server()
             .await
+            .map_err(EphemeralServerError::from_core)
             .map_err(WorkflowEnvironmentError::ServerStart)?;
         let target = Url::parse(&format!("http://{}", server.target))
             .map_err(WorkflowEnvironmentError::InvalidServerTarget)?;
@@ -476,7 +552,7 @@ impl WorkflowEnvironment<LocalServer> {
                     Ok(()) => Err(WorkflowEnvironmentError::ClientConnect(connect)),
                     Err(shutdown) => Err(WorkflowEnvironmentError::ClientConnectAndShutdown {
                         connect: Box::new(connect),
-                        shutdown: Box::new(shutdown),
+                        shutdown: Box::new(EphemeralServerError::from_core(shutdown)),
                     }),
                 };
             }
@@ -493,6 +569,7 @@ impl WorkflowEnvironment<LocalServer> {
             .server
             .shutdown()
             .await
+            .map_err(EphemeralServerError::from_core)
             .map_err(WorkflowEnvironmentError::ServerShutdown)
     }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
- Limit a bunch of core reexports. Tuner traits are what keep getting reexported, since we accept implementers directly so they end up being part of the SDK API. Next PR addresses providing a SDK owned face to these traits.
- Add SDK owned types that convert into the core types.
- Rename `Runtime::new_assume_tokio` to `Runtime::from_current_tokio` and make it error instead of panic if ran without a tokio runtime.

## Why?
Trying to make it easier to ensure that breaking core changes do not result in breaking Rust SDK usage.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io --> 