### PR TITLE
Test failed activation completion after requested eviction

### DIFF
--- a/crates/sdk-core/src/core_tests/workflow_tasks.rs
+++ b/crates/sdk-core/src/core_tests/workflow_tasks.rs
@@ -1130,6 +1130,45 @@ async fn complete_after_eviction() {
 }
 
 #[tokio::test]
+async fn failed_completion_after_eviction_releases_outstanding_replay_activation() {
+    let wfid = "fake_wf_id";
+    let t = canned_histories::single_timer("1");
+    let mut mock = mock_worker_client();
+    mock.expect_complete_workflow_task().times(0);
+    mock.expect_fail_workflow_task()
+        .returning(|_, _, _| Ok(Default::default()))
+        .times(1);
+    let mut mock = single_hist_mock_sg(wfid, t, [2], mock, true);
+    mock.make_wft_stream_interminable();
+    mock.worker_cfg(|wc| wc.max_cached_workflows = 10);
+    let core = mock_worker(mock);
+
+    let activation = core.poll_workflow_activation().await.unwrap();
+    core.request_workflow_eviction(&activation.run_id);
+    core.complete_workflow_activation(WorkflowActivationCompletion::fail(
+        activation.run_id,
+        Failure::application_failure("Language Workflow state was lost".to_string(), true),
+        None,
+    ))
+    .await
+    .unwrap();
+
+    // Failure marks the replay state as unusable, so pending replay jobs must not keep the requested eviction blocked.
+    let eviction = core.poll_workflow_activation().await.unwrap();
+    assert_matches!(
+        eviction.jobs.as_slice(),
+        [WorkflowActivationJob {
+            variant: Some(workflow_activation_job::Variant::RemoveFromCache(job)),
+        }] if job.reason == EvictionReason::LangFail as i32
+    );
+    core.complete_workflow_activation(WorkflowActivationCompletion::empty(eviction.run_id))
+        .await
+        .unwrap();
+
+    core.shutdown().await;
+}
+
+#[tokio::test]
 async fn sends_appropriate_sticky_task_queue_responses() {
     // This test verifies that when completions are sent with sticky queues enabled, that they
     // include the information that tells the server to enqueue the next task on a sticky queue.

--- a/crates/sdk-core/src/worker/mod.rs
+++ b/crates/sdk-core/src/worker/mod.rs
@@ -1565,9 +1565,10 @@ impl Worker {
 
     /// Request that a workflow be evicted by its run id. This will generate a workflow activation
     /// with the eviction job inside it to be eventually returned by
-    /// [Worker::poll_workflow_activation]. If the workflow had any existing outstanding
-    /// activations, such activations are invalidated and subsequent completions of them will do
-    /// nothing and log a warning.
+    /// [Worker::poll_workflow_activation]. If the workflow has an outstanding activation, the
+    /// language must still complete it before the eviction can be delivered. During replay,
+    /// already-buffered jobs may be delivered first; a failed completion instead makes the
+    /// workflow unusable and allows eviction immediately.
     pub fn request_workflow_eviction(&self, run_id: &str) {
         self.request_wf_eviction(
             run_id,


### PR DESCRIPTION
## Summary

- clarify that an outstanding Workflow activation must be completed before a requested eviction can be delivered
- cover a language-requested eviction followed by a failed outstanding activation
- verify that a failure during replay bypasses pending replay jobs and produces `removeFromCache` with `LangFail`

## Motivation

The TypeScript SDK proof of concept for language-initiated cache eviction can lose local Workflow state while Core still has an activation outstanding. The language side must fail that activation so Core can retire it and deliver the cache-removal activation.

## Testing

- `cargo test -p temporalio-sdk-core failed_completion_after_eviction_releases_outstanding_replay_activation`
- `cargo lint`
- `cargo +nightly fmt --all --check`
