### PR TITLE
Allow normal polling when sticky is saturated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ relevant information.
   views can observe values established by synchronous inbound interceptors, and outbound
   interceptors can use values to propagate metadata to activities, child workflows, signals,
   Nexus operations, and continue-as-new runs.
+  pollers reach their polling limit.
 ### Breaking Changes
 * `ActivityError`, `PayloadConversionError`, `ActivityExecutionError`,
   `ChildWorkflowStartError`, `ChildWorkflowExecutionError`, and `WorkflowSignalError` are now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ relevant information.
 ### Added
 * `CancelExternalWorkflowError` and `workflow_interceptors::CancelExternalWorkflowResult`
   for use in interceptors.
+### Fixed
+* Sticky workflow backlog no longer prevents normal pollers from using capacity after sticky
+  pollers reach their autoscaling target.
 ### Breaking Changes
 * `ActivityError`, `PayloadConversionError`, `ActivityExecutionError`,
   `ChildWorkflowStartError`, `ChildWorkflowExecutionError`, and `WorkflowSignalError` are now

--- a/crates/sdk-core/CHANGELOG.md
+++ b/crates/sdk-core/CHANGELOG.md
@@ -73,6 +73,8 @@ relevant information.
   are preserved on failure; workers warn when the server does not advertise support.
 
 ### Fixed
+* Sticky workflow backlog no longer prevents normal pollers from using capacity after sticky
+  pollers reach their autoscaling target.
 * Worker shutdown now drains activity completions that are still flushing their result to the
   server before finishing. Previously such a completion — typically one whose final heartbeat RPC
   was still in flight — could be permanently stranded by shutdown: the activity's result was

--- a/crates/sdk-core/CHANGELOG.md
+++ b/crates/sdk-core/CHANGELOG.md
@@ -73,8 +73,8 @@ relevant information.
   are preserved on failure; workers warn when the server does not advertise support.
 
 ### Fixed
-* Sticky workflow backlog no longer prevents normal pollers from using capacity after sticky
-  pollers reach their autoscaling target.
+* Workflow poll balancing now lets non-sticky pollers use capacity after sticky pollers reach their
+  configured or autoscaled polling limit.
 * Worker shutdown now drains activity completions that are still flushing their result to the
   server before finishing. Previously such a completion — typically one whose final heartbeat RPC
   was still in flight — could be permanently stranded by shutdown: the activity's result was

--- a/crates/sdk-core/src/pollers/poll_buffer.rs
+++ b/crates/sdk-core/src/pollers/poll_buffer.rs
@@ -137,7 +137,10 @@ impl LongPollBuffer<PollWorkflowTaskQueueResponse, WorkflowSlotKind> {
         );
         if let Some(wftps) = options.wft_poller_shared.as_ref() {
             if is_sticky {
-                wftps.set_sticky_active(poll_scaler.active_rx.clone());
+                wftps.set_sticky_active(
+                    poll_scaler.active_rx.clone(),
+                    poll_scaler.report_handle.target.clone(),
+                );
             } else {
                 wftps.set_non_sticky_active(poll_scaler.active_rx.clone());
             };
@@ -547,7 +550,7 @@ where
         let report_handle = Arc::new(PollScalerReportHandle {
             max,
             min,
-            target: AtomicUsize::new(target),
+            target: Arc::new(AtomicUsize::new(target)),
             ever_saw_scaling_decision: AtomicBool::default(),
             capabilities,
             behavior,
@@ -613,7 +616,7 @@ where
 struct PollScalerReportHandle {
     max: usize,
     min: usize,
-    target: AtomicUsize,
+    target: Arc<AtomicUsize>,
     ever_saw_scaling_decision: AtomicBool,
     capabilities: Arc<NamespaceCapabilities>,
     behavior: PollerBehavior,
@@ -1324,7 +1327,7 @@ mod tests {
         let handle = Arc::new(PollScalerReportHandle {
             max: 10,
             min: minimum,
-            target: AtomicUsize::new(10),
+            target: Arc::new(AtomicUsize::new(10)),
             ever_saw_scaling_decision: AtomicBool::new(false),
             capabilities: Arc::new(NamespaceCapabilities::resolved(Capabilities {
                 poller_autoscaling: supports_autoscaling,

--- a/crates/sdk-core/src/pollers/poll_buffer.rs
+++ b/crates/sdk-core/src/pollers/poll_buffer.rs
@@ -139,7 +139,7 @@ impl LongPollBuffer<PollWorkflowTaskQueueResponse, WorkflowSlotKind> {
             if is_sticky {
                 wftps.set_sticky_active(
                     poll_scaler.active_rx.clone(),
-                    poll_scaler.report_handle.target.clone(),
+                    poll_scaler.report_handle.target.subscribe(),
                 );
             } else {
                 wftps.set_non_sticky_active(poll_scaler.active_rx.clone());
@@ -547,10 +547,11 @@ where
                 initial,
             } => (minimum, maximum, initial),
         };
+        let target = watch::Sender::new(target);
         let report_handle = Arc::new(PollScalerReportHandle {
             max,
             min,
-            target: Arc::new(AtomicUsize::new(target)),
+            target,
             ever_saw_scaling_decision: AtomicBool::default(),
             capabilities,
             behavior,
@@ -599,10 +600,7 @@ where
 
     async fn wait_until_allowed(&mut self) -> ActiveCounter<impl Fn(usize) + use<F>> {
         self.active_rx
-            .wait_for(|v| {
-                *v < self.report_handle.max
-                    && *v < self.report_handle.target.load(Ordering::Relaxed)
-            })
+            .wait_for(|v| *v < self.report_handle.max && *v < *self.report_handle.target.borrow())
             .await
             .expect("Poll allow does not panic");
         ActiveCounter::new(self.active_tx.clone(), self.num_pollers_handler.clone())
@@ -616,7 +614,7 @@ where
 struct PollScalerReportHandle {
     max: usize,
     min: usize,
-    target: Arc<AtomicUsize>,
+    target: watch::Sender<usize>,
     ever_saw_scaling_decision: AtomicBool,
     capabilities: Arc<NamespaceCapabilities>,
     behavior: PollerBehavior,
@@ -736,11 +734,15 @@ impl PollScalerReportHandle {
 
     #[inline]
     fn change_target(&self, change: fn(usize, usize) -> usize, change_by: usize) {
-        self.target
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
-                Some(change(v, change_by).clamp(self.min, self.max))
-            })
-            .expect("Cannot fail because always returns Some");
+        self.target.send_if_modified(|target| {
+            let new_target = change(*target, change_by).clamp(self.min, self.max);
+            if *target == new_target {
+                return false;
+            }
+
+            *target = new_target;
+            true
+        });
     }
 
     /// We want to avoid scaling down on empty polls if the server has never made any scaling
@@ -1327,7 +1329,7 @@ mod tests {
         let handle = Arc::new(PollScalerReportHandle {
             max: 10,
             min: minimum,
-            target: Arc::new(AtomicUsize::new(10)),
+            target: watch::channel(10).0,
             ever_saw_scaling_decision: AtomicBool::new(false),
             capabilities: Arc::new(NamespaceCapabilities::resolved(Capabilities {
                 poller_autoscaling: supports_autoscaling,
@@ -1353,7 +1355,7 @@ mod tests {
             handle.poll_result(&empty_resp);
         }
 
-        assert_eq!(handle.target.load(Ordering::Relaxed), expected_target);
+        assert_eq!(*handle.target.borrow(), expected_target);
         assert!(!handle.ever_saw_scaling_decision.load(Ordering::Relaxed));
     }
 

--- a/crates/sdk-core/src/worker/workflow/wft_poller.rs
+++ b/crates/sdk-core/src/worker/workflow/wft_poller.rs
@@ -9,7 +9,10 @@ use crate::{
 use crossbeam_utils::atomic::AtomicCell;
 use futures_util::{Stream, stream};
 use std::{
-    sync::{Arc, OnceLock},
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::SystemTime,
 };
 use temporalio_common::protos::temporal::api::workflowservice::v1::PollWorkflowTaskQueueResponse;
@@ -98,6 +101,7 @@ pub(crate) fn make_wft_poller(
 pub(crate) struct WFTPollerShared {
     last_seen_sticky_backlog: (watch::Receiver<usize>, watch::Sender<usize>),
     sticky_active: OnceLock<watch::Receiver<usize>>,
+    sticky_target: OnceLock<Arc<AtomicUsize>>,
     non_sticky_active: OnceLock<watch::Receiver<usize>>,
     max_slots: Option<usize>,
 }
@@ -107,12 +111,14 @@ impl WFTPollerShared {
         Self {
             last_seen_sticky_backlog: (rx, tx),
             sticky_active: OnceLock::new(),
+            sticky_target: OnceLock::new(),
             non_sticky_active: OnceLock::new(),
             max_slots,
         }
     }
-    pub(crate) fn set_sticky_active(&self, rx: watch::Receiver<usize>) {
+    pub(crate) fn set_sticky_active(&self, rx: watch::Receiver<usize>, target: Arc<AtomicUsize>) {
         let _ = self.sticky_active.set(rx);
+        let _ = self.sticky_target.set(target);
     }
     pub(crate) fn set_non_sticky_active(&self, rx: watch::Receiver<usize>) {
         let _ = self.non_sticky_active.set(rx);
@@ -124,8 +130,9 @@ impl WFTPollerShared {
         // that we won't end up using every available permit with one kind of poller. In practice
         // this is only ever likely to be an issue with very small numbers of slots.
         if let Some(max_slots) = self.max_slots
-            && let Some((sticky_active, non_sticky_active)) =
-                self.sticky_active.get().zip(self.non_sticky_active.get())
+            && let Some(sticky_active) = self.sticky_active.get()
+            && let Some(sticky_target) = self.sticky_target.get()
+            && let Some(non_sticky_active) = self.non_sticky_active.get()
         {
             let mut sticky_active = sticky_active.clone();
             let mut non_sticky_active = non_sticky_active.clone();
@@ -135,6 +142,9 @@ impl WFTPollerShared {
                 let num_sticky_active = *sticky_active.borrow_and_update();
                 let num_non_sticky_active = *non_sticky_active.borrow_and_update();
                 let num_sticky_backlog = *sticky_backlog.borrow_and_update();
+                let sticky_needs_capacity = num_sticky_backlog > 1
+                    && num_sticky_backlog > num_sticky_active
+                    && num_sticky_active < sticky_target.load(Ordering::Relaxed);
 
                 let allow = || {
                     if !is_sticky {
@@ -149,7 +159,7 @@ impl WFTPollerShared {
                         }
 
                         // If there's a meaningful sticky backlog, prioritize sticky.
-                        if num_sticky_backlog > 1 && num_sticky_backlog > num_sticky_active {
+                        if sticky_needs_capacity {
                             return false;
                         }
                     } else {
@@ -164,7 +174,7 @@ impl WFTPollerShared {
                         }
 
                         // If there's a meaningful sticky backlog, prioritize sticky.
-                        if num_sticky_backlog > 1 && num_sticky_backlog > num_sticky_active {
+                        if sticky_needs_capacity {
                             return true;
                         }
                     }
@@ -279,6 +289,22 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
     };
     use temporalio_common::protos::temporal::api::enums::v1::EventType;
+
+    #[tokio::test]
+    async fn sticky_priority_respects_poller_target() {
+        let shared = WFTPollerShared::new(Some(4));
+        let (_sticky_tx, sticky_rx) = watch::channel(2);
+        let (_non_sticky_tx, non_sticky_rx) = watch::channel(1);
+        let sticky_target = Arc::new(AtomicUsize::new(3));
+        shared.set_sticky_active(sticky_rx, sticky_target.clone());
+        shared.set_non_sticky_active(non_sticky_rx);
+        shared.record_sticky_backlog(10);
+
+        assert!(shared.wait_if_needed(false).now_or_never().is_none());
+
+        sticky_target.store(2, Ordering::Relaxed);
+        assert!(shared.wait_if_needed(false).now_or_never().is_some());
+    }
 
     #[tokio::test]
     async fn poll_timeouts_do_not_produce_responses() {

--- a/crates/sdk-core/src/worker/workflow/wft_poller.rs
+++ b/crates/sdk-core/src/worker/workflow/wft_poller.rs
@@ -9,10 +9,7 @@ use crate::{
 use crossbeam_utils::atomic::AtomicCell;
 use futures_util::{Stream, stream};
 use std::{
-    sync::{
-        Arc, OnceLock,
-        atomic::{AtomicUsize, Ordering},
-    },
+    sync::{Arc, OnceLock},
     time::SystemTime,
 };
 use temporalio_common::protos::temporal::api::workflowservice::v1::PollWorkflowTaskQueueResponse;
@@ -101,7 +98,7 @@ pub(crate) fn make_wft_poller(
 pub(crate) struct WFTPollerShared {
     last_seen_sticky_backlog: (watch::Receiver<usize>, watch::Sender<usize>),
     sticky_active: OnceLock<watch::Receiver<usize>>,
-    sticky_target: OnceLock<Arc<AtomicUsize>>,
+    sticky_target: OnceLock<watch::Receiver<usize>>,
     non_sticky_active: OnceLock<watch::Receiver<usize>>,
     max_slots: Option<usize>,
 }
@@ -119,10 +116,10 @@ impl WFTPollerShared {
     pub(crate) fn set_sticky_active(
         &self,
         active_rx: watch::Receiver<usize>,
-        target: Arc<AtomicUsize>,
+        target_rx: watch::Receiver<usize>,
     ) {
         let _ = self.sticky_active.set(active_rx);
-        let _ = self.sticky_target.set(target);
+        let _ = self.sticky_target.set(target_rx);
     }
     pub(crate) fn set_non_sticky_active(&self, active_rx: watch::Receiver<usize>) {
         let _ = self.non_sticky_active.set(active_rx);
@@ -139,16 +136,18 @@ impl WFTPollerShared {
             && let Some(non_sticky_active) = self.non_sticky_active.get()
         {
             let mut sticky_active = sticky_active.clone();
+            let mut sticky_target = sticky_target.clone();
             let mut non_sticky_active = non_sticky_active.clone();
             let mut sticky_backlog = self.last_seen_sticky_backlog.0.clone();
 
             loop {
                 let num_sticky_active = *sticky_active.borrow_and_update();
+                let num_sticky_target = *sticky_target.borrow_and_update();
                 let num_non_sticky_active = *non_sticky_active.borrow_and_update();
                 let num_sticky_backlog = *sticky_backlog.borrow_and_update();
                 let sticky_should_be_chosen = num_sticky_backlog > 1
                     && num_sticky_backlog > num_sticky_active
-                    && num_sticky_active < sticky_target.load(Ordering::Relaxed);
+                    && num_sticky_active < num_sticky_target;
 
                 let allow = || {
                     if !is_sticky {
@@ -170,6 +169,11 @@ impl WFTPollerShared {
                         // There should always be at least one sticky poller.
                         if num_sticky_active == 0 {
                             return true;
+                        }
+
+                        // Do not reserve a slot that the sticky scaler cannot use.
+                        if num_sticky_active >= num_sticky_target {
+                            return false;
                         }
 
                         // Do not allow an additional sticky poller to prevent starting a first non-sticky poller.
@@ -198,6 +202,7 @@ impl WFTPollerShared {
 
                 tokio::select! {
                     _ = sticky_active.changed() => (),
+                    _ = sticky_target.changed() => (),
                     _ = non_sticky_active.changed() => (),
                     _ = sticky_backlog.changed() => (),
                 }
@@ -288,26 +293,61 @@ mod tests {
         },
     };
     use futures_util::{FutureExt, StreamExt, pin_mut};
-    use std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
+    use std::{
+        future::Future,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        task::{Context, Poll, Wake},
     };
     use temporalio_common::protos::temporal::api::enums::v1::EventType;
+
+    struct WakeCounter(AtomicUsize);
+
+    impl Wake for WakeCounter {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
 
     #[tokio::test]
     async fn sticky_priority_respects_poller_target() {
         let shared = WFTPollerShared::new(Some(4));
         let (_sticky_tx, sticky_rx) = watch::channel(2);
         let (_non_sticky_tx, non_sticky_rx) = watch::channel(1);
-        let sticky_target = Arc::new(AtomicUsize::new(3));
-        shared.set_sticky_active(sticky_rx, sticky_target.clone());
+        let (sticky_target_tx, sticky_target_rx) = watch::channel(3);
+        shared.set_sticky_active(sticky_rx, sticky_target_rx);
         shared.set_non_sticky_active(non_sticky_rx);
         shared.record_sticky_backlog(10);
 
         assert!(shared.wait_if_needed(false).now_or_never().is_none());
 
-        sticky_target.store(2, Ordering::Relaxed);
+        sticky_target_tx.send_replace(2);
         assert!(shared.wait_if_needed(false).now_or_never().is_some());
+        assert!(shared.wait_if_needed(true).now_or_never().is_none());
+    }
+
+    #[tokio::test]
+    async fn target_change_wakes_balancer() {
+        let shared = WFTPollerShared::new(Some(4));
+        let (_sticky_tx, sticky_rx) = watch::channel(2);
+        let (_non_sticky_tx, non_sticky_rx) = watch::channel(1);
+        let (sticky_target_tx, sticky_target_rx) = watch::channel(3);
+        shared.set_sticky_active(sticky_rx, sticky_target_rx);
+        shared.set_non_sticky_active(non_sticky_rx);
+        shared.record_sticky_backlog(10);
+
+        let waiter = shared.wait_if_needed(false);
+        pin_mut!(waiter);
+        let wake_counter = Arc::new(WakeCounter(AtomicUsize::new(0)));
+        let waker = wake_counter.clone().into();
+        let mut context = Context::from_waker(&waker);
+        assert_eq!(waiter.as_mut().poll(&mut context), Poll::Pending);
+
+        sticky_target_tx.send_replace(2);
+        assert_ne!(wake_counter.0.load(Ordering::Relaxed), 0);
+        assert_eq!(waiter.as_mut().poll(&mut context), Poll::Ready(()));
     }
 
     #[tokio::test]

--- a/crates/sdk-core/src/worker/workflow/wft_poller.rs
+++ b/crates/sdk-core/src/worker/workflow/wft_poller.rs
@@ -116,12 +116,16 @@ impl WFTPollerShared {
             max_slots,
         }
     }
-    pub(crate) fn set_sticky_active(&self, rx: watch::Receiver<usize>, target: Arc<AtomicUsize>) {
-        let _ = self.sticky_active.set(rx);
+    pub(crate) fn set_sticky_active(
+        &self,
+        active_rx: watch::Receiver<usize>,
+        target: Arc<AtomicUsize>,
+    ) {
+        let _ = self.sticky_active.set(active_rx);
         let _ = self.sticky_target.set(target);
     }
-    pub(crate) fn set_non_sticky_active(&self, rx: watch::Receiver<usize>) {
-        let _ = self.non_sticky_active.set(rx);
+    pub(crate) fn set_non_sticky_active(&self, active_rx: watch::Receiver<usize>) {
+        let _ = self.non_sticky_active.set(active_rx);
     }
     /// Makes either the sticky or non-sticky poller wait pre-permit-acquisition so that we can
     /// balance which kind of queue we poll appropriately.
@@ -142,7 +146,7 @@ impl WFTPollerShared {
                 let num_sticky_active = *sticky_active.borrow_and_update();
                 let num_non_sticky_active = *non_sticky_active.borrow_and_update();
                 let num_sticky_backlog = *sticky_backlog.borrow_and_update();
-                let sticky_needs_capacity = num_sticky_backlog > 1
+                let sticky_should_be_chosen = num_sticky_backlog > 1
                     && num_sticky_backlog > num_sticky_active
                     && num_sticky_active < sticky_target.load(Ordering::Relaxed);
 
@@ -159,7 +163,7 @@ impl WFTPollerShared {
                         }
 
                         // If there's a meaningful sticky backlog, prioritize sticky.
-                        if sticky_needs_capacity {
+                        if sticky_should_be_chosen {
                             return false;
                         }
                     } else {
@@ -174,7 +178,7 @@ impl WFTPollerShared {
                         }
 
                         // If there's a meaningful sticky backlog, prioritize sticky.
-                        if sticky_needs_capacity {
+                        if sticky_should_be_chosen {
                             return true;
                         }
                     }


### PR DESCRIPTION
## What was changed
We now only prioritize sticky when its backlog exceeds its active pollers and its active count is **below** its autoscaling target.


## Why?
Sticky backlog could keep normal workflow pollers waiting after sticky pollers reached their autoscaling target. Because sticky could not add another poller, shared workflow slots could remain unused.

Share the sticky poller target with workflow poll admission. Sticky backlog now receives priority only while another sticky poller can start. Normal pollers may use spare capacity once sticky reaches its target.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow task poll admission and sticky/non-sticky balancing in the worker hot path, which can alter throughput and latency under sticky backlog and autoscaling.
> 
> **Overview**
> Fixes a case where a large sticky workflow-task backlog could block **non-sticky** pollers even after sticky pollers were already at their configured or autoscaled limit, leaving shared poll capacity unused.
> 
> **Poll scaler target is now observable:** autoscaling target moves from an atomic counter to a `watch` channel so sticky admission and the sticky/non-sticky balancer can react when the target changes.
> 
> **Balancer rules:** sticky backlog only wins priority while another sticky poller is allowed (`active < target`). Once sticky is saturated at target, non-sticky pollers may proceed; sticky pollers stop reserving slots the scaler will not grant. Waiting pollers wake on target updates.
> 
> Changelog entries document the user-visible fix; unit tests cover target-aware priority and wake behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b2536ba29b999c57138b9bcbf4570e6bc51a959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->