### PR TITLE
fix(sdk/testing): hide cancellation token from public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ relevant information.
 * `CancelExternalWorkflowError` and `workflow_interceptors::CancelExternalWorkflowResult`
   for use in interceptors.
 ### Breaking Changes
+* `ActivityEnvironmentBuilder` no longer accepts a `tokio_util::sync::CancellationToken`.
+  Use `ActivityEnvironment::cancel` to cancel activities running in the test environment.
 * `ActivityError`, `PayloadConversionError`, `ActivityExecutionError`,
   `ChildWorkflowStartError`, `ChildWorkflowExecutionError`, and `WorkflowSignalError` are now
   non-exhaustive. Add wildcard branches when matching these enums.

--- a/crates/sdk/src/testing.rs
+++ b/crates/sdk/src/testing.rs
@@ -261,6 +261,8 @@ pub struct ActivityEnvironment {
     heartbeat_details: Vec<Payload>,
     #[builder(field)]
     implementers: ActivityImplementers,
+    #[builder(field = CancellationToken::new())]
+    cancellation_token: CancellationToken,
     #[builder(
         default,
         getter(name = payload_converter_ref, vis = ""),
@@ -272,8 +274,6 @@ pub struct ActivityEnvironment {
     #[builder(default)]
     headers: HashMap<String, Payload>,
     client: Option<Client>,
-    #[builder(default = CancellationToken::new())]
-    cancellation_token: CancellationToken,
 }
 
 impl<S: activity_environment_builder::State> ActivityEnvironmentBuilder<S> {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Swap from using `default` to `field` on the bon builder attribute

## Why?
`default` leaks this setter as a public API. Swap to `field` so this is private. Users have no reason to pass in a cancellation token. If they want to cancel the activity environment they call `ActivityEnvironment::cancel`.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io --> 