### PR TITLE
Add workflow-scoped context storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ relevant information.
 ### Added
 * `CancelExternalWorkflowError` and `workflow_interceptors::CancelExternalWorkflowResult`
   for use in interceptors.
+* `WorkflowContextKey` and context-value scopes provide replay-safe, workflow-run-owned context
+  storage for application code and workflow interceptors. Values survive async suspension while
+  remaining isolated between concurrent branches and signal/update handlers. Read-only workflow
+  views can observe values established by synchronous inbound interceptors, and outbound
+  interceptors can use values to propagate metadata to activities, child workflows, signals,
+  Nexus operations, and continue-as-new runs.
 ### Breaking Changes
 * `ActivityError`, `PayloadConversionError`, `ActivityExecutionError`,
   `ChildWorkflowStartError`, `ChildWorkflowExecutionError`, and `WorkflowSignalError` are now

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/interceptors.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/interceptors.rs
@@ -20,7 +20,8 @@ use temporalio_common::protos::temporal::api::{
 use temporalio_macros::{workflow, workflow_methods};
 use temporalio_sdk::{
     ActivityOptions, ChildWorkflowOptions, LocalActivityOptions, NexusOperationOptions,
-    SyncWorkflowContext, TimerResult, WorkflowContext, WorkflowContextView, WorkflowResult,
+    SyncWorkflowContext, TimerResult, WorkflowContext, WorkflowContextKey, WorkflowContextView,
+    WorkflowResult,
     workflow_interceptors::{
         CancellableWorkflowOutboundFuture, ExecuteWorkflowInput, ExecuteWorkflowResult,
         HandleQueryInput, HandleQueryResult, HandleSignalInput, HandleSignalResult,
@@ -69,9 +70,13 @@ impl InboundInterceptorWorkflow {
     #[update_validator(set_update)]
     fn validate_set_update(
         &self,
-        _ctx: &WorkflowContextView,
+        ctx: &WorkflowContextView,
         input: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        assert_eq!(
+            ctx.context_value::<CurrentContextLabel>().as_deref(),
+            Some(&"validator")
+        );
         assert!(input.ends_with("-validated"));
         if input.starts_with("reject") {
             Err("update rejected by validator".into())
@@ -88,7 +93,11 @@ impl InboundInterceptorWorkflow {
     }
 
     #[query]
-    fn get_status(&self, _ctx: &WorkflowContextView, input: String) -> String {
+    fn get_status(&self, ctx: &WorkflowContextView, input: String) -> String {
+        assert_eq!(
+            ctx.context_value::<CurrentContextLabel>().as_deref(),
+            Some(&"query")
+        );
         assert_eq!(input, "query-mutated");
         "query-original-output".to_string()
     }
@@ -190,7 +199,10 @@ impl WorkflowInterceptor for MutatingWorkflowInterceptor {
             *input = "query-mutated".to_string();
         }
 
-        let result = next.run(input)?;
+        assert!(ctx.context_value::<CurrentContextLabel>().is_none());
+        let result =
+            ctx.with_context_value::<CurrentContextLabel, _>("query", || next.run(input))?;
+        assert!(ctx.context_value::<CurrentContextLabel>().is_none());
         assert_eq!(
             result.downcast_ref::<String>().map(String::as_str),
             Some("query-original-output")
@@ -200,7 +212,7 @@ impl WorkflowInterceptor for MutatingWorkflowInterceptor {
 
     fn validate_update(
         &self,
-        _ctx: SyncWorkflowInterceptorContext,
+        ctx: SyncWorkflowInterceptorContext,
         mut input: ValidateUpdateInput,
         next: WorkflowNext<'_, ValidateUpdateInput, ValidateUpdateResult>,
     ) -> ValidateUpdateResult {
@@ -213,7 +225,11 @@ impl WorkflowInterceptor for MutatingWorkflowInterceptor {
         if let Some(input) = input.input_mut::<String>() {
             input.push_str("-validated");
         }
-        next.run(input)
+        assert!(ctx.context_value::<CurrentContextLabel>().is_none());
+        let result =
+            ctx.with_context_value::<CurrentContextLabel, _>("validator", || next.run(input));
+        assert!(ctx.context_value::<CurrentContextLabel>().is_none());
+        result
     }
 }
 
@@ -488,6 +504,146 @@ async fn all_handlers_finished_waits_for_handler_chain(
     let (_, worker_result) = join!(driver, worker.run_until_done());
     worker_result.unwrap();
     handle.fetch_history_and_replay(&mut worker).await.unwrap();
+}
+
+struct CurrentContextLabel;
+
+impl WorkflowContextKey for CurrentContextLabel {
+    type Value = &'static str;
+}
+
+#[workflow]
+#[derive(Default)]
+struct WorkflowContextPropagationWorkflow {
+    finish: bool,
+}
+
+#[workflow_methods]
+impl WorkflowContextPropagationWorkflow {
+    #[run]
+    async fn run(ctx: &mut WorkflowContext<Self>) -> WorkflowResult<()> {
+        let run_ctx = ctx.clone();
+        ctx.with_context_value::<CurrentContextLabel, _>("run", async move {
+            let left_ctx = run_ctx.clone();
+            let left = run_ctx.with_context_value::<CurrentContextLabel, _>("left", async move {
+                left_ctx.timer(Duration::from_millis(1)).await;
+                assert_eq!(
+                    left_ctx.context_value::<CurrentContextLabel>().as_deref(),
+                    Some(&"left")
+                );
+            });
+            let right_ctx = run_ctx.clone();
+            let right = run_ctx.with_context_value::<CurrentContextLabel, _>("right", async move {
+                right_ctx.timer(Duration::from_millis(1)).await;
+                assert_eq!(
+                    right_ctx.context_value::<CurrentContextLabel>().as_deref(),
+                    Some(&"right")
+                );
+            });
+            temporalio_sdk::workflows::join!(left, right);
+
+            assert_eq!(
+                run_ctx.context_value::<CurrentContextLabel>().as_deref(),
+                Some(&"run")
+            );
+            run_ctx.timer(Duration::from_millis(1)).await;
+            run_ctx.wait_condition(|state| state.finish).await
+        })
+        .await?;
+        assert!(ctx.context_value::<CurrentContextLabel>().is_none());
+        Ok(())
+    }
+
+    #[signal]
+    async fn finish(ctx: &mut WorkflowContext<Self>) {
+        let signal_ctx = ctx.clone();
+        ctx.with_context_value::<CurrentContextLabel, _>("signal", async move {
+            signal_ctx.timer(Duration::from_millis(1)).await;
+            assert_eq!(
+                signal_ctx.context_value::<CurrentContextLabel>().as_deref(),
+                Some(&"signal")
+            );
+            signal_ctx.state_mut(|state| state.finish = true);
+        })
+        .await;
+        assert!(ctx.context_value::<CurrentContextLabel>().is_none());
+    }
+}
+
+struct ObserveWorkflowContextInterceptor {
+    observed: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl WorkflowInterceptor for ObserveWorkflowContextInterceptor {
+    fn start_timer(
+        &self,
+        ctx: WorkflowInterceptorContext,
+        input: StartTimerInput,
+        next: WorkflowNext<
+            'static,
+            StartTimerInput,
+            CancellableWorkflowOutboundFuture<TimerResult>,
+        >,
+    ) -> CancellableWorkflowOutboundFuture<TimerResult> {
+        self.observed.lock().unwrap().push(
+            *ctx.context_value::<CurrentContextLabel>()
+                .expect("timer must have workflow context"),
+        );
+        next.run(input)
+    }
+}
+
+#[tokio::test]
+async fn workflow_context_is_branch_and_handler_local_during_replay() {
+    let mut starter =
+        CoreWfStarter::new("workflow_context_is_branch_and_handler_local_during_replay");
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let interceptor_observed = observed.clone();
+    starter
+        .sdk_config
+        .register_workflow::<WorkflowContextPropagationWorkflow>()
+        .unwrap()
+        .register_workflow_interceptors(vec![WorkflowInterceptorConstructor::new(move |_| {
+            ObserveWorkflowContextInterceptor {
+                observed: interceptor_observed.clone(),
+            }
+        })]);
+    let mut worker = starter.worker().await;
+
+    let handle = worker
+        .submit_workflow(
+            WorkflowContextPropagationWorkflow::run,
+            (),
+            WorkflowStartOptions::new(
+                starter.get_task_queue().to_owned(),
+                starter.get_wf_id().to_owned(),
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+    let driver = async {
+        handle
+            .signal(
+                WorkflowContextPropagationWorkflow::finish,
+                (),
+                WorkflowSignalOptions::default(),
+            )
+            .await
+            .unwrap();
+        handle.get_result(Default::default()).await.unwrap();
+    };
+    let (_, worker_result) = join!(driver, worker.run_until_done());
+    worker_result.unwrap();
+    let mut live_observed = observed.lock().unwrap().clone();
+    live_observed.sort_unstable();
+    assert_eq!(live_observed, ["left", "right", "run", "signal"]);
+
+    observed.lock().unwrap().clear();
+    handle.fetch_history_and_replay(&mut worker).await.unwrap();
+    let mut replay_observed = observed.lock().unwrap().clone();
+    replay_observed.sort_unstable();
+    assert_eq!(replay_observed, ["left", "right", "run", "signal"]);
 }
 
 #[tokio::test]

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -118,6 +118,11 @@ path = "examples/activity_interceptor/starter.rs"
 required-features = ["examples"]
 
 [[example]]
+name = "workflow-context"
+path = "examples/workflow_context.rs"
+required-features = ["examples"]
+
+[[example]]
 name = "timer-examples-worker"
 path = "examples/timer_examples/worker.rs"
 required-features = ["examples"]

--- a/crates/sdk/examples/workflow_context.rs
+++ b/crates/sdk/examples/workflow_context.rs
@@ -1,0 +1,83 @@
+//! Establish application context in workflow code and observe it in an outbound interceptor.
+
+use std::{sync::Arc, time::Duration};
+use temporalio_common::protos::temporal::api::common::v1::Payload;
+use temporalio_macros::{activities, workflow, workflow_methods};
+use temporalio_sdk::{
+    ActivityOptions, WorkflowContext, WorkflowContextKey, WorkflowResult,
+    activities::{ActivityContext, ActivityError},
+    workflow_interceptors::{
+        CancellableWorkflowOutboundFuture, ScheduleActivityInput, ScheduleActivityResult,
+        WorkflowInterceptor, WorkflowInterceptorContext, WorkflowNext,
+    },
+};
+
+struct CurrentSpan;
+
+impl WorkflowContextKey for CurrentSpan {
+    type Value = String;
+}
+
+#[workflow]
+#[derive(Default)]
+struct ContextWorkflow;
+
+#[workflow_methods]
+impl ContextWorkflow {
+    #[run]
+    async fn run(ctx: &mut WorkflowContext<Self>, name: String) -> WorkflowResult<String> {
+        let scoped_ctx = ctx.clone();
+        ctx.with_context_value::<CurrentSpan, _>(format!("greet-{name}"), async move {
+            scoped_ctx
+                .execute_activity(
+                    GreetingActivities::greet,
+                    name,
+                    ActivityOptions::start_to_close_timeout(Duration::from_secs(10)),
+                )
+                .await
+                .map_err(Into::into)
+        })
+        .await
+    }
+}
+
+struct GreetingActivities;
+
+#[activities]
+impl GreetingActivities {
+    #[activity]
+    async fn greet(_ctx: ActivityContext, name: String) -> Result<String, ActivityError> {
+        Ok(format!("Hello, {name}!"))
+    }
+}
+
+struct ContextHeaderInterceptor;
+
+impl WorkflowInterceptor for ContextHeaderInterceptor {
+    fn schedule_activity(
+        &self,
+        ctx: WorkflowInterceptorContext,
+        mut input: ScheduleActivityInput,
+        next: WorkflowNext<
+            'static,
+            ScheduleActivityInput,
+            CancellableWorkflowOutboundFuture<ScheduleActivityResult>,
+        >,
+    ) -> CancellableWorkflowOutboundFuture<ScheduleActivityResult> {
+        if let Some(span) = ctx.context_value::<CurrentSpan>() {
+            input.headers_mut().insert(
+                "example-span".to_owned(),
+                Payload {
+                    metadata: [("encoding".to_owned(), b"binary/plain".to_vec())].into(),
+                    data: span.as_bytes().to_vec(),
+                    ..Default::default()
+                },
+            );
+        }
+        next.run(input)
+    }
+}
+
+fn main() {
+    let _interceptor: Arc<dyn WorkflowInterceptor> = Arc::new(ContextHeaderInterceptor);
+}

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -105,8 +105,8 @@ pub use temporalio_workflow::{
     MemoValue, ParentClosePolicy, SignalWorkflowOptions, StartChildWorkflowExecutionFailedCause,
     StartChildWorkflowOutput, StartedChildWorkflow, SyncWorkflowContext, TimerOptions, TimerResult,
     VersioningIntent, WaitConditionOptions, WorkflowCancellationError, WorkflowCancellationToken,
-    WorkflowContext, WorkflowContextView, WorkflowIdReusePolicy, WorkflowRandomValue,
-    WorkflowResult, WorkflowTermination,
+    WorkflowContext, WorkflowContextFuture, WorkflowContextKey, WorkflowContextView,
+    WorkflowIdReusePolicy, WorkflowRandomValue, WorkflowResult, WorkflowTermination,
 };
 #[cfg(feature = "experimental")]
 pub use temporalio_workflow::{

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -73,8 +73,9 @@ pub use workflow_context::{
     ContinueAsNewOptions, ExternalWorkflowHandle, LocalActivityOptions, NamespacedWorkflowInfo,
     ParentClosePolicy, SignalWorkflowOptions, StartChildWorkflowExecutionFailedCause,
     StartChildWorkflowOutput, StartedChildWorkflow, SyncWorkflowContext, TimerOptions,
-    VersioningIntent, WaitConditionOptions, WorkflowContext, WorkflowContextView,
-    WorkflowIdReusePolicy, WorkflowRandomStream, WorkflowRandomValue,
+    VersioningIntent, WaitConditionOptions, WorkflowContext, WorkflowContextFuture,
+    WorkflowContextKey, WorkflowContextView, WorkflowIdReusePolicy, WorkflowRandomStream,
+    WorkflowRandomValue,
 };
 #[cfg(feature = "experimental")]
 pub use workflow_context::{

--- a/crates/workflow/src/workflow_context.rs
+++ b/crates/workflow/src/workflow_context.rs
@@ -50,8 +50,10 @@ use rand::SeedableRng;
 use rand_pcg::Pcg64Mcg;
 use siphasher::sip::SipHasher13;
 use std::{
+    any::{Any, TypeId},
     cell::{Cell, RefCell},
     collections::{HashMap, HashSet},
+    fmt,
     future::{self, Future},
     hash::Hasher,
     marker::PhantomData,
@@ -262,6 +264,106 @@ impl WorkflowRandomState {
 #[derive(Clone)]
 pub struct BaseWorkflowContext {
     inner: Rc<WorkflowContextInner>,
+}
+
+/// A typed key for values stored in the current workflow execution context.
+///
+/// Implement this trait on a dedicated marker type shared by the workflow and its interceptors.
+/// The marker type itself is the key, so different markers can store the same value type without
+/// colliding.
+///
+/// # Scope and propagation
+///
+/// A scope inherits the values active when it is created. A nested scope shadows only its selected
+/// key. Plain child futures polled inside a scope see that scope, while separately scoped
+/// concurrent futures retain their own snapshots. Independently scheduled signal and update
+/// handlers start without another routine's values; an inbound interceptor or the handler itself
+/// can establish a handler-local scope.
+///
+/// Values remain installed only while scoped workflow code is being polled. The SDK restores the
+/// prior snapshot on suspension, completion, cancellation by dropping the future, and panic. This
+/// prevents a value from leaking to another routine sharing the workflow's single-threaded
+/// executor, or to another workflow execution. Cache eviction drops all values; replay recreates
+/// them by executing the same deterministic scope calls.
+///
+/// Storage is in-memory and local to one workflow run. Cross-boundary propagation is explicit:
+/// outbound interceptors read values and write headers for activities, local activities, child
+/// workflows, signals, Nexus operations, or continue-as-new, and inbound interceptors decode those
+/// headers and establish a new scope.
+///
+/// ```
+/// use temporalio_workflow::WorkflowContextKey;
+///
+/// struct RequestId;
+///
+/// impl WorkflowContextKey for RequestId {
+///     type Value = String;
+/// }
+/// ```
+pub trait WorkflowContextKey: 'static {
+    /// Value stored under this key.
+    type Value: 'static;
+}
+
+type WorkflowContextValues = Rc<HashMap<TypeId, Rc<dyn Any>>>;
+
+#[derive(Clone, Default)]
+pub(super) struct WorkflowContextValueStore {
+    current: Rc<RefCell<WorkflowContextValues>>,
+}
+
+impl fmt::Debug for WorkflowContextValueStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WorkflowContextValueStore")
+            .finish_non_exhaustive()
+    }
+}
+
+impl WorkflowContextValueStore {
+    pub(super) fn context_value<K: WorkflowContextKey>(&self) -> Option<Rc<K::Value>> {
+        self.current
+            .borrow()
+            .get(&TypeId::of::<K>())
+            .cloned()
+            .and_then(|value| value.downcast().ok())
+    }
+}
+
+/// A future that installs workflow context values while polling its inner future.
+///
+/// Create this with [`WorkflowContext::with_context_value`] or
+/// [`WorkflowInterceptorContext::with_context_value`](crate::workflow_interceptors::WorkflowInterceptorContext::with_context_value).
+/// Values survive suspension and are isolated from concurrently polled workflow futures.
+#[must_use = "futures do nothing unless polled"]
+pub struct WorkflowContextFuture<F> {
+    base: BaseWorkflowContext,
+    values: WorkflowContextValues,
+    inner: Pin<Box<F>>,
+}
+
+impl<F: Future> Future for WorkflowContextFuture<F> {
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let _guard = this.base.install_context_values(this.values.clone());
+        this.inner.as_mut().poll(cx)
+    }
+}
+
+struct WorkflowContextRestoreGuard {
+    base: BaseWorkflowContext,
+    previous: Option<WorkflowContextValues>,
+}
+
+impl Drop for WorkflowContextRestoreGuard {
+    fn drop(&mut self) {
+        self.base
+            .inner
+            .context_values
+            .current
+            .replace(self.previous.take().expect("context is restored once"));
+    }
 }
 
 /// Input provided to a worker's patch activation callback.
@@ -521,6 +623,7 @@ impl BaseWorkflowContext {
             self.requires_replay_safety(),
             Some(self.inner.random.clone()),
         )
+        .with_context_values(self.inner.context_values.clone())
     }
 }
 
@@ -632,6 +735,7 @@ struct WorkflowContextInner {
     requires_replay_safety: Cell<bool>,
     condition_wakers: RefCell<Vec<Waker>>,
     current_waker: RefCell<Option<Waker>>,
+    context_values: WorkflowContextValueStore,
     workflow_interceptors: Rc<[Arc<dyn WorkflowInterceptor>]>,
 }
 
@@ -750,6 +854,7 @@ impl BaseWorkflowContext {
         let random = Rc::new(RefCell::new(WorkflowRandomState::new(
             initialize_workflow.randomness_seed,
         )));
+        let context_values = WorkflowContextValueStore::default();
         let view = WorkflowContextView::new(
             namespace,
             task_queue,
@@ -758,7 +863,8 @@ impl BaseWorkflowContext {
             data_converter.payload_converter().clone(),
             true,
             Some(random.clone()),
-        );
+        )
+        .with_context_values(context_values.clone());
         let workflow_interceptors = workflow_interceptor_constructors
             .into_iter()
             .map(|constructor| constructor.construct(&view))
@@ -803,8 +909,49 @@ impl BaseWorkflowContext {
                 requires_replay_safety: Cell::new(true),
                 condition_wakers: Default::default(),
                 current_waker: RefCell::new(None),
+                context_values,
                 workflow_interceptors,
             }),
+        }
+    }
+
+    pub(crate) fn context_value<K: WorkflowContextKey>(&self) -> Option<Rc<K::Value>> {
+        self.inner.context_values.context_value::<K>()
+    }
+
+    fn context_values_with<K: WorkflowContextKey>(&self, value: K::Value) -> WorkflowContextValues {
+        let mut values = self.inner.context_values.current.borrow().as_ref().clone();
+        values.insert(TypeId::of::<K>(), Rc::new(value));
+        Rc::new(values)
+    }
+
+    pub(crate) fn with_context_value<K: WorkflowContextKey, F: Future>(
+        &self,
+        value: K::Value,
+        future: F,
+    ) -> WorkflowContextFuture<F> {
+        WorkflowContextFuture {
+            base: self.clone(),
+            values: self.context_values_with::<K>(value),
+            inner: Box::pin(future),
+        }
+    }
+
+    pub(crate) fn with_context_value_sync<K: WorkflowContextKey, R>(
+        &self,
+        value: K::Value,
+        f: impl FnOnce() -> R,
+    ) -> R {
+        let values = self.context_values_with::<K>(value);
+        let _guard = self.install_context_values(values);
+        f()
+    }
+
+    fn install_context_values(&self, values: WorkflowContextValues) -> WorkflowContextRestoreGuard {
+        let previous = self.inner.context_values.current.replace(values);
+        WorkflowContextRestoreGuard {
+            base: self.clone(),
+            previous: Some(previous),
         }
     }
 
@@ -1484,6 +1631,26 @@ impl BaseWorkflowContext {
 }
 
 impl<W> SyncWorkflowContext<W> {
+    /// Return the value associated with key type `K` in the current workflow context scope.
+    ///
+    /// The returned [`Rc`] makes lookup inexpensive without requiring stored values to implement
+    /// [`Clone`]. Values exist only in memory for this workflow run and are rebuilt during replay.
+    pub fn context_value<K: WorkflowContextKey>(&self) -> Option<Rc<K::Value>> {
+        self.base.context_value::<K>()
+    }
+
+    /// Run synchronous workflow code with `value` installed for key type `K`.
+    ///
+    /// Nested calls inherit other current values and shadow the same key. The previous context is
+    /// restored when `f` returns or unwinds.
+    pub fn with_context_value_sync<K: WorkflowContextKey, R>(
+        &self,
+        value: K::Value,
+        f: impl FnOnce() -> R,
+    ) -> R {
+        self.base.with_context_value_sync::<K, R>(value, f)
+    }
+
     /// Return the workflow's unique identifier
     pub fn workflow_id(&self) -> &str {
         &self.base.inner.initial_information.workflow_id
@@ -2005,6 +2172,37 @@ impl<W> WorkflowContext<W> {
     }
 
     // --- Delegated methods from SyncWorkflowContext ---
+
+    /// Return the value associated with key type `K` in the current workflow context scope.
+    pub fn context_value<K: WorkflowContextKey>(&self) -> Option<Rc<K::Value>> {
+        self.sync.context_value::<K>()
+    }
+
+    /// Poll `future` with `value` installed for key type `K`.
+    ///
+    /// The scope captures the context active when this method is called. Nested scopes inherit
+    /// other values and shadow the same key. Context is restored after every poll, including when
+    /// the future completes or panics, so concurrent workflow branches and handlers cannot observe
+    /// one another's scoped values.
+    ///
+    /// Context values are runtime-only. They are not recorded in history or automatically placed
+    /// in command headers; outbound interceptors can read them and propagate selected values.
+    pub fn with_context_value<K: WorkflowContextKey, F: Future>(
+        &self,
+        value: K::Value,
+        future: F,
+    ) -> WorkflowContextFuture<F> {
+        self.sync.base.with_context_value::<K, F>(value, future)
+    }
+
+    /// Run synchronous workflow code with `value` installed for key type `K`.
+    pub fn with_context_value_sync<K: WorkflowContextKey, R>(
+        &self,
+        value: K::Value,
+        f: impl FnOnce() -> R,
+    ) -> R {
+        self.sync.with_context_value_sync::<K, R>(value, f)
+    }
 
     /// Return the workflow's unique identifier
     pub fn workflow_id(&self) -> &str {
@@ -4921,5 +5119,125 @@ mod tests {
         assert_eq!(info.raw().identity, "raw-only-identity");
         assert_eq!(info.raw(), &expected);
         assert_eq!(info.into_raw(), expected);
+    }
+
+    #[test]
+    fn async_context_values_survive_suspension_and_isolate_concurrent_branches() {
+        struct Label;
+
+        impl WorkflowContextKey for Label {
+            type Value = &'static str;
+        }
+
+        let ctx = test_context();
+        let first_poll = Rc::new(Cell::new(true));
+        let second_poll = Rc::new(Cell::new(true));
+        let first_ctx = ctx.clone();
+        let first_poll_in_future = first_poll.clone();
+        let first = ctx.with_context_value::<Label, _>(
+            "first",
+            future::poll_fn(move |_| {
+                assert_eq!(
+                    first_ctx.context_value::<Label>().as_deref(),
+                    Some(&"first")
+                );
+                if first_poll_in_future.replace(false) {
+                    Poll::Pending
+                } else {
+                    Poll::Ready(())
+                }
+            }),
+        );
+        let second_ctx = ctx.clone();
+        let second_poll_in_future = second_poll.clone();
+        let second = ctx.with_context_value::<Label, _>(
+            "second",
+            future::poll_fn(move |_| {
+                assert_eq!(
+                    second_ctx.context_value::<Label>().as_deref(),
+                    Some(&"second")
+                );
+                if second_poll_in_future.replace(false) {
+                    Poll::Pending
+                } else {
+                    Poll::Ready(())
+                }
+            }),
+        );
+        let mut joined = Box::pin(futures_util::future::join(first, second));
+        let waker = futures_util::task::noop_waker();
+        let mut poll_ctx = Context::from_waker(&waker);
+
+        assert!(joined.as_mut().poll(&mut poll_ctx).is_pending());
+        assert!(ctx.context_value::<Label>().is_none());
+        assert!(joined.as_mut().poll(&mut poll_ctx).is_ready());
+        assert!(ctx.context_value::<Label>().is_none());
+
+        let mut dropped =
+            Box::pin(ctx.with_context_value::<Label, _>("dropped", future::pending::<()>()));
+        assert!(dropped.as_mut().poll(&mut poll_ctx).is_pending());
+        assert!(ctx.context_value::<Label>().is_none());
+        drop(dropped);
+        assert!(ctx.context_value::<Label>().is_none());
+    }
+
+    #[test]
+    fn context_scopes_inherit_shadow_and_restore_after_panic() {
+        struct Label;
+        struct OtherLabel;
+        struct Count;
+
+        impl WorkflowContextKey for Label {
+            type Value = &'static str;
+        }
+
+        impl WorkflowContextKey for OtherLabel {
+            type Value = &'static str;
+        }
+
+        impl WorkflowContextKey for Count {
+            type Value = u32;
+        }
+
+        let ctx = test_context();
+        ctx.with_context_value_sync::<Label, _>("outer", || {
+            assert_eq!(ctx.context_value::<Label>().as_deref(), Some(&"outer"));
+            assert!(ctx.context_value::<OtherLabel>().is_none());
+            ctx.with_context_value_sync::<Count, _>(7, || {
+                assert_eq!(ctx.context_value::<Label>().as_deref(), Some(&"outer"));
+                assert_eq!(ctx.context_value::<Count>().as_deref(), Some(&7));
+                ctx.with_context_value_sync::<Label, _>("inner", || {
+                    assert_eq!(ctx.context_value::<Label>().as_deref(), Some(&"inner"));
+                });
+                assert_eq!(ctx.context_value::<Label>().as_deref(), Some(&"outer"));
+            });
+            assert!(ctx.context_value::<Count>().is_none());
+
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                ctx.with_context_value_sync::<Label, _>("panic", || panic!("test panic"));
+            }));
+            assert!(result.is_err());
+            assert_eq!(ctx.context_value::<Label>().as_deref(), Some(&"outer"));
+        });
+        assert!(ctx.context_value::<Label>().is_none());
+
+        let panic_ctx = ctx.clone();
+        let mut panic_future = Box::pin(ctx.with_context_value::<Label, _>(
+            "async-panic",
+            async move {
+                assert_eq!(
+                    panic_ctx.context_value::<Label>().as_deref(),
+                    Some(&"async-panic")
+                );
+                panic!("async test panic");
+            },
+        ));
+        let waker = futures_util::task::noop_waker();
+        let mut poll_ctx = Context::from_waker(&waker);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            panic_future.as_mut().poll(&mut poll_ctx)
+        }));
+        assert!(result.is_err());
+        assert!(ctx.context_value::<Label>().is_none());
     }
 }

--- a/crates/workflow/src/workflow_context/view.rs
+++ b/crates/workflow/src/workflow_context/view.rs
@@ -1,4 +1,7 @@
-use super::{WorkflowRandomState, WorkflowRandomStream, WorkflowRandomStreamSource};
+use super::{
+    WorkflowContextKey, WorkflowContextValueStore, WorkflowRandomState, WorkflowRandomStream,
+    WorkflowRandomStreamSource,
+};
 use std::{
     cell::RefCell,
     rc::Rc,
@@ -14,7 +17,7 @@ use temporalio_common_wasm::{
     search_attributes::SearchAttributes,
 };
 
-/// Read-only view of workflow context for use in init and query handlers.
+/// Read-only view of workflow context for use in init, query, and update-validator handlers.
 ///
 /// This provides access to workflow information but cannot issue commands.
 #[derive(Clone, Debug)]
@@ -27,6 +30,7 @@ pub struct WorkflowContextView {
     payload_converter: PayloadConverter,
     requires_replay_safety: bool,
     workflow_random: Option<Rc<RefCell<WorkflowRandomState>>>,
+    context_values: WorkflowContextValueStore,
 }
 
 impl WorkflowContextView {
@@ -48,7 +52,13 @@ impl WorkflowContextView {
             payload_converter,
             requires_replay_safety,
             workflow_random,
+            context_values: WorkflowContextValueStore::default(),
         }
+    }
+
+    pub(super) fn with_context_values(mut self, context_values: WorkflowContextValueStore) -> Self {
+        self.context_values = context_values;
+        self
     }
 
     pub(super) fn into_parts(self) -> (String, String, String, InitializeWorkflow) {
@@ -165,6 +175,14 @@ impl WorkflowContextView {
             .search_attributes
             .as_ref()
             .map(SearchAttributes::from_proto)
+    }
+
+    /// Return the value associated with key type `K` in the current workflow context scope.
+    ///
+    /// This allows queries and update validators to observe values established by synchronous
+    /// inbound interceptors without allowing the handler to modify the context scope.
+    pub fn context_value<K: WorkflowContextKey>(&self) -> Option<Rc<K::Value>> {
+        self.context_values.context_value::<K>()
     }
 
     #[allow(

--- a/crates/workflow/src/workflow_interceptors.rs
+++ b/crates/workflow/src/workflow_interceptors.rs
@@ -85,8 +85,8 @@ use crate::{
     ActivityOptions, BaseWorkflowContext, CancelExternalWorkflowError, CancellableFuture,
     CancellableFutureWithReason, ChildWorkflowOptions, ContinueAsNewOptions,
     ExternalWorkflowHandle, LocalActivityOptions, SignalWorkflowOptions, StartChildWorkflowOutput,
-    StartedChildWorkflow, TimerOptions, WorkflowCancellationToken, WorkflowContextView,
-    WorkflowRandomStream,
+    StartedChildWorkflow, TimerOptions, WorkflowCancellationToken, WorkflowContextFuture,
+    WorkflowContextKey, WorkflowContextView, WorkflowRandomStream,
     cancellation::WorkflowCancellationRegistration,
     runtime::{
         entry::WorkflowError,
@@ -280,6 +280,33 @@ impl WorkflowInterceptorContext {
         Self { base }
     }
 
+    /// Return the value associated with key type `K` in the current workflow context scope.
+    pub fn context_value<K: WorkflowContextKey>(&self) -> Option<Rc<K::Value>> {
+        self.base.context_value::<K>()
+    }
+
+    /// Poll `future` with `value` installed for key type `K`.
+    ///
+    /// Inbound interceptors can use this to establish context around `next.run(input)`. Outbound
+    /// interceptors invoked by the workflow inside that scope observe the value with
+    /// [`Self::context_value`]. The previous context is restored after each poll.
+    pub fn with_context_value<K: WorkflowContextKey, F: Future>(
+        &self,
+        value: K::Value,
+        future: F,
+    ) -> WorkflowContextFuture<F> {
+        self.base.with_context_value::<K, F>(value, future)
+    }
+
+    /// Run synchronous interceptor code with `value` installed for key type `K`.
+    pub fn with_context_value_sync<K: WorkflowContextKey, R>(
+        &self,
+        value: K::Value,
+        f: impl FnOnce() -> R,
+    ) -> R {
+        self.base.with_context_value_sync::<K, R>(value, f)
+    }
+
     /// Return the workflow's unique identifier.
     pub fn workflow_id(&self) -> &str {
         self.base.workflow_id()
@@ -418,6 +445,22 @@ pub struct SyncWorkflowInterceptorContext {
 impl SyncWorkflowInterceptorContext {
     pub(crate) fn new(base: BaseWorkflowContext) -> Self {
         Self { base }
+    }
+
+    /// Return the value associated with key type `K` in the current workflow context scope.
+    pub fn context_value<K: WorkflowContextKey>(&self) -> Option<Rc<K::Value>> {
+        self.base.context_value::<K>()
+    }
+
+    /// Run synchronous interceptor code with `value` installed for key type `K`.
+    ///
+    /// This is intended for query and update-validator interceptor chains, which cannot await.
+    pub fn with_context_value<K: WorkflowContextKey, R>(
+        &self,
+        value: K::Value,
+        f: impl FnOnce() -> R,
+    ) -> R {
+        self.base.with_context_value_sync::<K, R>(value, f)
     }
 
     /// Return the workflow's unique identifier.


### PR DESCRIPTION
## What was changed

- Added typed context storage for one Workflow run.
- Added async and synchronous context scopes for Workflow code and Workflow interceptors.
- Added read-only context lookup to `WorkflowContextView` for queries and Update validators.
- Added an example, API documentation, tests, and an Unreleased changelog entry.

The SDK restores the previous context after each Future poll. It also restores the context after completion, cancellation, or panic. Concurrent branches and handlers therefore do not share scoped values by accident.

The SDK does not serialize context values or propagate them automatically. An interceptor can read a value and put selected data in Temporal headers.

## Why?

Workflow code needs a safe way to give application context to SDK interceptors. For example, an OpenTelemetry interceptor must use an application span as the parent of an Activity, Child Workflow, Signal, Nexus Operation, or Continue-As-New span.

Process-global state and Tokio task-local state can leak between Workflow executions. This change keeps the state in the Workflow runtime. Replay rebuilds the state when Workflow code runs again.

## Checklist

1. Closes: N/A.

2. How was this tested:

   - `cargo test`
   - `cargo lint`
   - `cargo test-lint`
   - `cargo test -p temporalio-workflow --doc`
   - `cargo check -p temporalio-sdk --example workflow-context --features examples`
   - `cargo integ-test workflow_interceptors_mutate_inputs_and_replace_outputs -- --nocapture`
   - `cargo integ-test workflow_context_is_branch_and_handler_local_during_replay -- --nocapture`
   - `cargo +nightly fmt --check`

3. Any docs updates needed?

   No additional documentation update is needed. This PR adds public API documentation, an SDK example, and a changelog entry.
