### PR TITLE
chore(sdk): provide concrete types for worker tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ relevant information.
   distinguish a missing signal or cancellation target from other delivery failures.
 
 ### Breaking Changes
+* `temporalio-sdk` now exposes SDK-owned worker tuner and slot supplier types instead of
+  re-exporting the corresponding `temporalio-sdk-core` traits.
 * `temporalio-sdk` now owns its runtime, polling, workflow-error, worker-validation, and local test
   server configuration types instead of re-exporting their `temporalio-sdk-core` equivalents.
   `TokioRuntimeBuilder` is non-exhaustive and provides a builder for construction. Unrelated Core

--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -1845,8 +1845,6 @@ pub enum WorkflowErrorType {
     Nondeterminism,
 }
 
-// The Rust SDK intentionally re-exports this trait and the slot-supplier family below, so Core
-// changes to these APIs must preserve the Rust SDK's stability guarantees.
 /// This trait allows users to customize the performance characteristics of workers dynamically.
 /// For more, see the docstrings of the traits in the return types of its functions.
 pub trait WorkerTuner {

--- a/crates/sdk-core/src/worker/tuner.rs
+++ b/crates/sdk-core/src/worker/tuner.rs
@@ -1,8 +1,6 @@
 mod fixed_size;
 mod resource_based;
 
-// The Rust SDK intentionally re-exports this module's public tuner configuration types. Changes
-// here must preserve that stable user-facing API even while sdk-core itself remains pre-1.0.
 pub use fixed_size::FixedSizeSlotSupplier;
 pub(crate) use resource_based::{RealSysInfo, SystemResourceInfo};
 pub use resource_based::{

--- a/crates/sdk-core/tests/common/mod.rs
+++ b/crates/sdk-core/tests/common/mod.rs
@@ -60,8 +60,8 @@ use temporalio_sdk::{
 #[cfg(any(feature = "test-utilities", test))]
 pub(crate) use temporalio_sdk_core::test_help::NAMESPACE;
 use temporalio_sdk_core::{
-    CoreRuntime, RuntimeOptions, Worker as CoreWorker, WorkerConfig, WorkerVersioningStrategy,
-    init_replay_worker, init_worker,
+    CoreRuntime, RuntimeOptions, Worker as CoreWorker, WorkerConfig,
+    WorkerTuner as CoreWorkerTuner, WorkerVersioningStrategy, init_replay_worker, init_worker,
     replay::{HistoryForReplay, ReplayWorkerInput},
     test_help::{MockPollCfg, build_mock_pollers, mock_worker},
 };
@@ -355,6 +355,7 @@ pub(crate) struct CoreWfStarter {
     /// Run when initializing, allows for altering the config used to init the core worker
     #[allow(clippy::type_complexity)] // It's not tho
     core_config_mutator: Option<Arc<dyn Fn(&mut WorkerConfig)>>,
+    core_tuner_override: Option<Arc<dyn CoreWorkerTuner + Send + Sync>>,
     core_task_types: Option<WorkerTaskTypes>,
 }
 struct InitializedWorker {
@@ -480,6 +481,7 @@ impl CoreWfStarter {
             client_override,
             min_local_server_version: None,
             core_config_mutator: None,
+            core_tuner_override: None,
             core_task_types: None,
         }
     }
@@ -496,6 +498,7 @@ impl CoreWfStarter {
             min_local_server_version: self.min_local_server_version.clone(),
             initted_worker: Default::default(),
             core_config_mutator: self.core_config_mutator.clone(),
+            core_tuner_override: self.core_tuner_override.clone(),
             core_task_types: self.core_task_types,
         }
     }
@@ -522,6 +525,10 @@ impl CoreWfStarter {
 
     pub(crate) fn set_core_cfg_mutator(&mut self, mutator: impl Fn(&mut WorkerConfig) + 'static) {
         self.core_config_mutator = Some(Arc::new(mutator))
+    }
+
+    pub(crate) fn set_core_tuner(&mut self, tuner: Arc<dyn CoreWorkerTuner + Send + Sync>) {
+        self.core_tuner_override = Some(tuner);
     }
 
     pub(crate) fn set_core_task_types(&mut self, task_types: WorkerTaskTypes) {
@@ -676,6 +683,9 @@ impl CoreWfStarter {
                 }
                 if let Some(ref ccm) = self.core_config_mutator {
                     ccm(&mut core_config);
+                }
+                if let Some(tuner) = &self.core_tuner_override {
+                    core_config.tuner = Some(tuner.clone());
                 }
                 let worker =
                     init_worker(rt, core_config, connection).expect("Worker inits cleanly");

--- a/crates/sdk-core/tests/heavy_tests.rs
+++ b/crates/sdk-core/tests/heavy_tests.rs
@@ -84,8 +84,12 @@ async fn activity_load() {
     let mut starter = CoreWfStarter::new("activity_load");
     starter.sdk_config.max_cached_workflows = CONCURRENCY;
     starter.sdk_config.activity_task_poller_behavior = Some(PollerBehavior::SimpleMaximum(10));
-    starter.sdk_config.tuner =
-        Arc::new(TunerHolder::fixed_size(CONCURRENCY, CONCURRENCY, 100, 100));
+    starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(
+        CONCURRENCY,
+        CONCURRENCY,
+        100,
+        100,
+    )));
     starter.sdk_config.register_activities(StdActivities);
     starter
         .sdk_config
@@ -177,7 +181,7 @@ async fn chunky_activities_resource_based() {
             Duration::from_millis(0),
         ))
         .with_activity_slots_options(ResourceSlotOptions::new(5, 1000, Duration::from_millis(50)));
-    starter.sdk_config.tuner = Arc::new(tuner);
+    starter.set_core_tuner(Arc::new(tuner));
 
     starter.sdk_config.register_activities(ChunkyActivities);
     starter
@@ -254,7 +258,7 @@ async fn workflow_load() {
     let mut starter = CoreWfStarter::new_with_runtime("workflow_load", rt);
     starter.sdk_config.max_cached_workflows = 200;
     starter.sdk_config.activity_task_poller_behavior = Some(PollerBehavior::SimpleMaximum(10));
-    starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(5, 100, 100, 100));
+    starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(5, 100, 100, 100)));
     starter.sdk_config.register_activities(StdActivities);
     let task_queue = starter.get_task_queue().to_owned();
     starter
@@ -310,7 +314,7 @@ async fn evict_while_la_running_no_interference() {
     // Though it doesn't make sense to set wft higher than cached workflows, leaving this commented
     // introduces more instability that can be useful in the test.
     // starter.max_wft(20);
-    starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(100, 10, 20, 1));
+    starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(100, 10, 20, 1)));
     starter.sdk_config.register_activities(StdActivities);
     starter
         .sdk_config
@@ -466,7 +470,7 @@ async fn poller_autoscaling_basic_loadtest() {
     let wf_name = "poller_load";
     let mut starter = CoreWfStarter::new("poller_load");
     starter.sdk_config.max_cached_workflows = 5000;
-    starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(1000, 1000, 100, 1));
+    starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(1000, 1000, 100, 1)));
     starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling(
         AutoscalingOptions::builder()
             .minimum(1)

--- a/crates/sdk-core/tests/heavy_tests/fuzzy_workflow.rs
+++ b/crates/sdk-core/tests/heavy_tests/fuzzy_workflow.rs
@@ -79,7 +79,7 @@ async fn fuzzy_workflow() {
     let wf_name = "fuzzy_wf";
     let mut starter = CoreWfStarter::new("fuzzy_workflow");
     starter.sdk_config.max_cached_workflows = 25;
-    starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(25, 25, 100, 100));
+    starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(25, 25, 100, 100)));
     starter.sdk_config.register_activities(StdActivities);
     starter.sdk_config.register_workflow::<FuzzyWf>().unwrap();
     let mut worker = starter.worker().await;

--- a/crates/sdk-core/tests/integ_tests/metrics_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/metrics_tests.rs
@@ -494,7 +494,7 @@ async fn idle_activity_worker_reports_zero_slots_used() {
     let activity_slots = Arc::new(ReservationTrackingActivitySlotSupplier::new(3));
     let mut tuner = TunerBuilder::default();
     tuner.activity_slot_supplier(activity_slots.clone());
-    starter.sdk_config.tuner = Arc::new(tuner.build());
+    starter.set_core_tuner(Arc::new(tuner.build()));
 
     let finish_activity = Arc::new(Barrier::new(2));
     struct BlockingActivity {
@@ -1498,7 +1498,7 @@ async fn metrics_available_from_custom_slot_supplier() {
         inner: FixedSizeSlotSupplier::new(5),
         metrics: OnceLock::new(),
     }));
-    starter.sdk_config.tuner = Arc::new(tb.build());
+    starter.set_core_tuner(Arc::new(tb.build()));
     starter
         .sdk_config
         .register_workflow::<CustomSlotSupplierWf>()
@@ -1763,7 +1763,7 @@ async fn resource_based_tuner_metrics() {
     let mut starter = CoreWfStarter::new_with_runtime(wf_name, rt);
     // Create a resource-based tuner with reasonable thresholds
     let tuner = ResourceBasedTuner::new(0.8, 0.8);
-    starter.sdk_config.tuner = Arc::new(tuner);
+    starter.set_core_tuner(Arc::new(tuner));
     starter
         .sdk_config
         .register_workflow::<ResourceBasedTunerMetricsWf>()

--- a/crates/sdk-core/tests/integ_tests/polling_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/polling_tests.rs
@@ -289,7 +289,7 @@ async fn small_workflow_slots_and_pollers(#[values(false, true)] use_autoscaling
         starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::SimpleMaximum(2));
     }
     starter.sdk_config.activity_task_poller_behavior = Some(PollerBehavior::SimpleMaximum(1));
-    starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(2, 1, 1, 1));
+    starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(2, 1, 1, 1)));
     starter
         .sdk_config
         .register_activities(StdActivities)

--- a/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_heartbeat_tests.rs
@@ -188,7 +188,7 @@ async fn docker_worker_heartbeat_basic(#[values("otel", "prom", "no_metrics")] b
     let wf_name = format!("worker_heartbeat_basic_{backing}");
     let mut starter = CoreWfStarter::new_with_runtime(&wf_name, rt);
     starter.sdk_config.max_cached_workflows = 5_usize;
-    starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(5, 5, 100, 0));
+    starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(5, 5, 100, 0)));
     starter.set_core_cfg_mutator(|c| {
         c.plugins = vec![
             PluginInfo {
@@ -421,7 +421,7 @@ async fn docker_worker_heartbeat_tuner() {
             .initial(5)
             .build(),
     ));
-    starter.sdk_config.tuner = Arc::new(tuner);
+    starter.set_core_tuner(Arc::new(tuner));
     starter.sdk_config.register_activities(StdActivities);
 
     #[workflow]
@@ -677,7 +677,7 @@ async fn worker_heartbeat_sticky_cache_miss() {
     let wf_name = "worker_heartbeat_cache_miss";
     let mut starter = new_no_metrics_starter(wf_name);
     starter.sdk_config.max_cached_workflows = 1_usize;
-    starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(2, 10, 10, 10));
+    starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(2, 10, 10, 10)));
 
     struct StickyCacheActivities;
     #[activities]
@@ -825,7 +825,7 @@ async fn worker_heartbeat_multiple_workers() {
     let runtime = CoreRuntime::new_assume_tokio(runtime_options).unwrap();
     let mut starter = CoreWfStarter::new_with_runtime(wf_name, runtime);
     starter.sdk_config.max_cached_workflows = 5_usize;
-    starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(5, 10, 10, 10));
+    starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(5, 10, 10, 10)));
     starter.sdk_config.register_activities(StdActivities);
     starter
         .sdk_config
@@ -995,7 +995,7 @@ static WF_FAIL: Notify = Notify::const_new();
 async fn worker_heartbeat_failure_metrics() {
     let wf_name = "worker_heartbeat_failure_metrics";
     let mut starter = new_no_metrics_starter(wf_name);
-    starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(10, 5, 10, 10));
+    starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(10, 5, 10, 10)));
     // This test uses tokio::sync::Notify from workflow code for test coordination.
     starter.sdk_config.detect_nondeterministic_futures = false;
 

--- a/crates/sdk-core/tests/integ_tests/worker_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/worker_tests.rs
@@ -207,7 +207,7 @@ async fn resource_based_few_pollers_guarantees_non_sticky_poll() {
     // Set the limits to zero so it's essentially unwilling to hand out slots
     let mut tuner = ResourceBasedTuner::new(0.0, 0.0);
     tuner.with_workflow_slots_options(ResourceSlotOptions::new(2, 10, Duration::from_millis(0)));
-    starter.sdk_config.tuner = Arc::new(tuner);
+    starter.set_core_tuner(Arc::new(tuner));
     starter
         .sdk_config
         .register_workflow::<ResourceBasedNonStickyWf>()
@@ -1274,7 +1274,7 @@ async fn test_custom_slot_supplier_simple() {
     tb.workflow_slot_supplier(wf_supplier.clone());
     tb.activity_slot_supplier(activity_supplier.clone());
     tb.local_activity_slot_supplier(local_activity_supplier.clone());
-    starter.sdk_config.tuner = Arc::new(tb.build());
+    starter.set_core_tuner(Arc::new(tb.build()));
     starter
         .sdk_config
         .register_workflow::<SlotSupplierWorkflow>()

--- a/crates/sdk-core/tests/integ_tests/workflow_tests.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests.rs
@@ -389,7 +389,7 @@ async fn wft_timeout_doesnt_create_unsolvable_autocomplete() {
     let mut wf_starter = CoreWfStarter::new("wft_timeout_doesnt_create_unsolvable_autocomplete");
     // Test needs eviction on and a short timeout
     wf_starter.sdk_config.max_cached_workflows = 0_usize;
-    wf_starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(1, 1, 1, 1));
+    wf_starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(1, 1, 1, 1)));
     wf_starter.sdk_config.workflow_task_poller_behavior =
         Some(PollerBehavior::SimpleMaximum(1_usize));
     wf_starter.workflow_options.task_timeout = Some(Duration::from_secs(1));
@@ -518,7 +518,7 @@ impl SlowCompletesWf {
 async fn slow_completes_with_small_cache() {
     let wf_name = "slow_completes_with_small_cache";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(5, 10, 1, 1));
+    starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(5, 10, 1, 1)));
     starter.sdk_config.max_cached_workflows = 5_usize;
     starter.sdk_config.register_activities(StdActivities);
     starter

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/continue_as_new.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/continue_as_new.rs
@@ -115,7 +115,7 @@ async fn continue_as_new_multiple_concurrent() {
     let wf_name = "continue_as_new_multiple_concurrent";
     let mut starter = CoreWfStarter::new(wf_name);
     starter.sdk_config.max_cached_workflows = 5_usize;
-    starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(5, 1, 1, 1));
+    starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(5, 1, 1, 1)));
     starter
         .sdk_config
         .register_workflow::<ContinueAsNewWf>()

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/local_activities.rs
@@ -276,7 +276,7 @@ impl LocalActFanoutWf {
 async fn local_act_fanout() {
     let wf_name = "local_act_fanout";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(5, 1, 1, 1));
+    starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(5, 1, 1, 1)));
     starter.sdk_config.register_activities(StdActivities);
     starter
         .sdk_config

--- a/crates/sdk-core/tests/integ_tests/workflow_tests/stickyness.rs
+++ b/crates/sdk-core/tests/integ_tests/workflow_tests/stickyness.rs
@@ -121,7 +121,7 @@ impl CacheMissWf {
 async fn cache_miss_ok() {
     let wf_name = "cache_miss_ok";
     let mut starter = CoreWfStarter::new(wf_name);
-    starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(2, 1, 1, 1));
+    starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(2, 1, 1, 1)));
     starter.sdk_config.max_cached_workflows = 0_usize;
     starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::SimpleMaximum(1_usize));
 

--- a/crates/sdk-core/tests/manual_tests.rs
+++ b/crates/sdk-core/tests/manual_tests.rs
@@ -134,7 +134,7 @@ async fn poller_load_spiky() {
     let rt = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
     let mut starter = CoreWfStarter::new_with_runtime("poller_load", rt);
     starter.sdk_config.max_cached_workflows = 5000;
-    starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(1000, 1000, 100, 100));
+    starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(1000, 1000, 100, 100)));
     starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling(
         AutoscalingOptions::builder()
             .minimum(1)
@@ -280,7 +280,7 @@ async fn poller_load_sustained() {
     let rt = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
     let mut starter = CoreWfStarter::new_with_runtime("poller_load", rt);
     starter.sdk_config.max_cached_workflows = 5000;
-    starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(1000, 100, 100, 100));
+    starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(1000, 100, 100, 100)));
     starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling(
         AutoscalingOptions::builder()
             .minimum(1)
@@ -358,7 +358,7 @@ async fn poller_load_spike_then_sustained() {
     let rt = CoreRuntime::new_assume_tokio(get_integ_runtime_options(telemopts)).unwrap();
     let mut starter = CoreWfStarter::new_with_runtime("poller_load", rt);
     starter.sdk_config.max_cached_workflows = 5000;
-    starter.sdk_config.tuner = Arc::new(TunerHolder::fixed_size(1000, 100, 100, 100));
+    starter.set_core_tuner(Arc::new(TunerHolder::fixed_size(1000, 100, 100, 100)));
     starter.sdk_config.workflow_task_poller_behavior = Some(PollerBehavior::Autoscaling(
         AutoscalingOptions::builder()
             .minimum(1)

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -174,7 +174,7 @@ use tracing::{Instrument, Span, field};
 use uuid::Uuid;
 
 use crate::runtime::{
-    CoreWorker, PollerBehavior, TunerBuilder, WorkerConfig, WorkerTuner, WorkflowErrorType,
+    CoreWorker, PollerBehavior, WorkerConfig, WorkflowErrorType, worker_tuner::WorkerTuner,
 };
 
 /// Contains options for configuring a worker.
@@ -232,10 +232,10 @@ pub struct WorkerOptions {
     /// or failures.
     #[builder(default = 1000)]
     pub max_cached_workflows: usize,
-    /// Set a [crate::WorkerTuner] for this worker, which controls how many slots are available for
-    /// the different kinds of tasks.
-    #[builder(default = Arc::new(TunerBuilder::default().build()))]
-    pub tuner: Arc<dyn WorkerTuner + Send + Sync>,
+    /// Set a [`runtime::worker_tuner::WorkerTuner`] for this worker, which controls how many slots
+    /// are available for the different kinds of tasks.
+    #[builder(into, default)]
+    pub tuner: WorkerTuner,
     /// Controls how polling for Workflow tasks will happen on this worker's task queue. See also
     /// [WorkerConfig::nonsticky_to_sticky_poll_ratio]. If using SimpleMaximum, Must be at least 2
     /// when `max_cached_workflows` > 0, or is an error.
@@ -689,6 +689,8 @@ impl WorkerOptions {
         #[cfg(not(feature = "experimental"))]
         let plugin_info = HashSet::new();
 
+        let tuner = self.tuner.to_core()?;
+
         WorkerConfig::builder()
             .namespace(namespace)
             .task_queue(self.task_queue.clone())
@@ -702,7 +704,7 @@ impl WorkerOptions {
                 })
             }))
             .max_cached_workflows(self.max_cached_workflows)
-            .tuner(self.tuner.clone())
+            .tuner(tuner)
             .maybe_workflow_task_poller_behavior(
                 self.workflow_task_poller_behavior
                     .map(PollerBehavior::into_core),

--- a/crates/sdk/src/runtime.rs
+++ b/crates/sdk/src/runtime.rs
@@ -14,16 +14,8 @@ use temporalio_sdk_core::{
 
 use crate::error::RuntimeError;
 
-// These tuner types are intentionally part of the Rust SDK's public API. Changes to their Core
-// definitions must preserve the SDK's stability guarantees until the SDK owns this surface.
-pub use temporalio_sdk_core::{
-    ActivitySlotKind, FixedSizeSlotSupplier, LocalActivitySlotKind, NexusSlotKind,
-    ResourceBasedSlotsOptions, ResourceBasedSlotsOptionsBuilder, ResourceBasedTuner,
-    ResourceBasedTunerConfig, ResourceController, ResourceSlotOptions, SlotInfo, SlotInfoTrait,
-    SlotKind, SlotKindType, SlotMarkUsedContext, SlotReleaseContext, SlotReservationContext,
-    SlotSupplier, SlotSupplierOptions, SlotSupplierPermit, TunerBuilder, TunerHolder,
-    TunerHolderOptions, TunerHolderOptionsBuilder, WorkerTuner, WorkflowSlotKind,
-};
+/// Worker concurrency tuning.
+pub mod worker_tuner;
 
 // These remain public only for the raw-worker APIs that are being migrated separately.
 pub use temporalio_sdk_core::{Worker as CoreWorker, WorkerConfig};

--- a/crates/sdk/src/runtime/worker_tuner.rs
+++ b/crates/sdk/src/runtime/worker_tuner.rs
@@ -1,0 +1,461 @@
+//! Worker concurrency tuning for SDK workers.
+
+use std::{fmt::Debug, sync::Arc, time::Duration};
+
+use temporalio_sdk_core::{
+    ResourceBasedSlotsOptions as CoreResourceBasedSlotsOptions,
+    ResourceBasedTunerConfig as CoreResourceBasedTunerConfig,
+    ResourceController as CoreResourceController, ResourceSlotOptions as CoreResourceSlotOptions,
+    SlotKind as CoreSlotKind, SlotSupplierOptions as CoreSlotSupplierOptions,
+    TunerHolderOptions as CoreTunerHolderOptions, WorkerTuner as CoreWorkerTuner,
+};
+
+const DEFAULT_FIXED_SIZE_SLOTS: usize = 100;
+
+/// A worker tuner configuration.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum WorkerTuner {
+    /// A tuner that creates a resource controller scoped to this worker.
+    ResourceBased(ResourceBasedTuner),
+    /// A resource-based tuner using a controller that may be shared by multiple workers.
+    ResourceBasedWithController(ResourceBasedTunerWithController),
+    /// A tuner composed from independently selected slot suppliers.
+    TunerHolder(TunerHolder),
+}
+
+impl WorkerTuner {
+    pub(crate) fn to_core(&self) -> Result<Arc<dyn CoreWorkerTuner + Send + Sync>, String> {
+        match self {
+            Self::ResourceBased(tuner) => tuner.to_tuner_holder().to_core(),
+            Self::ResourceBasedWithController(tuner) => tuner.to_tuner_holder().to_core(),
+            Self::TunerHolder(tuner) => tuner.to_core(),
+        }
+    }
+}
+
+impl Default for WorkerTuner {
+    fn default() -> Self {
+        TunerHolder::builder()
+            .workflow_task_slot_supplier(FixedSizeSlotSupplier::new(DEFAULT_FIXED_SIZE_SLOTS))
+            .activity_task_slot_supplier(FixedSizeSlotSupplier::new(DEFAULT_FIXED_SIZE_SLOTS))
+            .local_activity_task_slot_supplier(FixedSizeSlotSupplier::new(DEFAULT_FIXED_SIZE_SLOTS))
+            .nexus_task_slot_supplier(FixedSizeSlotSupplier::new(DEFAULT_FIXED_SIZE_SLOTS))
+            .build()
+            .into()
+    }
+}
+
+impl From<ResourceBasedTuner> for WorkerTuner {
+    fn from(value: ResourceBasedTuner) -> Self {
+        Self::ResourceBased(value)
+    }
+}
+
+impl From<ResourceBasedTunerWithController> for WorkerTuner {
+    fn from(value: ResourceBasedTunerWithController) -> Self {
+        Self::ResourceBasedWithController(value)
+    }
+}
+
+impl From<TunerHolder> for WorkerTuner {
+    fn from(value: TunerHolder) -> Self {
+        Self::TunerHolder(value)
+    }
+}
+
+/// A tuner composed from independently selected slot suppliers.
+#[derive(Clone, Debug, bon::Builder)]
+#[builder(state_mod(vis = "pub"))]
+#[non_exhaustive]
+pub struct TunerHolder {
+    /// Supplies workflow-task slots.
+    #[builder(into)]
+    pub workflow_task_slot_supplier: SlotSupplier,
+    /// Supplies activity-task slots.
+    #[builder(into)]
+    pub activity_task_slot_supplier: SlotSupplier,
+    /// Supplies local-activity slots.
+    #[builder(into)]
+    pub local_activity_task_slot_supplier: SlotSupplier,
+    /// Supplies Nexus-task slots.
+    #[builder(into)]
+    pub nexus_task_slot_supplier: SlotSupplier,
+}
+
+impl TunerHolder {
+    fn to_core(&self) -> Result<Arc<dyn CoreWorkerTuner + Send + Sync>, String> {
+        let configurations = [
+            self.workflow_task_slot_supplier.resource_configuration(),
+            self.activity_task_slot_supplier.resource_configuration(),
+            self.local_activity_task_slot_supplier
+                .resource_configuration(),
+            self.nexus_task_slot_supplier.resource_configuration(),
+        ];
+        let mut configurations = configurations.into_iter().flatten();
+        let resource_based_config = configurations.next();
+        if let Some(first) = resource_based_config
+            && configurations.any(|other| !first.is_compatible_with(other))
+        {
+            return Err(
+                "cannot construct worker tuner with multiple different resource-based tuner configurations"
+                    .to_owned(),
+            );
+        }
+
+        CoreTunerHolderOptions::builder()
+            .workflow_slot_options(
+                self.workflow_task_slot_supplier
+                    .to_core(ResourceKind::Workflow),
+            )
+            .activity_slot_options(
+                self.activity_task_slot_supplier
+                    .to_core(ResourceKind::Activity),
+            )
+            .local_activity_slot_options(
+                self.local_activity_task_slot_supplier
+                    .to_core(ResourceKind::Activity),
+            )
+            .nexus_slot_options(self.nexus_task_slot_supplier.to_core(ResourceKind::Nexus))
+            .maybe_resource_based_config(resource_based_config.map(ResourceBasedConfig::to_core))
+            .build()
+            .map_err(|error| error.to_string())?
+            .build_tuner_holder()
+            .map(|tuner| Arc::new(tuner) as Arc<dyn CoreWorkerTuner + Send + Sync>)
+            .map_err(|error| error.to_string())
+    }
+}
+
+/// A resource-based tuner that creates a controller scoped to its worker.
+#[derive(Clone, Debug, bon::Builder)]
+#[builder(state_mod(vis = "pub"))]
+#[non_exhaustive]
+pub struct ResourceBasedTuner {
+    /// Target memory and CPU usage.
+    pub tuner_options: ResourceBasedTunerOptions,
+    /// Workflow-task slot options, or `None` to use defaults.
+    pub workflow_task_slot_options: Option<ResourceBasedSlotOptions>,
+    /// Activity-task slot options, or `None` to use defaults.
+    pub activity_task_slot_options: Option<ResourceBasedSlotOptions>,
+    /// Local-activity slot options, or `None` to use defaults.
+    pub local_activity_task_slot_options: Option<ResourceBasedSlotOptions>,
+    /// Nexus-task slot options, or `None` to use defaults.
+    pub nexus_task_slot_options: Option<ResourceBasedSlotOptions>,
+}
+
+impl ResourceBasedTuner {
+    fn to_tuner_holder(&self) -> TunerHolder {
+        TunerHolder::builder()
+            .workflow_task_slot_supplier(ResourceBasedSlotsForType::new(
+                self.tuner_options,
+                self.workflow_task_slot_options.unwrap_or_default(),
+            ))
+            .activity_task_slot_supplier(ResourceBasedSlotsForType::new(
+                self.tuner_options,
+                self.activity_task_slot_options.unwrap_or_default(),
+            ))
+            .local_activity_task_slot_supplier(ResourceBasedSlotsForType::new(
+                self.tuner_options,
+                self.local_activity_task_slot_options.unwrap_or_default(),
+            ))
+            .nexus_task_slot_supplier(ResourceBasedSlotsForType::new(
+                self.tuner_options,
+                self.nexus_task_slot_options.unwrap_or_default(),
+            ))
+            .build()
+    }
+}
+
+/// A resource-based tuner governed by a controller shared across workers.
+#[derive(Clone, Debug, bon::Builder)]
+#[builder(state_mod(vis = "pub"))]
+#[non_exhaustive]
+pub struct ResourceBasedTunerWithController {
+    /// The shared resource controller.
+    pub controller: ResourceBasedController,
+    /// Workflow-task slot options, or `None` to use defaults.
+    pub workflow_task_slot_options: Option<ResourceBasedSlotOptions>,
+    /// Activity-task slot options, or `None` to use defaults.
+    pub activity_task_slot_options: Option<ResourceBasedSlotOptions>,
+    /// Local-activity slot options, or `None` to use defaults.
+    pub local_activity_task_slot_options: Option<ResourceBasedSlotOptions>,
+    /// Nexus-task slot options, or `None` to use defaults.
+    pub nexus_task_slot_options: Option<ResourceBasedSlotOptions>,
+}
+
+impl ResourceBasedTunerWithController {
+    fn to_tuner_holder(&self) -> TunerHolder {
+        TunerHolder::builder()
+            .workflow_task_slot_supplier(ResourceBasedSlotsForType::with_controller(
+                self.controller.clone(),
+                self.workflow_task_slot_options.unwrap_or_default(),
+            ))
+            .activity_task_slot_supplier(ResourceBasedSlotsForType::with_controller(
+                self.controller.clone(),
+                self.activity_task_slot_options.unwrap_or_default(),
+            ))
+            .local_activity_task_slot_supplier(ResourceBasedSlotsForType::with_controller(
+                self.controller.clone(),
+                self.local_activity_task_slot_options.unwrap_or_default(),
+            ))
+            .nexus_task_slot_supplier(ResourceBasedSlotsForType::with_controller(
+                self.controller.clone(),
+                self.nexus_task_slot_options.unwrap_or_default(),
+            ))
+            .build()
+    }
+}
+
+/// Target resource usage for resource-based tuning.
+#[derive(Clone, Copy, Debug, PartialEq, bon::Builder)]
+#[builder(state_mod(vis = "pub"))]
+#[non_exhaustive]
+pub struct ResourceBasedTunerOptions {
+    /// Target system memory usage as a fraction from zero to one.
+    pub target_memory_usage: f64,
+    /// Target system CPU usage as a fraction from zero to one.
+    pub target_cpu_usage: f64,
+}
+
+impl ResourceBasedTunerOptions {
+    fn to_core(self) -> CoreResourceBasedSlotsOptions {
+        CoreResourceBasedSlotsOptions::builder()
+            .target_mem_usage(self.target_memory_usage)
+            .target_cpu_usage(self.target_cpu_usage)
+            .build()
+    }
+}
+
+/// Coordinates resource-based slot allocation across multiple workers.
+#[derive(Clone, derive_more::Debug)]
+pub struct ResourceBasedController(#[debug(skip)] Arc<CoreResourceController>);
+
+impl ResourceBasedController {
+    /// Creates a controller using system-wide memory and CPU measurements.
+    pub fn new(options: ResourceBasedTunerOptions) -> Self {
+        Self(Arc::new(CoreResourceController::new(options.to_core())))
+    }
+}
+
+/// Per-task-type options for resource-based slots.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, bon::Builder)]
+#[builder(state_mod(vis = "pub"))]
+#[non_exhaustive]
+pub struct ResourceBasedSlotOptions {
+    /// Slots issued without consulting resource usage, or `None` to use the task-type default.
+    pub minimum_slots: Option<usize>,
+    /// Maximum slots that may be issued, or `None` to use the task-type default.
+    pub maximum_slots: Option<usize>,
+    /// Minimum delay between slots above the minimum, or `None` to use the task-type default.
+    pub ramp_throttle: Option<Duration>,
+}
+
+impl ResourceBasedSlotOptions {
+    fn to_core(self, kind: ResourceKind) -> CoreResourceSlotOptions {
+        let defaults = kind.slot_defaults();
+        CoreResourceSlotOptions::new(
+            self.minimum_slots.unwrap_or(defaults.minimum_slots),
+            self.maximum_slots.unwrap_or(defaults.maximum_slots),
+            self.ramp_throttle.unwrap_or(defaults.ramp_throttle),
+        )
+    }
+}
+
+/// Resource-based slot settings for one task type.
+#[derive(Clone, Debug)]
+pub struct ResourceBasedSlotsForType {
+    configuration: ResourceBasedConfig,
+    /// Per-task-type slot settings.
+    pub slot_options: ResourceBasedSlotOptions,
+}
+
+impl ResourceBasedSlotsForType {
+    /// Creates settings that construct a resource controller with the worker.
+    pub fn new(
+        tuner_options: ResourceBasedTunerOptions,
+        slot_options: ResourceBasedSlotOptions,
+    ) -> Self {
+        Self {
+            configuration: ResourceBasedConfig::Options(tuner_options),
+            slot_options,
+        }
+    }
+
+    /// Creates settings governed by a shared resource controller.
+    pub fn with_controller(
+        controller: ResourceBasedController,
+        slot_options: ResourceBasedSlotOptions,
+    ) -> Self {
+        Self {
+            configuration: ResourceBasedConfig::Controller(controller),
+            slot_options,
+        }
+    }
+
+    /// Returns target options when the controller is scoped to the worker.
+    pub fn tuner_options(&self) -> Option<ResourceBasedTunerOptions> {
+        match self.configuration {
+            ResourceBasedConfig::Options(options) => Some(options),
+            ResourceBasedConfig::Controller(_) => None,
+        }
+    }
+
+    /// Returns the shared controller, when configured.
+    pub fn controller(&self) -> Option<&ResourceBasedController> {
+        match &self.configuration {
+            ResourceBasedConfig::Options(_) => None,
+            ResourceBasedConfig::Controller(controller) => Some(controller),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+enum ResourceBasedConfig {
+    Options(ResourceBasedTunerOptions),
+    Controller(ResourceBasedController),
+}
+
+impl ResourceBasedConfig {
+    fn is_compatible_with(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Options(left), Self::Options(right)) => left == right,
+            (Self::Controller(left), Self::Controller(right)) => Arc::ptr_eq(&left.0, &right.0),
+            (Self::Options(_), Self::Controller(_)) | (Self::Controller(_), Self::Options(_)) => {
+                false
+            }
+        }
+    }
+
+    fn to_core(&self) -> CoreResourceBasedTunerConfig {
+        match self {
+            Self::Options(options) => CoreResourceBasedTunerConfig::Options(options.to_core()),
+            Self::Controller(controller) => {
+                CoreResourceBasedTunerConfig::Controller(controller.0.clone())
+            }
+        }
+    }
+}
+
+/// A fixed-size slot supplier.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct FixedSizeSlotSupplier {
+    /// Maximum number of slots that may be issued.
+    pub num_slots: usize,
+}
+
+impl FixedSizeSlotSupplier {
+    /// Creates a fixed-size supplier.
+    pub fn new(num_slots: usize) -> Self {
+        Self { num_slots }
+    }
+}
+
+/// A fixed-size or resource-based slot supplier.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum SlotSupplier {
+    /// A supplier with a fixed concurrency limit.
+    FixedSize(FixedSizeSlotSupplier),
+    /// A supplier governed by resource usage.
+    ResourceBased(ResourceBasedSlotsForType),
+}
+
+impl From<FixedSizeSlotSupplier> for SlotSupplier {
+    fn from(value: FixedSizeSlotSupplier) -> Self {
+        Self::FixedSize(value)
+    }
+}
+
+impl From<ResourceBasedSlotsForType> for SlotSupplier {
+    fn from(value: ResourceBasedSlotsForType) -> Self {
+        Self::ResourceBased(value)
+    }
+}
+
+impl SlotSupplier {
+    fn resource_configuration(&self) -> Option<&ResourceBasedConfig> {
+        match self {
+            Self::ResourceBased(options) => Some(&options.configuration),
+            Self::FixedSize(_) => None,
+        }
+    }
+
+    fn to_core<SK: CoreSlotKind>(&self, kind: ResourceKind) -> CoreSlotSupplierOptions<SK> {
+        match self {
+            Self::FixedSize(supplier) => CoreSlotSupplierOptions::FixedSize {
+                slots: supplier.num_slots,
+            },
+            Self::ResourceBased(options) => {
+                CoreSlotSupplierOptions::ResourceBased(options.slot_options.to_core(kind))
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ResourceKind {
+    Workflow,
+    Activity,
+    Nexus,
+}
+
+impl ResourceKind {
+    fn slot_defaults(self) -> ResourceSlotDefaults {
+        match self {
+            Self::Workflow => ResourceSlotDefaults {
+                minimum_slots: 2,
+                maximum_slots: 1_000,
+                ramp_throttle: Duration::from_millis(10),
+            },
+            Self::Activity | Self::Nexus => ResourceSlotDefaults {
+                minimum_slots: 1,
+                maximum_slots: 2_000,
+                ramp_throttle: Duration::from_millis(50),
+            },
+        }
+    }
+}
+
+struct ResourceSlotDefaults {
+    minimum_slots: usize,
+    maximum_slots: usize,
+    ramp_throttle: Duration,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn composite_tuner_rejects_different_resource_options() {
+        let first_options = ResourceBasedTunerOptions::builder()
+            .target_memory_usage(0.5)
+            .target_cpu_usage(0.5)
+            .build();
+        let second_options = ResourceBasedTunerOptions::builder()
+            .target_memory_usage(0.6)
+            .target_cpu_usage(0.5)
+            .build();
+        let result = WorkerTuner::from(
+            TunerHolder::builder()
+                .workflow_task_slot_supplier(ResourceBasedSlotsForType::new(
+                    first_options,
+                    Default::default(),
+                ))
+                .activity_task_slot_supplier(ResourceBasedSlotsForType::new(
+                    second_options,
+                    Default::default(),
+                ))
+                .local_activity_task_slot_supplier(FixedSizeSlotSupplier::new(1))
+                .nexus_task_slot_supplier(FixedSizeSlotSupplier::new(1))
+                .build(),
+        )
+        .to_core();
+        assert!(
+            result
+                .err()
+                .is_some_and(|error| error.contains("different resource-based tuner"))
+        );
+    }
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Stop directly reexporting the various worker tuning/slot supplier. This is the last of the core reexports we were surfacing in the actual sdk.

Modeled these in a similar manner to Ruby as far as the language knobs for configuring the tuners.

## Why?
Allows the underlying tuner traits from core to evolve without breaking SDK users. Previous comment warning would be easy to miss.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Existing integration tests were updated.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io --> 