### PR TITLE
chore(sdk): limit reexport of core worker and worker config

### DIFF
--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -162,7 +162,9 @@ use temporalio_common::{
     },
     worker::{WorkerDeploymentOptions, WorkerTaskTypes, build_id_from_current_exe},
 };
-use temporalio_sdk_core::{PollError, WorkerVersioningStrategy, init_worker};
+use temporalio_sdk_core::{
+    PollError, Worker as CoreWorker, WorkerConfig, WorkerVersioningStrategy, init_worker,
+};
 use temporalio_workflow::{InternalPatchActivationCallback, workflows::WorkflowImplementation};
 use tokio::sync::{
     Notify,
@@ -173,9 +175,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, Span, field};
 use uuid::Uuid;
 
-use crate::runtime::{
-    CoreWorker, PollerBehavior, WorkerConfig, WorkflowErrorType, worker_tuner::WorkerTuner,
-};
+use crate::runtime::{PollerBehavior, WorkflowErrorType, worker_tuner::WorkerTuner};
 
 /// Contains options for configuring a worker.
 ///

--- a/crates/sdk/src/runtime.rs
+++ b/crates/sdk/src/runtime.rs
@@ -17,7 +17,9 @@ use crate::error::RuntimeError;
 /// Worker concurrency tuning.
 pub mod worker_tuner;
 
-// These remain public only for the raw-worker APIs that are being migrated separately.
+// Keep these public only with the raw-worker APIs while they are migrated separately.
+// Worker::new_from_core, Worker::new_from_core_options, Worker::with_new_core_worker
+#[cfg(feature = "experimental")]
 pub use temporalio_sdk_core::{Worker as CoreWorker, WorkerConfig};
 
 /// Wraps a Tokio runtime builder so the SDK can install its per-thread telemetry state.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Gate these reexports only when they are necessary for the hidden core worker methods used for testing.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io --> 