### PR TITLE
feat(client): allow usage of protox instead of system protoc

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -32,6 +32,11 @@ jobs:
       - run: cargo test-lint
       - run: cargo check
       - run: cargo check --features experimental
+      - name: Check vendored proto compilation
+        run: cargo check --features temporalio-client/vendored-protox
+        env:
+          PROTOC: /does/not/exist
+          CARGO_TARGET_DIR: /tmp/vendored-protox-target
       - run: git diff --exit-code
 
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ relevant information.
   `temporalio-sdk`, and Rust 1.88 for the other crates.
 
 ### Added
+* `temporalio-client` now provides a `vendored-protox` feature for compiling protobuf definitions
+  with `protox`, allowing client and Rust SDK builds without an installed `protoc`.
 * `CancelExternalWorkflowError` and `workflow_interceptors::CancelExternalWorkflowResult`
   for use in interceptors.
 * `WorkflowContextKey` and context-value scopes provide replay-safe, workflow-run-owned context

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -24,6 +24,7 @@ telemetry = ["dep:opentelemetry"]
 core-based-sdk = []
 envconfig = ["temporalio-common/envconfig"]
 dynamic-tls = ["dep:rustls-native-certs"]
+vendored-protox = ["temporalio-common/vendored-protox"]
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -167,6 +167,11 @@ while let Some(result) = stream.next().await {
 APIs that are still under development require the `experimental` Cargo feature and may change or
 be removed before stabilization.
 
+## Building Without `protoc`
+
+Enable the `vendored-protox` Cargo feature to compile protobuf definitions with `protox`
+instead of a system `protoc` binary.
+
 ## Raw gRPC Access
 
 For operations not covered by the high-level API, access the underlying gRPC service clients

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -37,6 +37,7 @@ envconfig = ["dep:toml", "dep:dirs"]
 serde_serialize = ["temporalio-common-wasm/serde_serialize", "temporalio-protos/serde_serialize"]
 core-telemetry-bridge = ["dep:ringbuf", "dep:futures-channel"]
 core-based-sdk = ["core-telemetry-bridge", "prometheus", "envconfig"]
+vendored-protox = ["temporalio-protos/vendored-protox"]
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/protos/Cargo.toml
+++ b/crates/protos/Cargo.toml
@@ -17,6 +17,7 @@ links = "temporalio_protos"
 default = []
 serde_serialize = []
 grpc-clients = ["tonic/channel"]
+vendored-protox = ["dep:protox", "prost-types/vendored-protox"]
 
 [dependencies]
 anyhow = "1.0"
@@ -34,9 +35,9 @@ pbjson = { workspace = true }
 
 [build-dependencies]
 prost = { workspace = true }
-prost-types = "0.14"
 tonic-prost-build = { workspace = true }
 pbjson-build = { workspace = true }
+protox = { version = "0.9.1", optional = true }
 
 [lints]
 workspace = true

--- a/crates/protos/README.md
+++ b/crates/protos/README.md
@@ -9,3 +9,6 @@ Compiled protobuf definitions for Temporal APIs and SDK Core protocols.
 
 Most Rust SDK users should use [`temporalio-client`](https://crates.io/crates/temporalio-client) or
 [`temporalio-sdk`](https://crates.io/crates/temporalio-sdk) instead.
+
+Enable the `vendored-protox` feature to compile the protobuf definitions with the pure-Rust
+`protox` implementation instead of requiring an installed `protoc` binary.

--- a/crates/protos/build.rs
+++ b/crates/protos/build.rs
@@ -1,4 +1,7 @@
 use std::{env, path::PathBuf};
+
+#[cfg(feature = "vendored-protox")]
+use prost::Message;
 use tonic_prost_build::Config;
 
 static ALWAYS_SERDE: &str = "#[cfg_attr(not(feature = \"serde_serialize\"), \
@@ -50,6 +53,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out = PathBuf::from(env::var("OUT_DIR").unwrap());
     let descriptor_file = out.join("descriptors.bin");
     println!("cargo:descriptor_path={}", descriptor_file.display());
+    let protos = &[
+        "./protos/local/temporal/sdk/core/core_interface.proto",
+        "./protos/api_upstream/temporal/api/sdk/v1/workflow_metadata.proto",
+        "./protos/api_upstream/temporal/api/workflowservice/v1/service.proto",
+        "./protos/api_upstream/temporal/api/nexusservices/workerservice/v1/request_response.proto",
+        "./protos/api_upstream/temporal/api/operatorservice/v1/service.proto",
+        "./protos/api_upstream/temporal/api/errordetails/v1/message.proto",
+        "./protos/api_cloud_upstream/temporal/api/cloud/cloudservice/v1/service.proto",
+        "./protos/testsrv_upstream/temporal/api/testservice/v1/service.proto",
+        "./protos/grpc/health/v1/health.proto",
+        "./protos/google/rpc/status.proto",
+    ];
+    let includes = &[
+        "./protos/api_upstream",
+        "./protos/api_cloud_upstream",
+        "./protos/local",
+        "./protos/testsrv_upstream",
+        "./protos/grpc",
+        "./protos",
+    ];
     let mut builder = tonic_prost_build::configure()
         // Workflow guests need message structs, while the native common crate enables this
         // feature to preserve the generated clients it re-exports today.
@@ -145,6 +168,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         builder = builder.type_attribute(*prefix, SERDE_ATTR);
     }
 
+    #[cfg(feature = "vendored-protox")]
+    {
+        let descriptors = protox::compile(protos, includes)?;
+        std::fs::write(&descriptor_file, descriptors.encode_to_vec())?;
+        builder = builder.skip_protoc_run();
+    }
+
     builder
         .file_descriptor_set_path(&descriptor_file)
         .compile_with_config(
@@ -153,26 +183,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 c.enable_type_names();
                 c
             },
-            &[
-                "./protos/local/temporal/sdk/core/core_interface.proto",
-                "./protos/api_upstream/temporal/api/sdk/v1/workflow_metadata.proto",
-                "./protos/api_upstream/temporal/api/workflowservice/v1/service.proto",
-                "./protos/api_upstream/temporal/api/nexusservices/workerservice/v1/request_response.proto",
-                "./protos/api_upstream/temporal/api/operatorservice/v1/service.proto",
-                "./protos/api_upstream/temporal/api/errordetails/v1/message.proto",
-                "./protos/api_cloud_upstream/temporal/api/cloud/cloudservice/v1/service.proto",
-                "./protos/testsrv_upstream/temporal/api/testservice/v1/service.proto",
-                "./protos/grpc/health/v1/health.proto",
-                "./protos/google/rpc/status.proto",
-            ],
-            &[
-                "./protos/api_upstream",
-                "./protos/api_cloud_upstream",
-                "./protos/local",
-                "./protos/testsrv_upstream",
-                "./protos/grpc",
-                "./protos",
-            ],
+            protos,
+            includes,
         )?;
 
     // TODO [rust-sdk-branch]: support normal JSON and proto JSON serialization


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add `vendored-protox` feature to the protos crate and thread it through up to the client crate. Enabling the feature will switch the proto build to use `protox` instead of trying to find a system protoc install.

## Why?
Useful for avoiding setting up a protoc to use the Rust SDK.

## Checklist
<!--- add/delete as needed --->

1. Closes #1589 

2. How was this tested:
Verified locally, added a CI job that verifies we can build without a protoc.

3. Any docs updates needed?
Added README updates to the appropriate crates.
